### PR TITLE
Add iramuteq export

### DIFF
--- a/src/qualcoder/GUI/ui_dialog_report_codings.py
+++ b/src/qualcoder/GUI/ui_dialog_report_codings.py
@@ -182,6 +182,7 @@ class Ui_Dialog_reportCodings(object):
         self.comboBox_export.setItemText(3, _translate("Dialog_reportCodings", "odt"))
         self.comboBox_export.setItemText(4, _translate("Dialog_reportCodings", "xlsx"))
         self.comboBox_export.setItemText(5, _translate("Dialog_reportCodings", "csv"))
+        self.comboBox_export.setItemText(5, _translate("Dialog_reportCodings", "iramuteq"))
         self.label_title.setText(_translate("Dialog_reportCodings", "Coding report"))
         self.comboBox_matrix.setToolTip(_translate("Dialog_reportCodings", "File and case matrix options"))
         self.checkBox_important.setToolTip(_translate("Dialog_reportCodings", "Filter results for those marked Important"))
@@ -217,3 +218,4 @@ if __name__ == "__main__":
     ui.setupUi(Dialog_reportCodings)
     Dialog_reportCodings.show()
     sys.exit(app.exec())
+


### PR DESCRIPTION
Iramuteq is a well-known free software program for lexical analysis, particularly used in France. This feature allows you to export in a format that can be used in this software, enabling more in-depth analysis after running through QualCoder.

PS: I'm not yet very familiar with contributing to GitHub, so I apologise that this has to be done in several pull requests.