### PR TITLE
Fix typo in ai_chat.py

### DIFF
--- a/src/qualcoder/ai_chat.py
+++ b/src/qualcoder/ai_chat.py
@@ -435,7 +435,7 @@ data collected. This information will accompany every prompt sent to the AI, res
             
             summary = _('Analyzing the free topic "{}" in the data.').format(self.ai_search_code_name)
             if self.ai_search_code_memo != '':
-                summary += _('\nDescription:') + ' ' + {self.ai_search_code_memo}
+                summary += _('\nDescription:') + f' {self.ai_search_code_memo}'
             logger.debug(f'New topic chat.')
             self.new_chat(_('Topic') + f' "{self.ai_search_code_name}"', 'topic chat', summary, self.ai_prompt.name_and_scope())
             # warn if project memo empty 


### PR DESCRIPTION
Fixes a typo that lead to a TypeError in trying to concatenate to string. Changed to an f-string as presumed original intention was.

Error appeared when adding any description to AI Topic Analysis chat.