### PR TITLE
Fixing incompatibilities in AI memory between Windows and Mac

### DIFF
--- a/qualcoder/ai_chat.py
+++ b/qualcoder/ai_chat.py
@@ -627,7 +627,10 @@ data collected. This information will accompany every prompt sent to the AI, res
                 self.ui.progressBar_ai.setRange(0, 0)  # Starts the animation
         # update ai status in the statusBar of the main window
         if self.app.ai is not None:
-            self.main_window.statusBar().showMessage(_('AI: ') + _(self.app.ai.get_status()))
+            if self.app.ai.get_status() == 'reading data':
+                self.main_window.statusBar().showMessage(_('AI: ') + _('reading data (') + str(self.app.ai.sources_vectorstore.ai_worker_running()) + _(' documents left to go)...'))
+            else:
+                self.main_window.statusBar().showMessage(_('AI: ') + _(self.app.ai.get_status()))
         else: 
             self.main_window.statusBar().showMessage('')
 

--- a/qualcoder/ai_chat.py
+++ b/qualcoder/ai_chat.py
@@ -627,8 +627,8 @@ data collected. This information will accompany every prompt sent to the AI, res
                 self.ui.progressBar_ai.setRange(0, 0)  # Starts the animation
         # update ai status in the statusBar of the main window
         if self.app.ai is not None:
-            if self.app.ai.get_status() == 'reading data':
-                self.main_window.statusBar().showMessage(_('AI: ') + _('reading data (') + str(self.app.ai.sources_vectorstore.ai_worker_running()) + _(' documents left to go)...'))
+            if self.app.ai.get_status() == 'reading data' and self.app.ai.sources_vectorstore.reading_doc != '':
+                self.main_window.statusBar().showMessage(_('AI: ') + _('reading data') + ' (' + self.app.ai.sources_vectorstore.reading_doc + ')')
             else:
                 self.main_window.statusBar().showMessage(_('AI: ') + _(self.app.ai.get_status()))
         else: 

--- a/qualcoder/ai_vectorstore.py
+++ b/qualcoder/ai_vectorstore.py
@@ -20,7 +20,8 @@ https://qualcoder.wordpress.com/
 """
 
 import os
-os.environ['FAISS_NO_AVX2'] = '1' 
+os.environ['FAISS_NO_AVX2'] = '1'  # This is suggested by Langchain, but will in fact NOT WORK
+os.environ['FAISS_OPT_LEVEL'] = ''  # This will atually create a 'generic' index. It is a poorly documented feature introduced here: https://github.com/facebookresearch/faiss/commit/eefa39105eda498ab5fcd82ea0e11b18fd3fc0d7
 # Must be set before importing faiss. This tells faiss not to use AVX2, which makes the resulting
 # index also compatible with older machines and non-intel platforms.    
 

--- a/qualcoder/ai_vectorstore.py
+++ b/qualcoder/ai_vectorstore.py
@@ -425,9 +425,6 @@ want to continue?\
         
         # split fulltext into smaller chunks 
         if text != '':  # Can only add embeddings if text is not empty
-            if signals is not None and signals.progress is not None:
-                signals.progress.emit(_('AI: Adding document to internal memory: ') + f'"{name}"')
-
             metadata = {'id': id_, 'name': name}
             document = Document(page_content=text, metadata=metadata)
             text_splitter = RecursiveCharacterTextSplitter(separators=[".", "!", "?", "\n\n", "\n", " ", ""], 
@@ -435,6 +432,12 @@ want to continue?\
                                                         add_start_index=True)
             chunks = text_splitter.split_documents([document])
             
+            if len(chunks) == 0:  # empty doc
+                return
+            
+            if signals is not None and signals.progress is not None:
+                signals.progress.emit(_('AI: Adding document to internal memory: ') + f'"{name}"')
+
             # create embeddings for these chunks and store them in the faiss_db (with metadata)
             for chunk in chunks:
                 if not self._is_closing:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ langchain-community>=0.2.7
 langchain-core>=0.2.19
 langchain-openai>=0.1.16
 langchain-text-splitters>=0.2.2 
-faiss-cpu<=1.7.2
+faiss-cpu
 sentence-transformers 
 fuzzysearch 
 PyYAML 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ langchain-community>=0.2.7
 langchain-core>=0.2.19
 langchain-openai>=0.1.16
 langchain-text-splitters>=0.2.2 
-faiss-cpu
+faiss-cpu<=1.7.2
 sentence-transformers 
 fuzzysearch 
 PyYAML 


### PR DESCRIPTION
I have bought a used Mac mini (M1 from 2020) for testing. QualCoder works fine, but there was one issue: 
If you open a project created on Windows on a Mac, the faiss index representing the AI memory is not compatible, which will through an error. The reason is that on Windows, the index was optimized for hardware acceleration based on AVX2, which is not available on newer Macs with Apple Silicon. 
I had to downgrade the `faiss-cpu` package to version 1.7.2 because newer versions would not allow to turn AVX2 off (a known issue: https://github.com/langchain-ai/chat-langchain/issues/61#issuecomment-1914426775). 
I also added error handling in case the faiss index needs to rebuilding.