### PR TITLE
add native os styling as option

### DIFF
--- a/qualcoder/__main__.py
+++ b/qualcoder/__main__.py
@@ -507,7 +507,7 @@ class App(object):
     def merge_settings_with_default_stylesheet(self, settings):
         """ Stylesheet is coded to avoid potential data file import errors with pyinstaller.
         Various options for colour schemes:
-        original, dark, blue, green, orange, purple, yellow
+        original, dark, blue, green, orange, purple, yellow, native
 
         Orange #f89407
 
@@ -623,6 +623,9 @@ class App(object):
         if self.settings['stylesheet'] == "purple":
             style = style.replace("#efefef", "#dfe2ff")
             style = style.replace("#f89407", "#ca1b9a")
+        if self.settings['stylesheet'] == "native":
+            style = "* {font-size: 12px;}\n\
+            "
         return style
 
     def load_settings(self):
@@ -821,7 +824,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
         # Test of macOS menu bar
-        self.ui.menubar.setNativeMenuBar(False)
+        
+        if self.app.settings['stylesheet'] == "native":
+            self.ui.menubar.setNativeMenuBar(True)
+        else:
+            self.ui.menubar.setNativeMenuBar(False)
         self.get_latest_github_release()
         try:
             w = int(self.app.settings['mainwindow_w'])
@@ -2147,9 +2154,10 @@ def gui():
     QtGui.QFontDatabase.addApplicationFont("GUI/NotoSans-hinted/NotoSans-Bold.ttf")
     stylesheet = qual_app.merge_settings_with_default_stylesheet(settings)
     app.setStyleSheet(stylesheet)
-    pm = QtGui.QPixmap()
-    pm.loadFromData(QtCore.QByteArray.fromBase64(qualcoder32), "png")
-    app.setWindowIcon(QtGui.QIcon(pm))
+    if sys.platform != 'darwin':
+      pm = QtGui.QPixmap()
+      pm.loadFromData(QtCore.QByteArray.fromBase64(qualcoder32), "png")
+      app.setWindowIcon(QtGui.QIcon(pm))
 
     # Use two character language setting
     lang = settings.get('language', 'en')

--- a/qualcoder/settings.py
+++ b/qualcoder/settings.py
@@ -118,7 +118,7 @@ class DialogSettings(QtWidgets.QDialog):
             self.ui.checkBox.setChecked(True)
         else:
             self.ui.checkBox.setChecked(False)
-        styles = [_("original"), _("dark"), _("blue"), _("green"), _("orange"), _("purple"), _("yellow"), _("rainbow")]
+        styles = [_("original"), _("dark"), _("blue"), _("green"), _("orange"), _("purple"), _("yellow"), _("rainbow"), _("native")]
         self.ui.comboBox_style.addItems(styles)
         for index, style in enumerate(styles):
             if style == self.settings['stylesheet']:
@@ -202,7 +202,7 @@ class DialogSettings(QtWidgets.QDialog):
         else:
             self.settings['showids'] = 'False'
         index = self.ui.comboBox_style.currentIndex()
-        styles = ["original", "dark", "blue", "green", "orange", "purple", "yellow", "rainbow"]
+        styles = ["original", "dark", "blue", "green", "orange", "purple", "yellow", "rainbow", "native"]
         if self.settings['stylesheet'] != styles[index]:
             restart_qualcoder = True
         self.settings['stylesheet'] = styles[index]


### PR DESCRIPTION
native styling means that the ui is dark/light depending on the system preferences
the ui looks also more native on windows and macOS
when native is active use system default menubar on macOS 
removed the dynamic low res appicon on macos because it comes with the build binary