### PR TITLE
Fix heading highlight regex

### DIFF
--- a/src/qualcoder/helpers.py
+++ b/src/qualcoder/helpers.py
@@ -857,17 +857,17 @@ class MarkdownHighlighter(QtGui.QSyntaxHighlighter):
         h1_format = QtGui.QTextCharFormat()
         h1_format.setFontPointSize(self.app.settings['docfontsize'] + 6)
         h1_format.setFontWeight(QtGui.QFont.Weight.Bold)
-        self.highlighting_rules += [(QtCore.QRegularExpression("# [^\n]*"), h1_format)]
+        self.highlighting_rules += [(QtCore.QRegularExpression("^# [^\n]*"), h1_format)]
         # Heading 2
         h2_format = QtGui.QTextCharFormat()
         h2_format.setFontPointSize(self.app.settings['docfontsize'] + 4)
         h2_format.setFontWeight(QtGui.QFont.Weight.Bold)
-        self.highlighting_rules += [(QtCore.QRegularExpression("## [^\n]*"), h2_format)]
+        self.highlighting_rules += [(QtCore.QRegularExpression("^## [^\n]*"), h2_format)]
         # Heading 3
         h3_format = QtGui.QTextCharFormat()
         h3_format.setFontPointSize(self.app.settings['docfontsize'] + 2)
         h3_format.setFontWeight(QtGui.QFont.Weight.Bold)
-        self.highlighting_rules += [(QtCore.QRegularExpression("### [^\n]*"), h3_format)]
+        self.highlighting_rules += [(QtCore.QRegularExpression("^### [^\n]*"), h3_format)]
         # Italic
         italic_format = QtGui.QTextCharFormat()
         italic_format.setFontItalic(True)


### PR DESCRIPTION
The heading highlight activated with the `#`  at the middle of the line.
<img width="1307" height="296" alt="image" src="https://github.com/user-attachments/assets/391f0389-33ae-435f-8a10-ef3e5fdb698f" />

I fixed the Regex rule and this fixed
<img width="777" height="248" alt="image" src="https://github.com/user-attachments/assets/a1b64cae-49c6-4b3d-af8c-086fbce61a68" />

