### PR TITLE
Get rid of pydantic

### DIFF
--- a/qualcoder/ai_llm.py
+++ b/qualcoder/ai_llm.py
@@ -39,7 +39,6 @@ from .ai_prompts import PromptItem
 from langchain_openai import ChatOpenAI
 from langchain_core.globals import set_llm_cache
 from langchain_community.cache import InMemoryCache
-from langchain.pydantic_v1 import BaseModel, Field
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.messages.human import HumanMessage

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,5 @@ langchain-text-splitters
 chromadb>0.4.0 
 sentence-transformers 
 fuzzysearch 
-pydantic 
 PyYAML 
 json_repair


### PR DESCRIPTION
I'm not using pydantic anymore, so we can get rid of it completely. This fixes the deprecation warning from langchain.