### PR TITLE
Update install_fedora.sh

### DIFF
--- a/install_fedora.sh
+++ b/install_fedora.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-echo "This installer is for Fedora Linux installations using python 3.8 only."
-echo "Change 3.8 in this script to higher numbers if you have a more recent version of python installed."
-echo "This installer uses RPM package management."
+echo "This installer is for Fedora Linux installations using python 3.9 only."
+echo "Change 3.9 in this script to higher numbers if you have a more recent version of python installed."
+echo "This installer uses DNF package management."
 echo "QualCoder will be copied to the directory /usr/share/"
 echo "These actions require owner (sudo) permission"
 echo "The installer will also install dependencies"
 sudo dnf install python3-pip python3-pyqt5 python3-lxml python3-pil vlc python3-ply python3-six python3-chardet
 # python3-ebooklib is not available in Fedora, so install using pip
 echo "Please wait ..."
-sudo python3 -m pip install pdfminer.six openpyxl Ebooklib
-sudo mv ~/.local/lib/python3.8/site-packages/Ebook* /usr/lib/python3.8/site-packages/
-sudo mv ~/.local/lib/python3.8/site-packages/ebook* /usr/lib/python3.8/site-packages/
+python3 -m pip install --user pdfminer.six openpyxl Ebooklib
+sudo mv ~/.local/lib/python3.9/site-packages/Ebook* /usr/lib/python3.9/site-packages/
+sudo mv ~/.local/lib/python3.9/site-packages/ebook* /usr/lib/python3.9/site-packages/
 sudo cp -r qualcoder /usr/share/qualcoder
 sudo cp qualcoder/GUI/qualcoder.png /usr/share/pixmaps/qualcoder.png
 sudo cp qualcoder/GUI/qualcoder.desktop /usr/share/applications/qualcoder.desktop


### PR DESCRIPTION
tested, also works with python 3.9
and removes root privileges from python install command.