### PR TITLE
Readme: Fedora 43 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,37 @@ Create a .Desktop file for launch, enter this command (adapt it according to the
 
 bash -c 'cd ~/.local/share/qualcoder/src/ && ~/.local/share/qualcoder/env/bin/python3.12 -m qualcoder'
 
+### Fedora 43
+
+These instructions are adapted from the Fedora 42 instructions below, tested with QualCoder 3.7 on Fedora 43 with Python 3.12.12.
+
+1. Install dependencies:
+
+    ```bash
+    sudo dnf install python3.12
+    ```
+
+2. Set up QualCoder:
+
+    ```bash
+    cd ~/qualcoder  # replace with appropriate location on your machine
+    python3.12 -m venv env
+    source env/bin/activate
+    python3.12 -m ensurepip
+    python3.12 -m pip install --upgrade pip
+    mkdir tmp
+    TMPDIR=./tmp python3.12 -m pip install -r requirements.txt
+    deactivate
+    ```
+
+3. Usage:
+
+    ```bash
+    cd ~/qualcoder  # replace with appropriate location on your machine
+    source env/bin/activate
+    cd src
+    python3.12 -m qualcoder
+    ```
 
 ### Fedora 42
 


### PR DESCRIPTION
Updated Readme file with instructions for Fedora 43.

Key differences from existing instructions:

- Creating the virtual environment using `python3.12` so that it isn't created with `python3.14`
- Manually setting `TMPDIR` to avoid an issue with `/tmp` running out of space

Seems to be working fine:

<img width="1121" height="1146" alt="Screenshot From 2025-11-23 14-17-57" src="https://github.com/user-attachments/assets/e45e0806-9ea6-4abd-a5c6-43234590af08" />

I haven't tested audio/video coding yet.
