### PR TITLE
Update ArchLinux Installation section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ Not tested, but please see the above instructions to build QualCoder inside a vi
 
 1. Install modules from the command line
 
-`sudo pacman -S python python-chardet python-lxml python-openpyxl python-pillow python-ply python-pyqt5 python-pip`
+`sudo pacman -S python python-chardet python-lxml python-openpyxl python-pdfminer python-pillow python-ply python-pyqt5 python-pip`
 
 2. Install additional python modules
 
-`sudo python3 -m pip install ebooklib pdfminer.six pydub SpeechRecognition`
+`sudo python3 -m pip install ebooklib pydub SpeechRecognition`
 
 If success, all requirements are satisfied.
 


### PR DESCRIPTION
Due to https://github.com/pdfminer/pdfminer.six/pull/727, source code on Github and ditribution on pypi of pdfminer.six has been synchronized. As a result, the package of python-pdfminer in ArchLinux repository has been synchronized with pypi. So we can install python-pdfminer from official repository now.