### PR TITLE
Line Numbers: Account for loading text in chunks in code_text

### DIFF
--- a/qualcoder/helpers.py
+++ b/qualcoder/helpers.py
@@ -872,7 +872,7 @@ class NumberBar(QtWidgets.QFrame):
         if new_digits <= 0:
             return  # no width adjustment needed
         self.digits = digits
-        font = self.font()
+        font = self.text_edit.font()
         font.setFamily('Monospace')
         font.setStyleHint(QtGui.QFont.StyleHint.TypeWriter)
         font_metrics = QtGui.QFontMetrics(font)
@@ -906,7 +906,7 @@ class NumberBar(QtWidgets.QFrame):
         text_edit_font_metrics = self.text_edit.fontMetrics()
 
         painter = QtGui.QPainter(self)
-        font = self.font()
+        font = self.text_edit.font()
         font.setFamily('Monospace')
         font.setStyleHint(QtGui.QFont.StyleHint.TypeWriter)
         text_color = self.palette().color(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text)

--- a/qualcoder/helpers.py
+++ b/qualcoder/helpers.py
@@ -840,6 +840,7 @@ class NumberBar(QtWidgets.QFrame):
         # The highest line that is currently visibile, used to update the width of the control
         self.highest_line = 0
         self.digits = 0
+        self.first_line = 1
 
         # Install event filter
         class EventFilter(QtCore.QObject):
@@ -864,6 +865,8 @@ class NumberBar(QtWidgets.QFrame):
         Will try to adjust the scrolling position accordingly so that the visible text is 
         not jumping too much.
         """
+        if self.first_line > self.highest_line:
+            self. highest_line = self.first_line
         if self.highest_line < 1000:
             digits = 3  # minimum width 3 digits
         else:
@@ -914,7 +917,7 @@ class NumberBar(QtWidgets.QFrame):
         painter.setFont(font)
         font_metrics = painter.fontMetrics()
 
-        line_count = 0
+        line_count = self.first_line - 1
         block = self.text_edit.document().begin()
 
         while block.isValid():
@@ -936,3 +939,12 @@ class NumberBar(QtWidgets.QFrame):
 
         painter.end()
         QtWidgets.QWidget.paintEvent(self, event)
+    
+    def set_first_line(self, line: int, do_update=True):
+        """
+        Defines the number of the first line. 
+        Used when loading long texts in chunks.
+        """
+        self.first_line = line
+        if do_update:
+            self.update()


### PR DESCRIPTION
@ccbogel: Good point remembering me about the option to load long texts in chunks in code_text. I have now adjusted the NumberBar to account for this. 
In doing that, I had to fight empty ghost lines appearing in the text edit. This had to do with the chunking algorithm that was adding the line break to the beginning of the next chunk. I corrected that. 
Also, I learned the QTextEdit is inconsistent in the handling of text ending with '\n'. Sometimes, a new empty line is added at the end (only visible now because of the line numbers), sometimes not. To rectify this, I had to delete '\n' from the end of each chunk before loading it into the text edit.  