### PR TITLE
Fix settings dialog: Selecting current style in languages other than …

### DIFF
--- a/qualcoder/settings.py
+++ b/qualcoder/settings.py
@@ -118,8 +118,9 @@ class DialogSettings(QtWidgets.QDialog):
             self.ui.checkBox.setChecked(True)
         else:
             self.ui.checkBox.setChecked(False)
-        styles = [_("original"), _("dark"), _("blue"), _("green"), _("orange"), _("purple"), _("yellow"), _("rainbow"), _("native")]
-        self.ui.comboBox_style.addItems(styles)
+        styles = ["original", "dark", "blue", "green", "orange", "purple", "yellow", "rainbow", "native"]
+        styles_translated = [_("original"), _("dark"), _("blue"), _("green"), _("orange"), _("purple"), _("yellow"), _("rainbow"), _("native")]
+        self.ui.comboBox_style.addItems(styles_translated)
         for index, style in enumerate(styles):
             if style == self.settings['stylesheet']:
                 self.ui.comboBox_style.setCurrentIndex(index)


### PR DESCRIPTION
…English

In languages other than English, the current style was always reset back to 'original' on opening the settings dialog because QualCoder expected the English name, not the translated one.