### PR TITLE
Make columns movable and resizable in the code tree widget

### DIFF
--- a/qualcoder/code_text.py
+++ b/qualcoder/code_text.py
@@ -549,6 +549,8 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.treeWidget.clear()
         self.ui.treeWidget.setColumnCount(4)
         self.ui.treeWidget.setHeaderLabels([_("Name"), _("Id"), _("Memo"), _("Count")])
+        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
+        self.ui.treeWidget.header().resizeSection(0, 400)
         if not self.app.settings['showids']:
             self.ui.treeWidget.setColumnHidden(1, True)
         else:


### PR DESCRIPTION
Could be made better, but I set a starting fixed size of 400 to avoid having the "Name" column too small by defaut.