### PR TITLE
Update README.md  - small grammatical error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # QualCoder
 QualCoder is a qualitative data analysis application written in python3 and Qt6.
 
-Text files can be typed in manually or loaded from txt, odt, docx, html, htm, md, epub and  PDF files. Images, video, and audio can also be imported for coding. Codes can be assigned to text, images, and a/v selections and grouped into categories in a hierarchical fashion. Various types of reports can be produced including visual coding graphs, word clouds, coder comparisons, and coding frequencies.
+Text files can be typed in manually or loaded from txt, odt, docx, html, htm, md, epub, and  PDF files. Images, video, and audio can also be imported for coding. Codes can be assigned to text, images, and a/v selections and grouped into categories in a hierarchical fashion. Various types of reports can be produced including visual coding graphs, word clouds, coder comparisons, and coding frequencies.
 
 This software has been used on MacOS and various Linux distros.
 Instructions and other information are available here: https://qualcoder.wordpress.com/ and on the [Github Wiki](https://github.com/ccbogel/QualCoder/wiki).


### PR DESCRIPTION
I have noticed one grammatical mistakes in **README** inside section "**QualCoder**"

"**html, htm, md, epub and PDF files.**"  should be "**html, htm, md, epub, and PDF files.**"


Screenshot-

![Screenshot (117)](https://github.com/ccbogel/QualCoder/assets/115995339/6b6a0a64-6208-4993-a233-fdd7bf14d539)
