### PR TITLE
BUGFIX: spurious + sign in the calculation of the documents import path.

### DIFF
--- a/qualcoder/refi.py
+++ b/qualcoder/refi.py
@@ -1316,7 +1316,7 @@ class RefiImport:
         media_path = "/docs/" + name  # Default
         if path_type == "internal":
             # Copy file into .qda documents folder and rename into original name
-            destination = os.path.join(self.app.project_path, +"documents", name)
+            destination = os.path.join(self.app.project_path, "documents", name)
             #print("destination: ", destination)
             try:
                 shutil.copyfile(source_path, destination)


### PR DESCRIPTION
Fixes #803.

An extra + was present in a call to os.path what led to an error that prevented the proper import of REFI-QDA file.