### PR TITLE
Correct typo in report_codes.py

### DIFF
--- a/qualcoder/report_codes.py
+++ b/qualcoder/report_codes.py
@@ -1342,7 +1342,7 @@ class DialogReportCodes(QtWidgets.QDialog):
             # Coded text
             sql = "select code_name.name, color, cases.name, "
             sql += "code_text.pos0, code_text.pos1, seltext, code_text.owner, code_text.fid, "
-            sql += "ifnull(cases.memo,''), ifnul(code_text.memo,''), ifnull(code_name.memo,''), "
+            sql += "ifnull(cases.memo,''), ifnull(code_text.memo,''), ifnull(code_name.memo,''), "
             sql += "ifnull(source.memo,''), ctid, code_name.cid "
             sql += "from code_text join code_name on code_name.cid = code_text.cid "
             sql += "join (case_text join cases on cases.caseid = case_text.caseid) on "


### PR DESCRIPTION
On line 1345, one of the `ifnull` clauses was spelled `ifnul` and caused an error in the Coding Reports after the most recent updates. Correcting this typo in my local copy solved the error, so offering it back as a PR.