### PR TITLE
Fix import issues discussed in issue #500

### DIFF
--- a/qualcoder/__main__.py
+++ b/qualcoder/__main__.py
@@ -45,32 +45,32 @@ from copy import copy
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-from .attributes import DialogManageAttributes
-from .cases import DialogCases
-from .codebook import Codebook
-from .code_text import DialogCodeText
-from .GUI.ui_main import Ui_MainWindow
-from .helpers import Message
-from .import_survey import DialogImportSurvey
-from .information import DialogInformation
-from .journals import DialogJournals
-from .manage_files import DialogManageFiles
-from .manage_links import DialogManageLinks
-from .memo import DialogMemo
-from .refi import RefiExport, RefiImport
-from .reports import DialogReportCoderComparisons, DialogReportCodeFrequencies
-from .report_code_summary import DialogReportCodeSummary
-from .report_codes import DialogReportCodes
-from .report_file_summary import DialogReportFileSummary
-from .report_relations import DialogReportRelations
-from .report_sql import DialogSQL
-from .rqda import Rqda_import
-from .settings import DialogSettings
-from .special_functions import DialogSpecialFunctions
+from qualcoder.attributes import DialogManageAttributes
+from qualcoder.cases import DialogCases
+from qualcoder.codebook import Codebook
+from qualcoder.code_text import DialogCodeText
+from qualcoder.GUI.ui_main import Ui_MainWindow
+from qualcoder.helpers import Message
+from qualcoder.import_survey import DialogImportSurvey
+from qualcoder.information import DialogInformation
+from qualcoder.journals import DialogJournals
+from qualcoder.manage_files import DialogManageFiles
+from qualcoder.manage_links import DialogManageLinks
+from qualcoder.memo import DialogMemo
+from qualcoder.refi import RefiExport, RefiImport
+from qualcoder.reports import DialogReportCoderComparisons, DialogReportCodeFrequencies
+from qualcoder.report_code_summary import DialogReportCodeSummary
+from qualcoder.report_codes import DialogReportCodes
+from qualcoder.report_file_summary import DialogReportFileSummary
+from qualcoder.report_relations import DialogReportRelations
+from qualcoder.report_sql import DialogSQL
+from qualcoder.rqda import Rqda_import
+from qualcoder.settings import DialogSettings
+from qualcoder.special_functions import DialogSpecialFunctions
 #from text_mining import DialogTextMining
-from .view_av import DialogCodeAV
-from .view_graph_original import ViewGraphOriginal
-from .view_image import DialogCodeImage
+from qualcoder.view_av import DialogCodeAV
+from qualcoder.view_graph_original import ViewGraphOriginal
+from qualcoder.view_image import DialogCodeImage
 
 qualcoder_version = "QualCoder 2.5"
 
@@ -1827,7 +1827,6 @@ def gui():
             proj_path = split_[1]
         ex.open_project(path=proj_path)
     sys.exit(app.exec_())
-
 
 if __name__ == "__main__":
     gui()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-mainscript = 'qualcoder/qualcoder.py'
+mainscript = 'qualcoder/__main__.py'
 OPTIONS = {
     'argv_emulation': True,
     'iconfile': 'qualcoder/GUI/qualcoder.icns'

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ else:
          # Normally unix-like platforms will use "setup.py install"
          # and install the main script as such
          entry_points={
-            'console_scripts': ['qualcoder=qualcoder.qualcoder:gui']
+            'console_scripts': ['qualcoder=qualcoder.__main__:gui']
          },
      )
 


### PR DESCRIPTION
qualcoder.py was renamed to `__main__.py` because Python will throw
incredibly confusing errors if a you have a `qualcoder.py` _file_ with the same name
as a _package_ (`qualcoder`), because it will try to import the file instead of the
package, if the the former comes first in the PYTHON_PATH.

This also allows running the module directly, i.e. `python -m
qualcoder` will now use python to resolve the the path of the module
qualcoder, and then basically run `python path/to/qualcoder/__main__.py`

The imports in this `__main__.py` are also changed to absolute imports,
because if the file is run directly, it isn't imported as a module, and
there is no module the imports could be relative to. The imports in the
other files can be left relative, because those files are imported
themselves, so a module to be relative to exists at that time.