### PR TITLE
Add a progress dialog to manage_links > find_filepaths

### DIFF
--- a/qualcoder/manage_files.py
+++ b/qualcoder/manage_files.py
@@ -1853,9 +1853,9 @@ class DialogManageFiles(QtWidgets.QDialog):
             msg += _("Deleted file: ") + s['name'] + "\n"
             self.files_renamed = [x for x in self.files_renamed if not (s['id'] == x.get('fid'))]
             # Delete text source
-            if s['mediapath'] is None or 'docs:' in s['mediapath']:
+            if s['mediapath'] is None or s['mediapath'][0:5] == 'docs:' or s['mediapath'][0:6] == '/docs/':
                 try:
-                    if s['mediapath'] is None:
+                    if s['mediapath'] is None or s['mediapath'][0:6] == '/docs/':
                         os.remove(self.app.project_path + "/documents/" + s['name'])
                 except OSError as err:
                     logger.warning(_("Deleting file error: ") + str(err))
@@ -1867,7 +1867,7 @@ class DialogManageFiles(QtWidgets.QDialog):
                 cur.execute("delete from attribute where attr_type ='file' and id=?", [s['id']])
                 self.app.conn.commit()
             # Delete image, audio or video source
-            if s['mediapath'] is not None and 'docs:' not in s['mediapath']:
+            if s['mediapath'] is not None and s['mediapath'][0:5] != 'docs:' and s['mediapath'][0:6] != '/docs/':
                 # Get linked transcript file id
                 cur.execute("select av_text_id from source where id=?", [s['id']])
                 res = cur.fetchone()
@@ -1937,9 +1937,9 @@ class DialogManageFiles(QtWidgets.QDialog):
         row = rows[0]
         file_id = self.source[row]['id']
         # Delete text source
-        if self.source[row]['mediapath'] is None or 'docs:' in self.source[row]['mediapath']:
+        if self.source[row]['mediapath'] is None or self.source[row]['mediapath'][0:5] == 'docs:' or self.source[row]['mediapath'][0:6] == '/docs/':
             try:
-                if self.source[row]['mediapath'] is None:
+                if self.source[row]['mediapath'] is None or self.source[row]['mediapath'][0:6] == '/docs/':
                     os.remove(self.app.project_path + "/documents/" + self.source[row]['name'])
             except OSError as err:
                 logger.warning(_("Deleting file error: ") + str(err))
@@ -1952,7 +1952,8 @@ class DialogManageFiles(QtWidgets.QDialog):
             self.app.conn.commit()
 
         # Delete image, audio or video source
-        if self.source[row]['mediapath'] is not None and 'docs:' not in self.source[row]['mediapath']:
+        # (why not simply use 'else' instead of this complicated second if-clause?)
+        if self.source[row]['mediapath'] is not None and self.source[row]['mediapath'][0:5] != 'docs:' and self.source[row]['mediapath'][0:6] != '/docs/':
             # Get linked transcript file id
             cur.execute("select av_text_id from source where id=?", [file_id])
             res = cur.fetchone()


### PR DESCRIPTION
"find_filepaths" can make the app unresponsive in a large filesystem. This pr adds a progress dialog so the user can observe and cancel the process. 

fixes https://github.com/ccbogel/QualCoder/issues/861