### PR TITLE
Improve setup.py and switch to relative imports

### DIFF
--- a/qualcoder/GUI/add_attribute.py
+++ b/qualcoder/GUI/add_attribute.py
@@ -32,7 +32,7 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_attribute import Ui_DialogAddAttribute
+from .ui_attribute import Ui_DialogAddAttribute
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/GUI/information.py
+++ b/qualcoder/GUI/information.py
@@ -32,7 +32,7 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_dialog_information import Ui_Dialog_information
+from .ui_dialog_information import Ui_Dialog_information
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/GUI/manage_files.py
+++ b/qualcoder/GUI/manage_files.py
@@ -40,7 +40,7 @@ import zipfile
 
 vlc_msg = ""
 try:
-    import vlc
+    import qualcoder.vlc as vlc
 except Exception as e:
     vlc_msg = str(e)
 
@@ -63,18 +63,18 @@ except:  # ModuleNotFoundError
 import ebooklib
 from ebooklib import epub
 
-from add_attribute import DialogAddAttribute
-from add_item_name import DialogAddItemName
-from confirm_delete import DialogConfirmDelete
-from docx import opendocx, getdocumenttext
-from GUI.ui_dialog_manage_files import Ui_Dialog_manage_files
-from GUI.ui_dialog_memo import Ui_Dialog_memo  # for manually creating a new file
-from helpers import Message
-from html_parser import *
-from memo import DialogMemo
-from select_items import DialogSelectItems
-from view_image import DialogViewImage
-from view_av import DialogViewAV
+from .add_attribute import DialogAddAttribute
+from .add_item_name import DialogAddItemName
+from .confirm_delete import DialogConfirmDelete
+from .docx import opendocx, getdocumenttext
+from .GUI.ui_dialog_manage_files import Ui_Dialog_manage_files
+from .GUI.ui_dialog_memo import Ui_Dialog_memo  # for manually creating a new file
+from .helpers import Message
+from .html_parser import *
+from .memo import DialogMemo
+from .select_items import DialogSelectItems
+from .view_image import DialogViewImage
+from .view_av import DialogViewAV
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/add_attribute.py
+++ b/qualcoder/add_attribute.py
@@ -32,7 +32,7 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_attribute import Ui_DialogAddAttribute
+from .GUI.ui_attribute import Ui_DialogAddAttribute
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/add_item_name.py
+++ b/qualcoder/add_item_name.py
@@ -32,7 +32,7 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_dialog_add_item import Ui_Dialog_add_item
+from .GUI.ui_dialog_add_item import Ui_Dialog_add_item
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/attributes.py
+++ b/qualcoder/attributes.py
@@ -34,12 +34,12 @@ import traceback
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-from add_attribute import DialogAddAttribute
-from confirm_delete import DialogConfirmDelete
-from memo import DialogMemo
-from GUI.base64_helper import *
-from GUI.ui_dialog_manage_attributes import Ui_Dialog_manage_attributes
-from GUI.ui_dialog_assign_attribute import Ui_Dialog_assignAttribute
+from .add_attribute import DialogAddAttribute
+from .confirm_delete import DialogConfirmDelete
+from .memo import DialogMemo
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_manage_attributes import Ui_Dialog_manage_attributes
+from .GUI.ui_dialog_assign_attribute import Ui_Dialog_assignAttribute
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/case_file_manager.py
+++ b/qualcoder/case_file_manager.py
@@ -36,11 +36,11 @@ from PyQt5 import QtWidgets, QtCore, QtGui
 from PyQt5.QtCore import Qt
 
 
-from GUI.ui_case_file_manager import Ui_Dialog_case_file_manager
-from confirm_delete import DialogConfirmDelete
-from helpers import DialogGetStartAndEndMarks, Message
-from view_av import DialogViewAV
-from view_image import DialogViewImage
+from .GUI.ui_case_file_manager import Ui_Dialog_case_file_manager
+from .confirm_delete import DialogConfirmDelete
+from .helpers import DialogGetStartAndEndMarks, Message
+from .view_av import DialogViewAV
+from .view_image import DialogViewImage
 
 ID = 0
 NAME = 1

--- a/qualcoder/cases.py
+++ b/qualcoder/cases.py
@@ -44,17 +44,17 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import Qt
 from PyQt5.Qt import QHelpEvent
 
-from add_attribute import DialogAddAttribute
-from add_item_name import DialogAddItemName
-from case_file_manager import DialogCaseFileManager
-from confirm_delete import DialogConfirmDelete
-from GUI.base64_helper import *
-from GUI.ui_dialog_cases import Ui_Dialog_cases
-from helpers import Message, ExportDirectoryPathDialog
+from .add_attribute import DialogAddAttribute
+from .add_item_name import DialogAddItemName
+from .case_file_manager import DialogCaseFileManager
+from .confirm_delete import DialogConfirmDelete
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_cases import Ui_Dialog_cases
+from .helpers import Message, ExportDirectoryPathDialog
 
-from memo import DialogMemo
-from view_av import DialogViewAV
-from view_image import DialogViewImage
+from .memo import DialogMemo
+from .view_av import DialogViewAV
+from .view_image import DialogViewImage
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/code_text.py
+++ b/qualcoder/code_text.py
@@ -42,19 +42,19 @@ from PyQt5.Qt import QHelpEvent
 from PyQt5.QtCore import Qt  # for context menu
 from PyQt5.QtGui import QBrush, QColor
 
-from add_item_name import DialogAddItemName
-from color_selector import DialogColorSelect
-from color_selector import colors, TextColor
-from confirm_delete import DialogConfirmDelete
-from helpers import msecs_to_mins_and_secs, Message, DialogCodeInAllFiles, DialogGetStartAndEndMarks
-from GUI.base64_helper import *
-from GUI.ui_dialog_code_text import Ui_Dialog_code_text
-from memo import DialogMemo
-from report_attributes import DialogSelectAttributeParameters
-from reports import DialogReportCoderComparisons, DialogReportCodeFrequencies  # for isinstance()
-from report_codes import DialogReportCodes
-from report_code_summary import DialogReportCodeSummary  # for isinstance()
-from select_items import DialogSelectItems  # for isinstance()
+from .add_item_name import DialogAddItemName
+from .color_selector import DialogColorSelect
+from .color_selector import colors, TextColor
+from .confirm_delete import DialogConfirmDelete
+from .helpers import msecs_to_mins_and_secs, Message, DialogCodeInAllFiles, DialogGetStartAndEndMarks
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_code_text import Ui_Dialog_code_text
+from .memo import DialogMemo
+from .report_attributes import DialogSelectAttributeParameters
+from .reports import DialogReportCoderComparisons, DialogReportCodeFrequencies  # for isinstance()
+from .report_codes import DialogReportCodes
+from .report_code_summary import DialogReportCodeSummary  # for isinstance()
+from .select_items import DialogSelectItems  # for isinstance()
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/color_selector.py
+++ b/qualcoder/color_selector.py
@@ -32,7 +32,7 @@ import traceback
 
 from PyQt5 import QtGui, QtWidgets, QtCore
 
-from GUI.ui_dialog_colour_selector import Ui_Dialog_colour_selector
+from .GUI.ui_dialog_colour_selector import Ui_Dialog_colour_selector
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/confirm_delete.py
+++ b/qualcoder/confirm_delete.py
@@ -31,7 +31,7 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_dialog_confirm_delete import Ui_Dialog_confirmDelete
+from .GUI.ui_dialog_confirm_delete import Ui_Dialog_confirmDelete
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/edit_textfile.py
+++ b/qualcoder/edit_textfile.py
@@ -34,7 +34,7 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_dialog_memo import Ui_Dialog_memo
+from .GUI.ui_dialog_memo import Ui_Dialog_memo
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/helpers.py
+++ b/qualcoder/helpers.py
@@ -30,13 +30,13 @@ import logging
 import os
 import platform
 import sys
-import vlc
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-from color_selector import TextColor
-from GUI.ui_dialog_code_context_image import Ui_Dialog_code_context_image
-from GUI.ui_dialog_start_and_end_marks import Ui_Dialog_StartAndEndMarks
+import qualcoder.vlc as vlc
+from .color_selector import TextColor
+from .GUI.ui_dialog_code_context_image import Ui_Dialog_code_context_image
+from .GUI.ui_dialog_start_and_end_marks import Ui_Dialog_StartAndEndMarks
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/import_survey.py
+++ b/qualcoder/import_survey.py
@@ -45,8 +45,8 @@ import sqlite3
 import sys
 import traceback
 
-from GUI.ui_dialog_import import Ui_Dialog_Import
-from helpers import Message
+from .GUI.ui_dialog_import import Ui_Dialog_Import
+from .helpers import Message
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/information.py
+++ b/qualcoder/information.py
@@ -32,7 +32,7 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_dialog_information import Ui_Dialog_information
+from .GUI.ui_dialog_information import Ui_Dialog_information
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/journals.py
+++ b/qualcoder/journals.py
@@ -36,11 +36,11 @@ import logging
 import traceback
 import webbrowser
 
-from add_item_name import DialogAddItemName
-from confirm_delete import DialogConfirmDelete
-from GUI.base64_helper import *
-from GUI.ui_dialog_journals import Ui_Dialog_journals
-from helpers import Message, ExportDirectoryPathDialog
+from .add_item_name import DialogAddItemName
+from .confirm_delete import DialogConfirmDelete
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_journals import Ui_Dialog_journals
+from .helpers import Message, ExportDirectoryPathDialog
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/manage_files.py
+++ b/qualcoder/manage_files.py
@@ -42,7 +42,7 @@ import zipfile
 
 vlc_msg = ""
 try:
-    import vlc
+    import qualcoder.vlc as vlc
 except Exception as e:
     vlc_msg = str(e)
 
@@ -65,22 +65,22 @@ except:  # ModuleNotFoundError
 import ebooklib
 from ebooklib import epub
 
-from add_attribute import DialogAddAttribute
-from add_item_name import DialogAddItemName
-from GUI.base64_helper import *
-from code_text import DialogCodeText  # for isinstance()
-from confirm_delete import DialogConfirmDelete
-from docx import opendocx, getdocumenttext
-from GUI.ui_dialog_manage_files import Ui_Dialog_manage_files
-from GUI.ui_dialog_memo import Ui_Dialog_memo  # for manually creating a new file
-from edit_textfile import DialogEditTextFile
-from helpers import Message, ExportDirectoryPathDialog
-from html_parser import *
-from memo import DialogMemo
-from select_items import DialogSelectItems
-from view_image import DialogViewImage, DialogCodeImage  # DialogCodeImage for isinstance()
-from view_av import DialogViewAV, DialogCodeAV  # DialogCodeAV for isinstance()
-from report_codes import DialogReportCodes  # for isInstance()
+from .add_attribute import DialogAddAttribute
+from .add_item_name import DialogAddItemName
+from .GUI.base64_helper import *
+from .code_text import DialogCodeText  # for isinstance()
+from .confirm_delete import DialogConfirmDelete
+from .docx import opendocx, getdocumenttext
+from .GUI.ui_dialog_manage_files import Ui_Dialog_manage_files
+from .GUI.ui_dialog_memo import Ui_Dialog_memo  # for manually creating a new file
+from .edit_textfile import DialogEditTextFile
+from .helpers import Message, ExportDirectoryPathDialog
+from .html_parser import *
+from .memo import DialogMemo
+from .select_items import DialogSelectItems
+from .view_image import DialogViewImage, DialogCodeImage  # DialogCodeImage for isinstance()
+from .view_av import DialogViewAV, DialogCodeAV  # DialogCodeAV for isinstance()
+from .report_codes import DialogReportCodes  # for isInstance()
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/manage_links.py
+++ b/qualcoder/manage_links.py
@@ -34,13 +34,13 @@ import traceback
 
 from PyQt5 import QtCore, QtWidgets, QtGui
 
-from code_text import DialogCodeText  # for isinstance()
-from confirm_delete import DialogConfirmDelete
-from GUI.ui_dialog_manage_links import Ui_Dialog_manage_links
-from report_codes import DialogReportCodes  # for isinstance()
-from view_image import DialogCodeImage  # for isinstance()
-from view_av import DialogCodeAV  # for isinstance()
-from view_image import DialogCodeImage  # DialogCodeImage for isinstance()
+from .code_text import DialogCodeText  # for isinstance()
+from .confirm_delete import DialogConfirmDelete
+from .GUI.ui_dialog_manage_links import Ui_Dialog_manage_links
+from .report_codes import DialogReportCodes  # for isinstance()
+from .view_image import DialogCodeImage  # for isinstance()
+from .view_av import DialogCodeAV  # for isinstance()
+from .view_image import DialogCodeImage  # DialogCodeImage for isinstance()
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/memo.py
+++ b/qualcoder/memo.py
@@ -32,7 +32,7 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_dialog_memo import Ui_Dialog_memo
+from .GUI.ui_dialog_memo import Ui_Dialog_memo
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/qualcoder.py
+++ b/qualcoder/qualcoder.py
@@ -41,36 +41,36 @@ import sqlite3
 import traceback
 import urllib.request
 import webbrowser
+from copy import copy
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-from attributes import DialogManageAttributes
-from cases import DialogCases
-from codebook import Codebook
-from code_text import DialogCodeText
-from copy import copy
-from GUI.ui_main import Ui_MainWindow
-from helpers import Message
-from import_survey import DialogImportSurvey
-from information import DialogInformation
-from journals import DialogJournals
-from manage_files import DialogManageFiles
-from manage_links import DialogManageLinks
-from memo import DialogMemo
-from refi import RefiExport, RefiImport
-from reports import DialogReportCoderComparisons, DialogReportCodeFrequencies
-from report_code_summary import DialogReportCodeSummary
-from report_codes import DialogReportCodes
-from report_file_summary import DialogReportFileSummary
-from report_relations import DialogReportRelations
-from report_sql import DialogSQL
-from rqda import Rqda_import
-from settings import DialogSettings
-from special_functions import DialogSpecialFunctions
+from .attributes import DialogManageAttributes
+from .cases import DialogCases
+from .codebook import Codebook
+from .code_text import DialogCodeText
+from .GUI.ui_main import Ui_MainWindow
+from .helpers import Message
+from .import_survey import DialogImportSurvey
+from .information import DialogInformation
+from .journals import DialogJournals
+from .manage_files import DialogManageFiles
+from .manage_links import DialogManageLinks
+from .memo import DialogMemo
+from .refi import RefiExport, RefiImport
+from .reports import DialogReportCoderComparisons, DialogReportCodeFrequencies
+from .report_code_summary import DialogReportCodeSummary
+from .report_codes import DialogReportCodes
+from .report_file_summary import DialogReportFileSummary
+from .report_relations import DialogReportRelations
+from .report_sql import DialogSQL
+from .rqda import Rqda_import
+from .settings import DialogSettings
+from .special_functions import DialogSpecialFunctions
 #from text_mining import DialogTextMining
-from view_av import DialogCodeAV
-from view_graph_original import ViewGraphOriginal
-from view_image import DialogCodeImage
+from .view_av import DialogCodeAV
+from .view_graph_original import ViewGraphOriginal
+from .view_image import DialogCodeImage
 
 qualcoder_version = "QualCoder 2.5"
 

--- a/qualcoder/refi.py
+++ b/qualcoder/refi.py
@@ -39,18 +39,17 @@ import sys
 import traceback
 import uuid
 try:
-    import vlc
+    import qualcoder.vlc as vlc
 except:
     pass
-from xsd import codebook, project
 import zipfile
 
 from PyQt5 import QtWidgets, QtCore
 
-from confirm_delete import DialogConfirmDelete  # REFI export question about line endings
-from GUI.ui_dialog_refi_export_endings import Ui_Dialog_refi_export_line_endings
-from helpers import Message
-
+from .xsd import codebook, project
+from .confirm_delete import DialogConfirmDelete  # REFI export question about line endings
+from .GUI.ui_dialog_refi_export_endings import Ui_Dialog_refi_export_line_endings
+from .helpers import Message
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/report_attributes.py
+++ b/qualcoder/report_attributes.py
@@ -32,8 +32,8 @@ import os
 import sys
 import traceback
 
-from GUI.ui_report_attribute_parameters import Ui_Dialog_report_attribute_parameters
-from helpers import Message
+from .GUI.ui_report_attribute_parameters import Ui_Dialog_report_attribute_parameters
+from .helpers import Message
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/report_code_summary.py
+++ b/qualcoder/report_code_summary.py
@@ -31,13 +31,13 @@ import os
 from PIL import Image
 import sys
 import traceback
-import vlc
+import qualcoder.vlc as vlc
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import Qt
 
-from GUI.ui_dialog_report_code_summary import Ui_Dialog_code_summary
-from color_selector import TextColor
+from .GUI.ui_dialog_report_code_summary import Ui_Dialog_code_summary
+from .color_selector import TextColor
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/report_codes.py
+++ b/qualcoder/report_codes.py
@@ -35,21 +35,21 @@ import platform
 from shutil import copyfile
 import sys
 import traceback
-import vlc
+import qualcoder.vlc as vlc
 
 from PyQt5 import QtGui, QtWidgets, QtCore
 from PyQt5.Qt import QHelpEvent
 from PyQt5.QtCore import Qt, QTextCodec
 from PyQt5.QtGui import QBrush
 
-from color_selector import TextColor
-from GUI.base64_helper import *
-from GUI.ui_dialog_report_codings import Ui_Dialog_reportCodings
-from GUI.ui_dialog_report_comparisons import Ui_Dialog_reportComparisons
-from GUI.ui_dialog_report_code_frequencies import Ui_Dialog_reportCodeFrequencies
-from helpers import Message, msecs_to_mins_and_secs, DialogCodeInImage, DialogCodeInAV, DialogCodeInText, ExportDirectoryPathDialog
-from report_attributes import DialogSelectAttributeParameters
-from select_items import DialogSelectItems
+from .color_selector import TextColor
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_report_codings import Ui_Dialog_reportCodings
+from .GUI.ui_dialog_report_comparisons import Ui_Dialog_reportComparisons
+from .GUI.ui_dialog_report_code_frequencies import Ui_Dialog_reportCodeFrequencies
+from .helpers import Message, msecs_to_mins_and_secs, DialogCodeInImage, DialogCodeInAV, DialogCodeInText, ExportDirectoryPathDialog
+from .report_attributes import DialogSelectAttributeParameters
+from .select_items import DialogSelectItems
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/report_file_summary.py
+++ b/qualcoder/report_file_summary.py
@@ -33,11 +33,11 @@ from PIL.ExifTags import TAGS
 import platform
 import sys
 import traceback
-import vlc
+import qualcoder.vlc as vlc
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-from GUI.ui_dialog_report_file_summary import Ui_Dialog_file_summary
+from .GUI.ui_dialog_report_file_summary import Ui_Dialog_file_summary
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/report_relations.py
+++ b/qualcoder/report_relations.py
@@ -37,10 +37,10 @@ from PyQt5 import QtGui, QtWidgets, QtCore
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QBrush
 
-from color_selector import TextColor
-from GUI.base64_helper import *
-from GUI.ui_dialog_code_relations import Ui_Dialog_CodeRelations
-from helpers import ExportDirectoryPathDialog, Message
+from .color_selector import TextColor
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_code_relations import Ui_Dialog_CodeRelations
+from .helpers import ExportDirectoryPathDialog, Message
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/report_sql.py
+++ b/qualcoder/report_sql.py
@@ -35,10 +35,10 @@ from datetime import datetime
 import logging
 import traceback
 
-from GUI.base64_helper import *
-from GUI.ui_dialog_SQL import Ui_Dialog_sql
-from helpers import ExportDirectoryPathDialog, Message
-from highlighter import Highlighter
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_SQL import Ui_Dialog_sql
+from .helpers import ExportDirectoryPathDialog, Message
+from .highlighter import Highlighter
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/reports.py
+++ b/qualcoder/reports.py
@@ -35,21 +35,21 @@ import platform
 from shutil import copyfile
 import sys
 import traceback
-import vlc
 
 from PyQt5 import QtGui, QtWidgets, QtCore
 from PyQt5.Qt import QHelpEvent
 from PyQt5.QtCore import Qt, QTextCodec
 from PyQt5.QtGui import QBrush
 
-from color_selector import TextColor
-from GUI.base64_helper import *
-from GUI.ui_dialog_report_codings import Ui_Dialog_reportCodings
-from GUI.ui_dialog_report_comparisons import Ui_Dialog_reportComparisons
-from GUI.ui_dialog_report_code_frequencies import Ui_Dialog_reportCodeFrequencies
-from helpers import Message, msecs_to_mins_and_secs, DialogCodeInImage, DialogCodeInAV, DialogCodeInText, ExportDirectoryPathDialog
-from report_attributes import DialogSelectAttributeParameters
-from select_items import DialogSelectItems
+import qualcoder.vlc as vlc
+from .color_selector import TextColor
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_report_codings import Ui_Dialog_reportCodings
+from .GUI.ui_dialog_report_comparisons import Ui_Dialog_reportComparisons
+from .GUI.ui_dialog_report_code_frequencies import Ui_Dialog_reportCodeFrequencies
+from .helpers import Message, msecs_to_mins_and_secs, DialogCodeInImage, DialogCodeInAV, DialogCodeInText, ExportDirectoryPathDialog
+from .report_attributes import DialogSelectAttributeParameters
+from .select_items import DialogSelectItems
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/rqda.py
+++ b/qualcoder/rqda.py
@@ -43,7 +43,7 @@ import zipfile
 
 from PyQt5 import QtWidgets
 
-from color_selector import colors
+from .color_selector import colors
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/select_items.py
+++ b/qualcoder/select_items.py
@@ -32,8 +32,8 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_dialog_select_items import Ui_Dialog_selectitems
-from helpers import Message
+from .GUI.ui_dialog_select_items import Ui_Dialog_selectitems
+from .helpers import Message
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/settings.py
+++ b/qualcoder/settings.py
@@ -32,8 +32,8 @@ import sys
 import logging
 import traceback
 
-from GUI.ui_dialog_settings import Ui_Dialog_settings
-from helpers import Message
+from .GUI.ui_dialog_settings import Ui_Dialog_settings
+from .helpers import Message
 
 home = os.path.expanduser('~')
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/special_functions.py
+++ b/qualcoder/special_functions.py
@@ -32,9 +32,9 @@ import traceback
 
 from PyQt5 import QtGui, QtWidgets, QtCore
 
-from code_text import DialogCodeText  # for isinstance()
-from confirm_delete import DialogConfirmDelete
-from GUI.ui_dialog_special_functions import Ui_Dialog_special_functions
+from .code_text import DialogCodeText  # for isinstance()
+from .confirm_delete import DialogConfirmDelete
+from .GUI.ui_dialog_special_functions import Ui_Dialog_special_functions
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/text_mining.py
+++ b/qualcoder/text_mining.py
@@ -35,12 +35,8 @@ from copy import copy
 import logging
 import traceback
 
-try:
-    from select_file import DialogSelectFile
-    from GUI.ui_dialog_text_mining import Ui_Dialog_text_mining
-except:
-    from .select_file import DialogSelectFile
-    from .GUI.ui_dialog_text_mining import Ui_Dialog_text_mining
+from .select_file import DialogSelectFile
+from .GUI.ui_dialog_text_mining import Ui_Dialog_text_mining
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/qualcoder/view_av.py
+++ b/qualcoder/view_av.py
@@ -65,7 +65,7 @@ if sys.platform.startswith("win"):
         logger.debug(str(e))
 vlc_msg = ""
 try:
-    import vlc
+    import qualcoder.vlc as vlc
 except Exception as e:
     vlc_msg = str(e) + "\n"
     if sys.platform.startswith("win"):
@@ -79,20 +79,20 @@ except Exception as e:
         vlc_msg = msg
     QtWidgets.QMessageBox.critical(None, _('Cannot import vlc'), vlc_msg)
 
-from add_item_name import DialogAddItemName
-from color_selector import DialogColorSelect
-from color_selector import colors, TextColor
-from confirm_delete import DialogConfirmDelete
-from GUI.base64_helper import *
-from GUI.ui_dialog_code_av import Ui_Dialog_code_av
-from GUI.ui_dialog_view_av import Ui_Dialog_view_av
-from helpers import msecs_to_hours_mins_secs, Message, DialogCodeInAllFiles
-from information import DialogInformation
-from memo import DialogMemo
-from report_attributes import DialogSelectAttributeParameters
-from reports import DialogReportCoderComparisons, DialogReportCodeFrequencies  # for isinstance()
-from report_codes import DialogReportCodes
-from select_items import DialogSelectItems
+from .add_item_name import DialogAddItemName
+from .color_selector import DialogColorSelect
+from .color_selector import colors, TextColor
+from .confirm_delete import DialogConfirmDelete
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_code_av import Ui_Dialog_code_av
+from .GUI.ui_dialog_view_av import Ui_Dialog_view_av
+from .helpers import msecs_to_hours_mins_secs, Message, DialogCodeInAllFiles
+from .information import DialogInformation
+from .memo import DialogMemo
+from .report_attributes import DialogSelectAttributeParameters
+from .reports import DialogReportCoderComparisons, DialogReportCodeFrequencies  # for isinstance()
+from .report_codes import DialogReportCodes
+from .select_items import DialogSelectItems
 
 
 def exception_handler(exception_type, value, tb_obj):

--- a/qualcoder/view_graph_original.py
+++ b/qualcoder/view_graph_original.py
@@ -37,11 +37,11 @@ import traceback
 from PyQt5 import QtCore, QtWidgets, QtGui
 from PyQt5.QtWidgets import QDialog
 
-from color_selector import TextColor
-from GUI.ui_visualise_graph_original import Ui_Dialog_visualiseGraph_original
-from helpers import msecs_to_mins_and_secs, DialogCodeInAllFiles
-from information import DialogInformation
-from memo import DialogMemo
+from .color_selector import TextColor
+from .GUI.ui_visualise_graph_original import Ui_Dialog_visualiseGraph_original
+from .helpers import msecs_to_mins_and_secs, DialogCodeInAllFiles
+from .information import DialogInformation
+from .memo import DialogMemo
 
 
 path = os.path.abspath(os.path.dirname(__file__))

--- a/qualcoder/view_image.py
+++ b/qualcoder/view_image.py
@@ -40,20 +40,20 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QBrush
 
-from add_item_name import DialogAddItemName
-from color_selector import DialogColorSelect
-from color_selector import colors
-from confirm_delete import DialogConfirmDelete
-from GUI.base64_helper import *
-from GUI.ui_dialog_code_image import Ui_Dialog_code_image
-from GUI.ui_dialog_view_image import Ui_Dialog_view_image
-from helpers import msecs_to_mins_and_secs, Message, DialogCodeInAllFiles
-from information import DialogInformation
-from memo import DialogMemo
-from report_attributes import DialogSelectAttributeParameters
-from reports import DialogReportCoderComparisons, DialogReportCodeFrequencies  # for isinstance()
-from report_codes import DialogReportCodes
-from select_items import DialogSelectItems
+from .add_item_name import DialogAddItemName
+from .color_selector import DialogColorSelect
+from .color_selector import colors
+from .confirm_delete import DialogConfirmDelete
+from .GUI.base64_helper import *
+from .GUI.ui_dialog_code_image import Ui_Dialog_code_image
+from .GUI.ui_dialog_view_image import Ui_Dialog_view_image
+from .helpers import msecs_to_mins_and_secs, Message, DialogCodeInAllFiles
+from .information import DialogInformation
+from .memo import DialogMemo
+from .report_attributes import DialogSelectAttributeParameters
+from .reports import DialogReportCoderComparisons, DialogReportCodeFrequencies  # for isinstance()
+from .report_codes import DialogReportCodes
+from .select_items import DialogSelectItems
 
 path = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ else:
      extra_options = dict(
          # Normally unix-like platforms will use "setup.py install"
          # and install the main script as such
-         scripts=[mainscript],
+         entry_points={
+            'console_scripts': ['qualcoder=qualcoder.qualcoder:gui']
+         },
      )
 
 
@@ -50,7 +52,7 @@ setup(
         'Development Status :: 3 - Alpha'
     ],
     keywords='qualitative data analysis',
-    package_dir={'': 'qualcoder'},
+    packages=find_packages(include=['qualcoder','qualcoder.*']),
     python_requires='>=3.5',
     install_requires=[
         'pyqt5',
@@ -62,7 +64,6 @@ setup(
         'chardet',
         'openpyxl'
     ],
-    data_files=['qualcoder/locale'],
     package_data={
         'qualcoder':['Codebook.xsd', 'Project-mrt2019.xsd',
         'GUI/*.html', 'GUI/NotoSans-hinted/*.ttf',
@@ -72,5 +73,6 @@ setup(
         'locale/en/LC_MESSAGES/en,mo',]
     },
     zip_safe=False,
+    include_package_data=True
     **extra_options
 )


### PR DESCRIPTION
## Commit message

With the old setup.py I was not able to install the program so I tried
to fix the setup.py.

Now it creates a correct wheel, and creates a "qualcoder" executable
that will be installed into the /bin/ folder that setup-tools uses to
install software.

Using this install method the unqualified import didn‘t work, so I made
them relative.

I can not test this on windows, but I assume there has to be a way to
use setup.py to create an executable similar to the linux "qualcoder"
executable.

## Comment

I am not very certain about python best practices. Nevertheless I think this should be an improvement. I thought I should create this PR in the hope, that it might benefit you.