### PR TITLE
Improved propagation of database changes throughout the app

### DIFF
--- a/src/qualcoder/__main__.py
+++ b/src/qualcoder/__main__.py
@@ -171,6 +171,46 @@ class ProjectLockHeartbeatWorker(QtCore.QObject):
         self.finished.emit()
 
 
+class ProjectEventBus(QtCore.QObject):
+    """Application-wide event bus for project database changes."""
+
+    project_data_changed = QtCore.pyqtSignal(object)
+
+    def emit_table_changes(self, tables, source=""):
+        """Emit one normalized project-change event."""
+
+        if not isinstance(tables, dict) or len(tables) == 0:
+            return
+        payload = {
+            "source": str(source if source is not None else ""),
+            "tables": {},
+        }
+        for table_name, table_change in tables.items():
+            if not isinstance(table_name, str) or table_name.strip() == "":
+                continue
+            change = table_change if isinstance(table_change, dict) else {}
+            ops = change.get("ops", [])
+            if isinstance(ops, str):
+                ops = [ops]
+            elif not isinstance(ops, (list, tuple, set)):
+                ops = []
+            normalized = {
+                "ops": sorted({str(op).strip() for op in ops if str(op).strip() != ""}),
+            }
+            for key in ("affected_ids", "affected_file_ids", "affected_code_ids", "affected_cat_ids", "changed_columns"):
+                values = change.get(key, [])
+                if isinstance(values, (list, tuple, set)):
+                    normalized[key] = sorted({value for value in values if value is not None})
+                elif values is None:
+                    normalized[key] = []
+                else:
+                    normalized[key] = [values]
+            payload["tables"][table_name] = normalized
+        if len(payload["tables"]) == 0:
+            return
+        self.project_data_changed.emit(payload)
+
+
 class App(object):
     """ General methods for loading settings and recent project stored in .qualcoder folder.
     Savable settings does not contain project name, project path or db connection.
@@ -192,6 +232,7 @@ class App(object):
     ai_models = []
     # This is the sentence transformer embedding function. It is stored here so it must not be reloaded every time a project is opened.
     ai_embedding_function = None
+    project_events = None
     
     def __init__(self):
         self.conn = None
@@ -208,6 +249,7 @@ class App(object):
         self.settings, self.ai_models = self.load_settings()
         self.last_export_directory = copy(self.settings['directory'])
         self.version = qualcoder_version
+        self.project_events = ProjectEventBus()
 
     def read_previous_project_paths(self):
         """ Recent project paths are stored in .qualcoder/recent_projects.txt

--- a/src/qualcoder/__main__.py
+++ b/src/qualcoder/__main__.py
@@ -172,43 +172,25 @@ class ProjectLockHeartbeatWorker(QtCore.QObject):
 
 
 class ProjectEventBus(QtCore.QObject):
-    """Application-wide event bus for project database changes."""
+    """Application-wide event bus for project database changes.
+    This is used to notify other dialogs (e.g. reports) of changes to the project database, 
+    so they can update their UI (e.g the code tree)."""
 
-    project_data_changed = QtCore.pyqtSignal(object)
+    project_data_changed = QtCore.pyqtSignal(list, object)
 
-    def emit_table_changes(self, tables, source=""):
-        """Emit one normalized project-change event."""
+    def emit_table_changes(self, tables: list[str], source=None):
+        """Emit one project-change event for changed database tables.
 
-        if not isinstance(tables, dict) or len(tables) == 0:
+        Args:
+            tables: List of database table names that changed. An empty list means that no
+                project-wide event is emitted.
+            source: Optional object identifying the emitter. Subscribers can compare this to
+                themselves to ignore events that originated from the same dialog instance.
+        """
+
+        if len(tables) == 0:
             return
-        payload = {
-            "source": str(source if source is not None else ""),
-            "tables": {},
-        }
-        for table_name, table_change in tables.items():
-            if not isinstance(table_name, str) or table_name.strip() == "":
-                continue
-            change = table_change if isinstance(table_change, dict) else {}
-            ops = change.get("ops", [])
-            if isinstance(ops, str):
-                ops = [ops]
-            elif not isinstance(ops, (list, tuple, set)):
-                ops = []
-            normalized = {
-                "ops": sorted({str(op).strip() for op in ops if str(op).strip() != ""}),
-            }
-            for key in ("affected_ids", "affected_file_ids", "affected_code_ids", "affected_cat_ids", "changed_columns"):
-                values = change.get(key, [])
-                if isinstance(values, (list, tuple, set)):
-                    normalized[key] = sorted({value for value in values if value is not None})
-                elif values is None:
-                    normalized[key] = []
-                else:
-                    normalized[key] = [values]
-            payload["tables"][table_name] = normalized
-        if len(payload["tables"]) == 0:
-            return
-        self.project_data_changed.emit(payload)
+        self.project_data_changed.emit(tables, source)
 
 
 class App(object):

--- a/src/qualcoder/ai_chat.py
+++ b/src/qualcoder/ai_chat.py
@@ -252,6 +252,8 @@ class DialogAIChat(QtWidgets.QDialog):
                 icon = self.app.ai.text_analysis_icon()
             elif analysis_type == 'code chat':
                 icon = self.app.ai.code_analysis_icon()
+            else: # unknown type, ignore this chat altogether
+                continue
 
             item = QtWidgets.QListWidgetItem(icon, name)
             item.setToolTip(tooltip_text)

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -267,9 +267,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.ui.checkBox_text.stateChanged.connect(self.update_page)
 
         self.get_files()
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -2175,7 +2173,12 @@ class DialogCodePdf(QtWidgets.QWidget):
             self.app.project_events.emit_table_changes(tables, source=self)
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local PDF coding UI when project events affect it."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -1444,7 +1444,6 @@ class DialogCodePdf(QtWidgets.QWidget):
                 if code['catid'] == catid:
                     cur.execute("update code_name set catid=? where catid=?", [category['catid'], catid])
             cur.execute("delete from code_cat where catid=?", [catid])
-            self.update_dialog_codes_and_categories()
             for cat in self.categories:
                 if cat['supercatid'] == catid:
                     cur.execute("update code_cat set supercatid=? where supercatid=?", [category['catid'], catid])
@@ -1461,7 +1460,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             self.app.conn.rollback()  # Revert all changes
             self.update_dialog_codes_and_categories()
             raise
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
 
     def move_code(self, selected):
         """ Move code to another category or to no category.
@@ -1484,7 +1483,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         category = ui.get_selected()
         cur.execute("update code_name set catid=? where cid=?", [category['catid'], cid])
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
 
     def show_important_coded(self):
         """ Show codes flagged as important.
@@ -2027,7 +2026,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             cur.execute("update code_cat set supercatid=? where catid=?",
                         [self.categories[found]['supercatid'], self.categories[found]['catid']])
             self.app.conn.commit()
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_cat"])
             self.app.delete_backup = False
             return
 
@@ -2054,7 +2053,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                         [self.codes[found]['catid'], self.codes[found]['cid']])
             self.app.conn.commit()
             self.app.delete_backup = False
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_name"])
 
     def merge_codes(self, item, parent):
         """ Merge code with another code.
@@ -2116,7 +2115,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.app.delete_backup = False
         msg = msg.replace("\n", " ")
         self.parent_textEdit.append(msg)
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
         self.get_coded_text_update_eventfilter_tooltips()
         self.display_page_text_objects()
 
@@ -2156,67 +2155,34 @@ class DialogCodePdf(QtWidgets.QWidget):
         except sqlite3.IntegrityError:
             # Can occur with in vivo coding
             return False
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
         self.get_coded_text_update_eventfilter_tooltips()
         return True
 
-    def update_dialog_codes_and_categories(self):
-        """ Update code and category tree here and in DialogReportCodes, ReportCoderComparisons, ReportCodeFrequencies
-        Using try except blocks for each instance, as instance may have been deleted. """
+    def update_dialog_codes_and_categories(self, tables: list[str] = []):
+        """Refresh the local dialog after code/category changes and optionally notify other dialogs.
+
+        Args:
+            tables: Optional list of changed database table names to emit to the project event bus.
+                Use an empty list for a local-only refresh without notifying other dialogs.
+        """
 
         self.get_codes_and_categories()
         self.fill_tree()
         self.get_coded_text_update_eventfilter_tooltips()
 
-        contents = self.tab_reports.layout()
-        if contents:
-            for i in reversed(range(contents.count())):
-                c = contents.itemAt(i).widget()
-                if isinstance(c, DialogReportCodes):
-                    c.get_codes_categories_coders()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCoderComparisons):
-                    c.get_data()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCodeFrequencies):
-                    c.get_data()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCodeSummary):
-                    c.get_codes_and_categories()
-                    c.fill_tree()
+        if self.app.project_events is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local PDF coding UI when project events affect it."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
 
-        current_file_id = int(self.file_["id"]) if self.file_ is not None else None
         code_tree_changed = "code_cat" in tables or "code_name" in tables
-
-        code_text_change = tables.get("code_text", {})
-        if not isinstance(code_text_change, dict):
-            code_text_change = {}
-        affected_file_ids = code_text_change.get("affected_file_ids", [])
-        if not isinstance(affected_file_ids, list):
-            affected_file_ids = []
-        current_file_text_changed = (
-            current_file_id is not None and
-            (len(affected_file_ids) == 0 or current_file_id in affected_file_ids)
-        )
-
-        refresh_current_text = current_file_text_changed
-        if "code_name" in tables and self.code_text:
-            code_name_change = tables.get("code_name", {})
-            if not isinstance(code_name_change, dict):
-                code_name_change = {}
-            affected_code_ids = code_name_change.get("affected_code_ids", [])
-            if isinstance(affected_code_ids, list) and affected_code_ids:
-                current_code_ids = {int(item["cid"]) for item in self.code_text if item.get("cid") is not None}
-                refresh_current_text = refresh_current_text or bool(current_code_ids.intersection(affected_code_ids))
+        refresh_current_text = "code_text" in tables or ("code_name" in tables and bool(self.code_text))
 
         if code_tree_changed:
             self.get_codes_and_categories()
@@ -2225,7 +2191,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                 self.get_coded_text_update_eventfilter_tooltips()
             return
 
-        if "code_text" not in tables or not current_file_text_changed:
+        if "code_text" not in tables or self.file_ is None:
             return
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
@@ -2248,7 +2214,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         cur.execute("insert into code_cat (name, memo, owner, date, supercatid) values(?,?,?,?,?)",
                     (item['name'], item['memo'], item['owner'], item['date'], supercatid))
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat"])
         self.app.delete_backup = False
         self.parent_textEdit.append(_("New category: ") + item['name'])
 
@@ -2258,6 +2224,8 @@ class DialogCodePdf(QtWidgets.QWidget):
         if selected.text(1)[0:3] == 'cat':
             self.delete_category(selected)
             return  # Avoid error as selected is now None
+        changed_tables = []
+
         if selected.text(1)[0:3] == 'cid':
             self.delete_code(selected)
 
@@ -2284,14 +2252,13 @@ class DialogCodePdf(QtWidgets.QWidget):
         cur.execute("delete from code_image where cid=?", [code_['cid'], ])
         self.app.conn.commit()
         self.app.delete_backup = False
-        self.update_dialog_codes_and_categories()
         self.parent_textEdit.append(_("Code deleted: ") + code_['name'] + "\n")
         # Remove from recent codes
         for item in self.recent_codes:
             if item['name'] == code_['name']:
                 self.recent_codes.remove(item)
                 break
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
         self.display_page_text_objects()
 
     def delete_category(self, selected):
@@ -2319,7 +2286,7 @@ class DialogCodePdf(QtWidgets.QWidget):
               "(select catid from code_cat)"
         cur.execute(sql)
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
         self.app.delete_backup = False
         self.parent_textEdit.append(_("Category deleted: ") + category['name'])
 
@@ -2343,6 +2310,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                 cur.execute("update code_name set memo=? where cid=?", (memo, self.codes[found]['cid']))
                 self.app.conn.commit()
                 self.app.delete_backup = False
+                changed_tables = ["code_name"]
             if memo == "":
                 selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
             else:
@@ -2367,12 +2335,13 @@ class DialogCodePdf(QtWidgets.QWidget):
                 cur.execute("update code_cat set memo=? where catid=?", (memo, self.categories[found]['catid']))
                 self.app.conn.commit()
                 self.app.delete_backup = False
+                changed_tables = ["code_cat"]
             if memo == "":
                 selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
             else:
                 selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
                 self.parent_textEdit.append(_("Memo for category: ") + self.categories[found]['name'])
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(changed_tables)
 
     def rename_category_or_code(self, selected):
         """ Rename a code or category.
@@ -2416,7 +2385,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             self.app.delete_backup = False
             old_name = self.codes[found]['name']
             self.parent_textEdit.append(f'{_("Code renamed:")} {old_name} -> {new_name}')
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_name"])
             self.display_page_text_objects()
             return
 
@@ -2450,7 +2419,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             self.app.conn.commit()
             self.app.delete_backup = False
             old_name = self.categories[found]['name']
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_cat"])
             self.parent_textEdit.append(f'{_("Category renamed:")} {old_name} -> {new_name}')
 
     def change_code_color(self, selected):
@@ -2480,7 +2449,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                     (self.codes[found]['color'], self.codes[found]['cid']))
         self.app.conn.commit()
         self.app.delete_backup = False
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
         self.display_page_text_objects()
 
     def file_menu(self, position):

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -267,6 +267,9 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.ui.checkBox_text.stateChanged.connect(self.update_page)
 
         self.get_files()
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -2181,6 +2184,51 @@ class DialogCodePdf(QtWidgets.QWidget):
                 if isinstance(c, DialogReportCodeSummary):
                     c.get_codes_and_categories()
                     c.fill_tree()
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local PDF coding UI when project events affect it."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+
+        current_file_id = int(self.file_["id"]) if self.file_ is not None else None
+        code_tree_changed = "code_cat" in tables or "code_name" in tables
+
+        code_text_change = tables.get("code_text", {})
+        if not isinstance(code_text_change, dict):
+            code_text_change = {}
+        affected_file_ids = code_text_change.get("affected_file_ids", [])
+        if not isinstance(affected_file_ids, list):
+            affected_file_ids = []
+        current_file_text_changed = (
+            current_file_id is not None and
+            (len(affected_file_ids) == 0 or current_file_id in affected_file_ids)
+        )
+
+        refresh_current_text = current_file_text_changed
+        if "code_name" in tables and self.code_text:
+            code_name_change = tables.get("code_name", {})
+            if not isinstance(code_name_change, dict):
+                code_name_change = {}
+            affected_code_ids = code_name_change.get("affected_code_ids", [])
+            if isinstance(affected_code_ids, list) and affected_code_ids:
+                current_code_ids = {int(item["cid"]) for item in self.code_text if item.get("cid") is not None}
+                refresh_current_text = refresh_current_text or bool(current_code_ids.intersection(affected_code_ids))
+
+        if code_tree_changed:
+            self.get_codes_and_categories()
+            self.fill_tree()
+            if refresh_current_text:
+                self.get_coded_text_update_eventfilter_tooltips()
+            return
+
+        if "code_text" not in tables or not current_file_text_changed:
+            return
+        self.get_coded_text_update_eventfilter_tooltips()
+        self.fill_code_counts_in_tree()
 
     def add_category(self, supercatid=None):
         """ When button pressed, add a new category.

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -407,6 +407,9 @@ class DialogCodeText(QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)  # Remove margins if needed
         layout.addWidget(self.number_bar)
         self.ui.lineNumbers.setLayout(layout)
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -3764,6 +3767,41 @@ class DialogCodeText(QtWidgets.QWidget):
                 if isinstance(c, DialogReportCodeSummary):
                     c.get_codes_and_categories()
                     c.fill_tree()
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local code tree or text codings when project events touch them."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        if "code_cat" not in tables and "code_name" not in tables:
+            if "code_text" not in tables:
+                return
+            # Only code_text changed, so refresh tooltips and code counts without rebuilding the tree.
+            code_text_change = tables.get("code_text", {})
+            if not isinstance(code_text_change, dict):
+                return
+            affected_file_ids = code_text_change.get("affected_file_ids", [])
+            if not isinstance(affected_file_ids, list):
+                affected_file_ids = []
+            ai_assisted_coding = self.ui.tabWidget.currentIndex() == 1
+            current_file_matches = (
+                self.file_ is not None and (
+                    len(affected_file_ids) == 0 or int(self.file_['id']) in affected_file_ids
+                )
+            )
+            if current_file_matches:
+                self.get_coded_text_update_eventfilter_tooltips()
+            if current_file_matches or ai_assisted_coding:
+                self.fill_code_counts_in_tree()
+            return
+        self.get_codes_and_categories()
+        self.fill_tree()
+        self.unlight()
+        self.highlight()
+        self.get_coded_text_update_eventfilter_tooltips()
 
     def add_category(self, supercatid=None):
         """ When button pressed, add a new category.

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -2137,7 +2137,6 @@ class DialogCodeText(QtWidgets.QWidget):
                 if code['catid'] == catid:
                     cur.execute("update code_name set catid=? where catid=?", [category['catid'], catid])
             cur.execute("delete from code_cat where catid=?", [catid])
-            self.update_dialog_codes_and_categories()
             for cat in self.categories:
                 if cat['supercatid'] == catid:
                     cur.execute("update code_cat set supercatid=? where supercatid=?", [category['catid'], catid])
@@ -2154,7 +2153,7 @@ class DialogCodeText(QtWidgets.QWidget):
             self.app.conn.rollback()  # Revert all changes
             self.update_dialog_codes_and_categories()
             raise
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
 
     def move_code(self, selected):
         """ Move code to another category or to no category.
@@ -2177,7 +2176,7 @@ class DialogCodeText(QtWidgets.QWidget):
         category = ui.get_selected()
         cur.execute("update code_name set catid=? where cid=?", [category['catid'], cid])
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
 
     def show_memos(self):
         """ Show all memos for coded text in dialog. """
@@ -3594,7 +3593,7 @@ class DialogCodeText(QtWidgets.QWidget):
             cur.execute("update code_cat set supercatid=? where catid=?",
                         [self.categories[found]['supercatid'], self.categories[found]['catid']])
             self.app.conn.commit()
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_cat"])
             self.app.delete_backup = False
             return
 
@@ -3621,7 +3620,7 @@ class DialogCodeText(QtWidgets.QWidget):
                         [self.codes[found]['catid'], self.codes[found]['cid']])
             self.app.conn.commit()
             self.app.delete_backup = False
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_name"])
 
     def merge_codes(self, item, parent):
         """ Merge code with another code.
@@ -3697,7 +3696,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.app.delete_backup = False
         msg = msg.replace("\n", " ")
         self.parent_textEdit.append(msg)
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
         self.get_coded_text_update_eventfilter_tooltips()
 
     def add_code(self, catid=None, code_name=""):
@@ -3737,13 +3736,17 @@ class DialogCodeText(QtWidgets.QWidget):
             # Can occur with in vivo coding
             print("in vivo coding. Code already exists")
             return False
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
         self.get_coded_text_update_eventfilter_tooltips()
         return True
 
-    def update_dialog_codes_and_categories(self):
-        """ Update code and category tree here and in DialogReportCodes, ReportCoderComparisons, ReportCodeFrequencies
-        Using try except blocks for each instance, as instance may have been deleted. """
+    def update_dialog_codes_and_categories(self, tables: list[str] = []):
+        """Refresh the local dialog after code/category changes and optionally notify other dialogs.
+
+        Args:
+            tables: Optional list of changed database table names to emit to the project event bus.
+                Use an empty list for a local-only refresh without notifying other dialogs.
+        """
 
         self.get_codes_and_categories()
         self.fill_tree()
@@ -3751,56 +3754,28 @@ class DialogCodeText(QtWidgets.QWidget):
         self.highlight()
         self.get_coded_text_update_eventfilter_tooltips()
 
-        contents = self.tab_reports.layout()
-        if contents:
-            for i in reversed(range(contents.count())):
-                c = contents.itemAt(i).widget()
-                if isinstance(c, DialogReportCodes):
-                    c.get_codes_categories_coders()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCoderComparisons):
-                    c.get_data()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCodeFrequencies):
-                    c.get_data()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCodeSummary):
-                    c.get_codes_and_categories()
-                    c.fill_tree()
+        if self.app.project_events is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local code tree or text codings when project events touch them."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         if "code_cat" not in tables and "code_name" not in tables:
             if "code_text" not in tables:
                 return
-            # Only code_text changed, so refresh tooltips and code counts without rebuilding the tree.
-            code_text_change = tables.get("code_text", {})
-            if not isinstance(code_text_change, dict):
-                return
-            affected_file_ids = code_text_change.get("affected_file_ids", [])
-            if not isinstance(affected_file_ids, list):
-                affected_file_ids = []
+            # only code_text has changed
             ai_assisted_coding = self.ui.tabWidget.currentIndex() == 1
-            current_file_matches = (
-                self.file_ is not None and (
-                    len(affected_file_ids) == 0 or int(self.file_['id']) in affected_file_ids
-                )
-            )
-            if current_file_matches:
+            if self.file_ is not None:
                 self.get_coded_text_update_eventfilter_tooltips()
-            if current_file_matches or ai_assisted_coding:
+            if self.file_ is not None or ai_assisted_coding:
                 self.fill_code_counts_in_tree()
             return
+        # codes or categories have changed, so refresh all
         self.get_codes_and_categories()
         self.fill_tree()
-        self.unlight()
-        self.highlight()
         self.get_coded_text_update_eventfilter_tooltips()
 
     def add_category(self, supercatid=None):
@@ -3821,7 +3796,7 @@ class DialogCodeText(QtWidgets.QWidget):
         cur.execute("insert into code_cat (name, memo, owner, date, supercatid) values(?,?,?,?,?)",
                     (item['name'], item['memo'], item['owner'], item['date'], supercatid))
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat"])
         self.app.delete_backup = False
         self.parent_textEdit.append(_("New category: ") + item['name'])
 
@@ -3862,14 +3837,13 @@ class DialogCodeText(QtWidgets.QWidget):
         cur.execute("delete from code_image where cid=?", [code_['cid'], ])
         self.app.conn.commit()
         self.app.delete_backup = False
-        self.update_dialog_codes_and_categories()
         self.parent_textEdit.append(_("Code deleted: ") + code_['name'] + "\n")
         # Remove from recent codes
         for item in self.recent_codes:
             if item['name'] == code_['name']:
                 self.recent_codes.remove(item)
                 break
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
         self.app.delete_backup = False
 
     def delete_category(self, selected):
@@ -3900,7 +3874,7 @@ class DialogCodeText(QtWidgets.QWidget):
               "(select catid from code_cat)"
         cur.execute(sql)
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
         self.app.delete_backup = False
         self.parent_textEdit.append(_("Category deleted: ") + category['name'])
 
@@ -3909,6 +3883,8 @@ class DialogCodeText(QtWidgets.QWidget):
         Args:
             selected: QTreeWidgetItem
         """
+
+        changed_tables = []
 
         if selected.text(1)[0:3] == 'cid':
             # Find the code in the list
@@ -3927,6 +3903,7 @@ class DialogCodeText(QtWidgets.QWidget):
                 cur.execute("update code_name set memo=? where cid=?", (memo, self.codes[found]['cid']))
                 self.app.conn.commit()
                 self.app.delete_backup = False
+                changed_tables = ["code_name"]
             if memo == "":
                 selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
             else:
@@ -3951,12 +3928,13 @@ class DialogCodeText(QtWidgets.QWidget):
                 cur.execute("update code_cat set memo=? where catid=?", (memo, self.categories[found]['catid']))
                 self.app.conn.commit()
                 self.app.delete_backup = False
+                changed_tables = ["code_cat"]
             if memo == "":
                 selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
             else:
                 selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
                 self.parent_textEdit.append(_("Memo for category: ") + self.categories[found]['name'])
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(changed_tables)
 
     def rename_category_or_code(self, selected):
         """ Rename a code or category.
@@ -4000,7 +3978,7 @@ class DialogCodeText(QtWidgets.QWidget):
             self.app.delete_backup = False
             old_name = self.codes[found]['name']
             self.parent_textEdit.append(_("Code renamed from: ") + old_name + _(" to: ") + new_name)
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_name"])
             return
 
         if selected.text(1)[0:3] == 'cat':
@@ -4033,7 +4011,7 @@ class DialogCodeText(QtWidgets.QWidget):
             self.app.conn.commit()
             self.app.delete_backup = False
             old_name = self.categories[found]['name']
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_cat"])
             self.parent_textEdit.append(_("Category renamed from: ") + old_name + _(" to: ") + new_name)
 
     def change_code_color(self, selected):
@@ -4063,7 +4041,7 @@ class DialogCodeText(QtWidgets.QWidget):
                     (self.codes[found]['color'], self.codes[found]['cid']))
         self.app.conn.commit()
         self.app.delete_backup = False
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
 
     def file_menu(self, position):
         """ Context menu for listWidget files to get to the next file and
@@ -4401,7 +4379,7 @@ class DialogCodeText(QtWidgets.QWidget):
         if self.file_ is not None:
             ui_speaker = DialogSpeakers(self.app, self.file_['id'], self.file_['name'])
             if ui_speaker.exec() == QtWidgets.QDialog.DialogCode.Accepted:
-                self.update_dialog_codes_and_categories()
+                self.update_dialog_codes_and_categories(["code_name", "code_text"])
                 if self.app.conn is not None and speaker_coder_name not in self.app.get_coder_names_in_project(
                         only_visible=True):
                     msg = _(

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -407,9 +407,7 @@ class DialogCodeText(QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)  # Remove margins if needed
         layout.addWidget(self.number_bar)
         self.ui.lineNumbers.setLayout(layout)
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -3758,7 +3756,12 @@ class DialogCodeText(QtWidgets.QWidget):
             self.app.project_events.emit_table_changes(tables, source=self)
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local code tree or text codings when project events touch them."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/report_code_summary.py
+++ b/src/qualcoder/report_code_summary.py
@@ -103,14 +103,12 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
 
         self.codes, self.categories = self.app.get_codes_categories()
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local code tree when project events change the code system."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         if "code_cat" not in tables and "code_name" not in tables:
             return
         self.fill_tree()

--- a/src/qualcoder/report_code_summary.py
+++ b/src/qualcoder/report_code_summary.py
@@ -86,6 +86,9 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
         self.ui.treeWidget.itemClicked.connect(self.fill_text_edit)
         self.ui.textEdit.setTabChangesFocus(True)
         self.ui.comboBox_stopwords.currentTextChanged.connect(self.fill_text_edit)
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def splitter_sizes(self):
         """ Detect size changes in splitter and store in app.settings variable. """
@@ -99,6 +102,18 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
         Also called on other coding dialogs in the dialog_list. """
 
         self.codes, self.categories = self.app.get_codes_categories()
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local code tree when project events change the code system."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        if "code_cat" not in tables and "code_name" not in tables:
+            return
+        self.fill_tree()
 
     def get_collapsed(self, item):
         """ On category collapse or expansion signal, find the collapsed parent category items.

--- a/src/qualcoder/report_code_summary.py
+++ b/src/qualcoder/report_code_summary.py
@@ -86,9 +86,7 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
         self.ui.treeWidget.itemClicked.connect(self.fill_text_edit)
         self.ui.textEdit.setTabChangesFocus(True)
         self.ui.comboBox_stopwords.currentTextChanged.connect(self.fill_text_edit)
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def splitter_sizes(self):
         """ Detect size changes in splitter and store in app.settings variable. """
@@ -104,7 +102,12 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
         self.codes, self.categories = self.app.get_codes_categories()
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local code tree when project events change the code system."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/report_codes.py
+++ b/src/qualcoder/report_codes.py
@@ -289,14 +289,12 @@ class DialogReportCodes(QtWidgets.QDialog):
         for row in result:
             self.coders.append(row[0])
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local code tree when project events change the code system."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         if "code_cat" not in tables and "code_name" not in tables:
             return
         self.code_names, self.categories = self.app.get_codes_categories()

--- a/src/qualcoder/report_codes.py
+++ b/src/qualcoder/report_codes.py
@@ -181,9 +181,7 @@ class DialogReportCodes(QtWidgets.QDialog):
         self.ui.treeWidget.customContextMenuRequested.connect(self.treewidget_menu)
         self.eventFilterTT = ToolTipEventFilter()
         self.ui.textEdit.installEventFilter(self.eventFilterTT)
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def splitter_sizes(self):
         """ Detect size changes in splitter and store in app.settings variable. """
@@ -290,7 +288,12 @@ class DialogReportCodes(QtWidgets.QDialog):
             self.coders.append(row[0])
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local code tree when project events change the code system."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/report_codes.py
+++ b/src/qualcoder/report_codes.py
@@ -181,6 +181,9 @@ class DialogReportCodes(QtWidgets.QDialog):
         self.ui.treeWidget.customContextMenuRequested.connect(self.treewidget_menu)
         self.eventFilterTT = ToolTipEventFilter()
         self.ui.textEdit.installEventFilter(self.eventFilterTT)
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def splitter_sizes(self):
         """ Detect size changes in splitter and store in app.settings variable. """
@@ -285,6 +288,19 @@ class DialogReportCodes(QtWidgets.QDialog):
         self.coders = [""]
         for row in result:
             self.coders.append(row[0])
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local code tree when project events change the code system."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        if "code_cat" not in tables and "code_name" not in tables:
+            return
+        self.code_names, self.categories = self.app.get_codes_categories()
+        self.fill_tree()
 
     def get_selected_files_and_cases(self):
         """ Fill file_ids and case_ids Strings used in the search.

--- a/src/qualcoder/report_codes_by_segments.py
+++ b/src/qualcoder/report_codes_by_segments.py
@@ -172,16 +172,14 @@ class DialogCodesBySegments(QtWidgets.QDialog):
         for row in result:
             self.coders.append(row[0])
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local tree when project events affect segment reports."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         watched_tables = {"code_cat", "code_name", "code_text", "code_av", "code_image"}
-        if watched_tables.isdisjoint(tables.keys()):
+        if watched_tables.isdisjoint(tables):
             return
 
         current_coder = self.ui.comboBox_coders.currentText()

--- a/src/qualcoder/report_codes_by_segments.py
+++ b/src/qualcoder/report_codes_by_segments.py
@@ -112,6 +112,9 @@ class DialogCodesBySegments(QtWidgets.QDialog):
         self.segment_rows = []
         self.horizontal_labels = []
         self.xlsx_results = []
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def get_files_and_cases(self, file_sort="name asc"):
         """ Get text files with additional details and fill files list widget.
@@ -168,6 +171,29 @@ class DialogCodesBySegments(QtWidgets.QDialog):
         self.coders = [""]
         for row in result:
             self.coders.append(row[0])
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local tree when project events affect segment reports."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        watched_tables = {"code_cat", "code_name", "code_text", "code_av", "code_image"}
+        if watched_tables.isdisjoint(tables.keys()):
+            return
+
+        current_coder = self.ui.comboBox_coders.currentText()
+        self.get_codes_categories_coders()
+        self.ui.comboBox_coders.blockSignals(True)
+        self.ui.comboBox_coders.clear()
+        self.ui.comboBox_coders.insertItems(0, self.coders)
+        index = self.ui.comboBox_coders.findText(current_coder)
+        if index >= 0:
+            self.ui.comboBox_coders.setCurrentIndex(index)
+        self.ui.comboBox_coders.blockSignals(False)
+        self.fill_tree()
 
     def get_selected_files_and_cases(self):
         """ Fill file_ids and case_ids Strings used in the search.

--- a/src/qualcoder/report_codes_by_segments.py
+++ b/src/qualcoder/report_codes_by_segments.py
@@ -112,9 +112,7 @@ class DialogCodesBySegments(QtWidgets.QDialog):
         self.segment_rows = []
         self.horizontal_labels = []
         self.xlsx_results = []
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def get_files_and_cases(self, file_sort="name asc"):
         """ Get text files with additional details and fill files list widget.
@@ -173,7 +171,12 @@ class DialogCodesBySegments(QtWidgets.QDialog):
             self.coders.append(row[0])
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local tree when project events affect segment reports."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/report_compare_coder_file.py
+++ b/src/qualcoder/report_compare_coder_file.py
@@ -109,6 +109,9 @@ class DialogCompareCoderByFile(QtWidgets.QDialog):
         self.ui.treeWidget.itemSelectionChanged.connect(self.code_selected)
         self.ui.listWidget_files.itemClicked.connect(self.file_selected)
         self.ui.textEdit.setReadOnly(True)
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def information(self):
         """ Provide statistical help information. """
@@ -131,6 +134,19 @@ class DialogCompareCoderByFile(QtWidgets.QDialog):
         for row in result:
             self.coders.append(row[0])
         self.get_files()
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local code tree when project events change the code system."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        if "code_cat" not in tables and "code_name" not in tables:
+            return
+        self.codes, self.categories = self.app.get_codes_categories()
+        self.fill_tree()
 
     def file_menu(self, position):
         """ Context menu for listWidget files for Sorting files.

--- a/src/qualcoder/report_compare_coder_file.py
+++ b/src/qualcoder/report_compare_coder_file.py
@@ -109,9 +109,7 @@ class DialogCompareCoderByFile(QtWidgets.QDialog):
         self.ui.treeWidget.itemSelectionChanged.connect(self.code_selected)
         self.ui.listWidget_files.itemClicked.connect(self.file_selected)
         self.ui.textEdit.setReadOnly(True)
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def information(self):
         """ Provide statistical help information. """
@@ -136,7 +134,12 @@ class DialogCompareCoderByFile(QtWidgets.QDialog):
         self.get_files()
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local code tree when project events change the code system."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/report_compare_coder_file.py
+++ b/src/qualcoder/report_compare_coder_file.py
@@ -135,14 +135,12 @@ class DialogCompareCoderByFile(QtWidgets.QDialog):
             self.coders.append(row[0])
         self.get_files()
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local code tree when project events change the code system."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         if "code_cat" not in tables and "code_name" not in tables:
             return
         self.codes, self.categories = self.app.get_codes_categories()

--- a/src/qualcoder/report_comparison_table.py
+++ b/src/qualcoder/report_comparison_table.py
@@ -143,16 +143,14 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         fresh_code_map = {code["cid"]: code for code in fresh_codes}
         self.codes = [fresh_code_map[cid] for cid in previous_selected_ids if cid in fresh_code_map]
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local comparison table when project events affect it."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         watched_tables = {"code_cat", "code_name", "code_text", "code_av", "code_image"}
-        if watched_tables.isdisjoint(tables.keys()):
+        if watched_tables.isdisjoint(tables):
             return
 
         self._refresh_selected_codes_from_project()

--- a/src/qualcoder/report_comparison_table.py
+++ b/src/qualcoder/report_comparison_table.py
@@ -103,9 +103,7 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         self.data_counts = []
         self.data_colors = []
         self.data_list_widget = []   # Used to transfer data from list widget item to DialogCodeIn...
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def clear_table_and_data(self):
         self.data = []
@@ -144,7 +142,12 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         self.codes = [fresh_code_map[cid] for cid in previous_selected_ids if cid in fresh_code_map]
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local comparison table when project events affect it."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/report_comparison_table.py
+++ b/src/qualcoder/report_comparison_table.py
@@ -76,6 +76,8 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         self.ui.splitter.setSizes([500, 0])
 
         self.codes, self.categories = self.app.get_codes_categories()
+        self.code_selection_mode = "all"
+        self.selected_category_ids = []
         self.files = self.app.get_text_filenames()
         # Get attributes
         sql = "select name, valuetype, caseOrFile,0,0 from attribute_type where caseOrFile!='journal'"
@@ -101,6 +103,9 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         self.data_counts = []
         self.data_colors = []
         self.data_list_widget = []   # Used to transfer data from list widget item to DialogCodeIn...
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def clear_table_and_data(self):
         self.data = []
@@ -111,6 +116,57 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         self.ui.tableWidget.setRowCount(0)
         self.ui.tableWidget.setColumnCount(0)
         self.ui.listWidget.clear()
+
+    def _selected_code_ids(self):
+        return [code["cid"] for code in self.codes if isinstance(code, dict) and code.get("cid") is not None]
+
+    def _refresh_selected_codes_from_project(self):
+        fresh_codes, fresh_categories = self.app.get_codes_categories()
+        self.categories = fresh_categories
+        previous_selected_ids = self._selected_code_ids()
+
+        if self.code_selection_mode == "all":
+            self.codes = fresh_codes
+            return
+
+        if self.code_selection_mode == "categories" and self.selected_category_ids:
+            matched_categories = [cat for cat in fresh_categories if cat["catid"] in self.selected_category_ids]
+            refreshed_codes = []
+            for category in matched_categories:
+                for code_ in self.get_children_of_category(category):
+                    code_copy = dict(code_)
+                    code_copy["name"] = f"{category['name']}:\n{code_copy['name']}"
+                    refreshed_codes.append(code_copy)
+            self.codes = refreshed_codes
+            return
+
+        fresh_code_map = {code["cid"]: code for code in fresh_codes}
+        self.codes = [fresh_code_map[cid] for cid in previous_selected_ids if cid in fresh_code_map]
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local comparison table when project events affect it."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        watched_tables = {"code_cat", "code_name", "code_text", "code_av", "code_image"}
+        if watched_tables.isdisjoint(tables.keys()):
+            return
+
+        self._refresh_selected_codes_from_project()
+        if not self.codes:
+            self.clear_table_and_data()
+            return
+
+        has_visible_results = bool(self.data_counts) or self.ui.tableWidget.rowCount() > 0 or self.ui.tableWidget.columnCount() > 0
+        if not has_visible_results:
+            return
+
+        self.ui.listWidget.clear()
+        self.data_list_widget = []
+        self.process_files_data()
 
     def select_attribute(self):
         """ Select an attribute.
@@ -358,10 +414,14 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         if not selected or selected[0]['name'] == '':
             #selected = deepcopy(self.codes)
             self.codes = codes
+            self.code_selection_mode = "all"
+            self.selected_category_ids = []
             Message(self.app, _("Codes selected"), _("All codes selected")).exec()
         else:
             msg = ""
             self.codes = []
+            self.code_selection_mode = "codes"
+            self.selected_category_ids = []
             for selected_code in selected:
                 self.codes.append(selected_code)
                 msg += f"{selected_code['name']}\n"
@@ -381,6 +441,8 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
             return
         category = ui.get_selected()
         self.codes = self.get_children_of_category(category)
+        self.code_selection_mode = "categories"
+        self.selected_category_ids = [category["catid"]] if category.get("catid") is not None else []
         for code_ in self.codes:
             code_['name'] = f"{category['name']}:\n{code_['name']}"
         self.clear_table_and_data()

--- a/src/qualcoder/report_cooccurrence.py
+++ b/src/qualcoder/report_cooccurrence.py
@@ -119,6 +119,8 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
         self.subtitle_attributes_selected = ""
 
         self.codes, self.categories = self.app.get_codes_categories()
+        self.code_selection_mode = "all"
+        self.selected_category_ids = []
         self.code_names_list = []
         self.code_names_str = ""
         self.code_ids_str = ""
@@ -135,6 +137,75 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
         self.data_colors = []
         self.data_details = []
         self.file_ids_names = self.app.get_text_filenames()
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.process_data()
+
+    def _rebuild_selected_code_strings(self):
+        self.code_names_list = []
+        self.code_names_str = ""
+        self.code_ids_str = ""
+        for code_ in self.selected_codes:
+            self.code_names_list.append(code_["name"])
+            self.code_names_str += f"{code_['name']}|"
+            self.code_ids_str += f",{code_['cid']}"
+        self.code_ids_str = self.code_ids_str[1:] if self.code_ids_str else ""
+
+    def _refresh_selected_codes_from_project(self):
+        fresh_codes, fresh_categories = self.app.get_codes_categories()
+        self.codes, self.categories = fresh_codes, fresh_categories
+
+        if self.code_selection_mode == "all":
+            self.selected_codes = deepcopy(self.codes)
+            self.selected_categories_string = ""
+            self._rebuild_selected_code_strings()
+            return
+
+        if self.code_selection_mode == "categories" and self.selected_category_ids:
+            matched_categories = [cat for cat in self.categories if cat["catid"] in self.selected_category_ids]
+            self.selected_categories_string = "; ".join(cat["name"] for cat in matched_categories)
+            refreshed_codes = []
+            for category in matched_categories:
+                for code_ in self.codes_of_category(category):
+                    if code_ not in refreshed_codes:
+                        refreshed_codes.append(code_)
+            self.selected_codes = refreshed_codes
+            self._rebuild_selected_code_strings()
+            return
+
+        selected_ids = [code["cid"] for code in self.selected_codes if isinstance(code, dict) and code.get("cid") is not None]
+        code_map = {code["cid"]: code for code in self.codes}
+        self.selected_codes = [code_map[cid] for cid in selected_ids if cid in code_map]
+        self.selected_categories_string = ""
+        self._rebuild_selected_code_strings()
+
+    def _clear_results(self):
+        self.result_relations = []
+        self.max_count = 0
+        self.data_counts = []
+        self.data_colors = []
+        self.data_details = []
+        self.ui.tableWidget.setRowCount(0)
+        self.ui.tableWidget.setColumnCount(0)
+        self.ui.textEdit.clear()
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local co-occurrence dialog when project events affect it."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        watched_tables = {"code_cat", "code_name", "code_text"}
+        if watched_tables.isdisjoint(tables.keys()):
+            return
+
+        self._refresh_selected_codes_from_project()
+        if not self.selected_codes or not self.code_ids_str:
+            self._clear_results()
+            return
         self.process_data()
 
     def select_files(self):
@@ -248,11 +319,15 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
         self.selected_codes = ui.get_selected()
         if not self.selected_codes or self.selected_codes[0]['name'] == '':
             self.selected_codes = deepcopy(self.codes)
+            self.code_selection_mode = "all"
+            self.selected_category_ids = []
             Message(self.app, _("Codes selected"), _("All codes selected")).exec()
             self.subtitle_codes_selected = ""
             self.subtitle_categories_selected = ""
         else:
             msg = ""
+            self.code_selection_mode = "codes"
+            self.selected_category_ids = []
             for s in self.selected_codes:
                 msg += f"{s['name']}\n"
             Message(self.app, _("Codes selected"), msg).exec()
@@ -284,10 +359,12 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
         if not selected_categories or selected_categories[0]['name'] == '':
             selected_categories = deepcopy(self.categories)
             msg = _("All categories selected")
+            self.selected_category_ids = [category["catid"] for category in selected_categories if category.get("catid") is not None]
             self.subtitle_categories_selected = ""
             self.subtitle_codes_selected = ""
         else:
             msg = ""
+            self.selected_category_ids = [category["catid"] for category in selected_categories if category.get("catid") is not None]
             for category in selected_categories:
                 msg += f"{category['name']}\n"
                 self.selected_categories_string += category['name'] + "; "
@@ -297,6 +374,7 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
             else:
                 self.subtitle_categories_selected = f"{len(selected_categories)} " + _("Categories selected ")
             self.subtitle_codes_selected = ""
+        self.code_selection_mode = "categories"
         self.selected_codes = []
         for category in selected_categories:
             codes = self.codes_of_category(category)

--- a/src/qualcoder/report_cooccurrence.py
+++ b/src/qualcoder/report_cooccurrence.py
@@ -190,16 +190,14 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
         self.ui.tableWidget.setColumnCount(0)
         self.ui.textEdit.clear()
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local co-occurrence dialog when project events affect it."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         watched_tables = {"code_cat", "code_name", "code_text"}
-        if watched_tables.isdisjoint(tables.keys()):
+        if watched_tables.isdisjoint(tables):
             return
 
         self._refresh_selected_codes_from_project()

--- a/src/qualcoder/report_cooccurrence.py
+++ b/src/qualcoder/report_cooccurrence.py
@@ -137,9 +137,7 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
         self.data_colors = []
         self.data_details = []
         self.file_ids_names = self.app.get_text_filenames()
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
         self.process_data()
 
     def _rebuild_selected_code_strings(self):
@@ -191,7 +189,12 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
         self.ui.textEdit.clear()
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local co-occurrence dialog when project events affect it."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/report_exact_matches.py
+++ b/src/qualcoder/report_exact_matches.py
@@ -103,9 +103,7 @@ class DialogReportExactTextMatches(QtWidgets.QDialog):
         self.ui.pushButton_run.pressed.connect(self.get_exact_text_matches)
         self.ui.tableWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.tableWidget.customContextMenuRequested.connect(self.table_menu)
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def get_data(self):
         """ Called from init. gets code_names, categories and owner names.
@@ -133,7 +131,12 @@ class DialogReportExactTextMatches(QtWidgets.QDialog):
             self.ui.comboBox_coders.blockSignals(False)
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local exact-match dialog when project events affect it."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/report_exact_matches.py
+++ b/src/qualcoder/report_exact_matches.py
@@ -132,16 +132,14 @@ class DialogReportExactTextMatches(QtWidgets.QDialog):
                 self.ui.comboBox_coders.setCurrentIndex(index)
             self.ui.comboBox_coders.blockSignals(False)
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local exact-match dialog when project events affect it."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         watched_tables = {"code_cat", "code_name", "code_text"}
-        if watched_tables.isdisjoint(tables.keys()):
+        if watched_tables.isdisjoint(tables):
             return
 
         selected_files = {item.text() for item in self.ui.listWidget_files.selectedItems()}

--- a/src/qualcoder/report_exact_matches.py
+++ b/src/qualcoder/report_exact_matches.py
@@ -103,11 +103,17 @@ class DialogReportExactTextMatches(QtWidgets.QDialog):
         self.ui.pushButton_run.pressed.connect(self.get_exact_text_matches)
         self.ui.tableWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.tableWidget.customContextMenuRequested.connect(self.table_menu)
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def get_data(self):
         """ Called from init. gets code_names, categories and owner names.
         """
 
+        current_coder = ""
+        if hasattr(self, "ui") and hasattr(self.ui, "comboBox_coders"):
+            current_coder = self.ui.comboBox_coders.currentText()
         self.coder_names = self.app.get_coder_names_in_project()
         self.codes, self.categories = self.app.get_codes_categories()
         sql = "select owner from  code_image union select owner from code_text union select owner from code_av"
@@ -117,7 +123,41 @@ class DialogReportExactTextMatches(QtWidgets.QDialog):
         self.coders = []
         for row in result:
             self.coders.append(row[0])
-        self.ui.comboBox_coders.insertItems(0, self.coders)
+        if hasattr(self, "ui") and hasattr(self.ui, "comboBox_coders"):
+            self.ui.comboBox_coders.blockSignals(True)
+            self.ui.comboBox_coders.clear()
+            self.ui.comboBox_coders.insertItems(0, self.coders)
+            index = self.ui.comboBox_coders.findText(current_coder)
+            if index >= 0:
+                self.ui.comboBox_coders.setCurrentIndex(index)
+            self.ui.comboBox_coders.blockSignals(False)
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local exact-match dialog when project events affect it."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        watched_tables = {"code_cat", "code_name", "code_text"}
+        if watched_tables.isdisjoint(tables.keys()):
+            return
+
+        selected_files = {item.text() for item in self.ui.listWidget_files.selectedItems()}
+        self.get_data()
+        available_cids = {code["cid"] for code in self.codes}
+        self.excluded_codes = [item for item in self.excluded_codes if item[0] in available_cids]
+        if "code_cat" in tables or "code_name" in tables:
+            self.excluded_codes = []
+            self.fill_tree()
+        if "code_text" in tables:
+            self.get_files_fill_list_widget()
+            for i in range(self.ui.listWidget_files.count()):
+                item = self.ui.listWidget_files.item(i)
+                item.setSelected(item.text() in selected_files)
+        self.results_display = []
+        self.fill_table()
 
     def get_files_fill_list_widget(self):
         """ Get source files with additional details and fill list widget.

--- a/src/qualcoder/report_relations.py
+++ b/src/qualcoder/report_relations.py
@@ -227,16 +227,14 @@ class DialogReportRelations(QtWidgets.QDialog):
         self.coder_names = self.app.get_coder_names_in_project()
         self.codes, self.categories = self.app.get_codes_categories()
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local relations dialog when project events affect it."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         watched_tables = {"code_cat", "code_name", "code_text"}
-        if watched_tables.isdisjoint(tables.keys()):
+        if watched_tables.isdisjoint(tables):
             return
 
         self.get_code_data()

--- a/src/qualcoder/report_relations.py
+++ b/src/qualcoder/report_relations.py
@@ -121,9 +121,7 @@ class DialogReportRelations(QtWidgets.QDialog):
         self.files = []
         for r in res:
             self.files.append({'name': r[0], 'fid': r[1]})
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def select_files(self):
         """ Select files for analysis. """
@@ -228,7 +226,12 @@ class DialogReportRelations(QtWidgets.QDialog):
         self.codes, self.categories = self.app.get_codes_categories()
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local relations dialog when project events affect it."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/report_relations.py
+++ b/src/qualcoder/report_relations.py
@@ -121,6 +121,9 @@ class DialogReportRelations(QtWidgets.QDialog):
         self.files = []
         for r in res:
             self.files.append({'name': r[0], 'fid': r[1]})
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def select_files(self):
         """ Select files for analysis. """
@@ -223,6 +226,27 @@ class DialogReportRelations(QtWidgets.QDialog):
 
         self.coder_names = self.app.get_coder_names_in_project()
         self.codes, self.categories = self.app.get_codes_categories()
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local relations dialog when project events affect it."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        watched_tables = {"code_cat", "code_name", "code_text"}
+        if watched_tables.isdisjoint(tables.keys()):
+            return
+
+        self.get_code_data()
+        if "code_cat" in tables or "code_name" in tables:
+            self.fill_tree()
+        self.result_relations = []
+        self.result_summary = []
+        self.dataframe = None
+        self.fill_table()
+        self.ui.tableWidget_statistics.setRowCount(0)
 
     def calculate_code_relations(self):
         """ Calculate the relations for selected codes for THIS coder or ALL coders.

--- a/src/qualcoder/reports.py
+++ b/src/qualcoder/reports.py
@@ -86,6 +86,9 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
         self.ui.treeWidget.itemExpanded.connect(self.get_collapsed)
         self.ui.radioButton.clicked.connect(self.sort_by_alphabet)
         self.ui.radioButton_2.clicked.connect(self.sort_by_totals)
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def select_files_button(self):
         """ Report code frequencies for all files or selected files.
@@ -296,6 +299,22 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
         self.categories = sorted(self.categories, key=lambda i: (i['display_list'][0]))
         self.codes = sorted(self.codes, key=lambda i: (i['display_list'][0]))
         self.fill_tree()
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local tree when project events change codes or codings."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        watched_tables = {"code_cat", "code_name", "code_text", "code_av", "code_image"}
+        if watched_tables.isdisjoint(tables.keys()):
+            return
+        if self.ui.radioButton_2.isChecked():
+            self.sort_by_totals()
+            return
+        self.sort_by_alphabet()
 
     def depthgauge(self, item):
         """ Get depth for treewidget item. """
@@ -559,6 +578,9 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
         self.ui.treeWidget.itemExpanded.connect(self.get_collapsed)
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def get_data(self):
         """ Called from init. gets coders, codes, categories, file_summaries.
@@ -574,6 +596,23 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
         self.coders = [""]
         for row in result:
             self.coders.append(row[0])
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local comparison tree when project events touch it."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+        watched_tables = {"code_cat", "code_name", "code_text"}
+        if watched_tables.isdisjoint(tables.keys()):
+            return
+        if "code_text" in tables:
+            self.get_data()
+        else:
+            self.codes, self.categories = self.app.get_codes_categories()
+        self.fill_tree()
 
     def coder_selected(self):
         """ Select coders for comparison - only two coders can be selected. """

--- a/src/qualcoder/reports.py
+++ b/src/qualcoder/reports.py
@@ -300,16 +300,14 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
         self.codes = sorted(self.codes, key=lambda i: (i['display_list'][0]))
         self.fill_tree()
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local tree when project events change codes or codings."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         watched_tables = {"code_cat", "code_name", "code_text", "code_av", "code_image"}
-        if watched_tables.isdisjoint(tables.keys()):
+        if watched_tables.isdisjoint(tables):
             return
         if self.ui.radioButton_2.isChecked():
             self.sort_by_totals()
@@ -597,16 +595,14 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
         for row in result:
             self.coders.append(row[0])
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local comparison tree when project events touch it."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
         watched_tables = {"code_cat", "code_name", "code_text"}
-        if watched_tables.isdisjoint(tables.keys()):
+        if watched_tables.isdisjoint(tables):
             return
         if "code_text" in tables:
             self.get_data()

--- a/src/qualcoder/reports.py
+++ b/src/qualcoder/reports.py
@@ -86,9 +86,7 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
         self.ui.treeWidget.itemExpanded.connect(self.get_collapsed)
         self.ui.radioButton.clicked.connect(self.sort_by_alphabet)
         self.ui.radioButton_2.clicked.connect(self.sort_by_totals)
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def select_files_button(self):
         """ Report code frequencies for all files or selected files.
@@ -301,7 +299,12 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
         self.fill_tree()
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local tree when project events change codes or codings."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return
@@ -576,9 +579,7 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
         self.ui.treeWidget.itemExpanded.connect(self.get_collapsed)
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
     def get_data(self):
         """ Called from init. gets coders, codes, categories, file_summaries.
@@ -596,7 +597,12 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
             self.coders.append(row[0])
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local comparison tree when project events touch it."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/view_av.py
+++ b/src/qualcoder/view_av.py
@@ -231,9 +231,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
         self.ui.treeWidget.itemClicked.connect(self.assign_selected_text_to_code)
         self.get_files()
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -1662,7 +1660,12 @@ class DialogCodeAV(QtWidgets.QDialog):
             self.app.project_events.emit_table_changes(tables, source=self)
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local media coding UI when project events affect it."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return

--- a/src/qualcoder/view_av.py
+++ b/src/qualcoder/view_av.py
@@ -1571,7 +1571,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         """
 
         DialogCodeInAllFiles(self.app, code_dict)
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name", "code_cat", "code_text", "code_av", "code_image"])
 
     def move_code(self, selected):
         """ Move code to another category or to no category.
@@ -1593,7 +1593,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             return
         category = ui.get_selected()
         cur.execute("update code_name set catid=? where cid=?", [category['catid'], cid])
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
 
     def show_codes_like(self):
         """ Show all codes if text is empty.
@@ -1643,12 +1643,13 @@ class DialogCodeAV(QtWidgets.QDialog):
                 item.child(i).setHidden(False)
             self.recursive_traverse(item.child(i), txt)
 
-    def update_dialog_codes_and_categories(self):
-        """ Update code and category tree in DialogCodeImage, DialogCodeAV,
-        DialogCodeText, DialogReportCodes.
-        Not using isinstance for other classes as could not import the classes to test
-        against. There was an import error.
-        Using try except blocks for each instance, as instance may have been deleted. """
+    def update_dialog_codes_and_categories(self, tables: list[str] = []):
+        """Refresh the local dialog after code/category changes and optionally notify other dialogs.
+
+        Args:
+            tables: Optional list of changed database table names to emit to the project event bus.
+                Use an empty list for a local-only refresh without notifying other dialogs.
+        """
 
         self.get_codes_and_categories()
         self.fill_tree()
@@ -1657,72 +1658,21 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.highlight()
         self.get_coded_text_update_eventfilter_tooltips()
 
-        contents = self.tab_reports.layout()
-        if contents:
-            for i in reversed(range(contents.count())):
-                c = contents.itemAt(i).widget()
-                if isinstance(c, DialogReportCodes):
-                    c.get_codes_categories_coders()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCoderComparisons):
-                    c.get_data()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCodeFrequencies):
-                    c.get_data()
-                    c.fill_tree()
+        if self.app.project_events is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local media coding UI when project events affect it."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
 
-        current_av_file_id = int(self.file_["id"]) if self.file_ is not None else None
-        current_text_file_id = int(self.transcription[0]) if self.transcription is not None else None
         code_tree_changed = "code_cat" in tables or "code_name" in tables
 
-        refresh_segments = False
-        refresh_transcript = False
-        refresh_counts = False
-
-        if "code_av" in tables:
-            code_av_change = tables.get("code_av", {})
-            if not isinstance(code_av_change, dict):
-                code_av_change = {}
-            affected_file_ids = code_av_change.get("affected_file_ids", [])
-            if not isinstance(affected_file_ids, list):
-                affected_file_ids = []
-            if current_av_file_id is not None and (len(affected_file_ids) == 0 or current_av_file_id in affected_file_ids):
-                refresh_segments = True
-                refresh_counts = True
-
-        if "code_text" in tables:
-            code_text_change = tables.get("code_text", {})
-            if not isinstance(code_text_change, dict):
-                code_text_change = {}
-            affected_file_ids = code_text_change.get("affected_file_ids", [])
-            if not isinstance(affected_file_ids, list):
-                affected_file_ids = []
-            if current_text_file_id is not None and (len(affected_file_ids) == 0 or current_text_file_id in affected_file_ids):
-                refresh_transcript = True
-                refresh_segments = True
-                refresh_counts = True
-
-        if "code_name" in tables:
-            code_name_change = tables.get("code_name", {})
-            if not isinstance(code_name_change, dict):
-                code_name_change = {}
-            affected_code_ids = code_name_change.get("affected_code_ids", [])
-            if isinstance(affected_code_ids, list) and affected_code_ids:
-                segment_code_ids = {int(item["cid"]) for item in self.segments if item.get("cid") is not None}
-                transcript_code_ids = {int(item["cid"]) for item in self.code_text if item.get("cid") is not None}
-                if segment_code_ids.intersection(affected_code_ids):
-                    refresh_segments = True
-                if transcript_code_ids.intersection(affected_code_ids):
-                    refresh_transcript = True
+        refresh_segments = "code_av" in tables or "code_text" in tables or ("code_name" in tables and bool(self.segments))
+        refresh_transcript = "code_text" in tables or ("code_name" in tables and bool(self.code_text))
+        refresh_counts = "code_av" in tables or "code_text" in tables
 
         if code_tree_changed:
             self.get_codes_and_categories()
@@ -2285,7 +2235,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             cur.execute("update code_cat set supercatid=? where catid=?",
                         [self.categories[found]['supercatid'], self.categories[found]['catid']])
             self.app.conn.commit()
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_cat"])
             return
 
         # Find the code in the list
@@ -2309,7 +2259,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             cur.execute("update code_name set catid=? where cid=?",
                         [self.codes[found]['catid'], self.codes[found]['cid']])
             self.app.conn.commit()
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_name"])
             self.app.delete_backup = False
 
     def recursive_non_merge_item(self, item, no_merge_list):
@@ -2357,7 +2307,6 @@ class DialogCodeAV(QtWidgets.QDialog):
                 if code['catid'] == catid:
                     cur.execute("update code_name set catid=? where catid=?", [category['catid'], catid])
             cur.execute("delete from code_cat where catid=?", [catid])
-            self.update_dialog_codes_and_categories()
             for cat in self.categories:
                 if cat['supercatid'] == catid:
                     cur.execute("update code_cat set supercatid=? where supercatid=?", [category['catid'], catid])
@@ -2373,7 +2322,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             self.app.conn.rollback()  # revert all changes
             self.update_dialog_codes_and_categories()
             raise            
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
 
     def merge_codes(self, item, parent):
         """ Merge code with another code .
@@ -2429,7 +2378,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         except:
             self.app.conn.rollback() # revert all changes 
             raise                
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
         self.parent_textEdit.append(msg_)
         self.load_segments()
 
@@ -2454,7 +2403,7 @@ class DialogCodeAV(QtWidgets.QDialog):
                     (item['name'], item['memo'], item['owner'], item['date'], item['catid'], item['color']))
         self.app.conn.commit()
         self.parent_textEdit.append(_("Code added: ") + item['name'])
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
         self.app.delete_backup = False
 
     def add_category(self, supercatid=None):
@@ -2475,7 +2424,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         cur.execute("insert into code_cat (name, memo, owner, date, supercatid) values(?,?,?,?,?)",
                     (item['name'], item['memo'], item['owner'], item['date'], supercatid))
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat"])
         self.app.delete_backup = False
 
     def delete_category_or_code(self, selected):
@@ -2514,7 +2463,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         cur.execute("delete from code_text where cid=?", [code_['cid'], ])
         self.app.conn.commit()
         self.parent_textEdit.append(_("Code deleted: ") + code_['name'])
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
         self.app.delete_backup = False
 
     def delete_category(self, selected):
@@ -2545,13 +2494,15 @@ class DialogCodeAV(QtWidgets.QDialog):
         cur.execute(sql)
         self.app.conn.commit()
         self.parent_textEdit.append(_("Category deleted: ") + category['name'])
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
         self.app.delete_backup = False
 
     def add_edit_code_memo(self, selected):
         """ View and edit a memo to a code.
         param:
             selected: QTreeWidgetItem """
+
+        changed_tables = []
 
         if selected.text(1)[0:3] == 'cid':
             # find the code in the list
@@ -2576,6 +2527,7 @@ class DialogCodeAV(QtWidgets.QDialog):
                 cur.execute("update code_name set memo=? where cid=?", (memo, self.codes[found]['cid']))
                 self.app.conn.commit()
                 self.app.delete_backup = False
+                changed_tables = ["code_name"]
 
         if selected.text(1)[0:3] == 'cat':
             # Find the category in the list
@@ -2600,7 +2552,8 @@ class DialogCodeAV(QtWidgets.QDialog):
                 cur.execute("update code_cat set memo=? where catid=?", (memo, self.categories[found]['catid']))
                 self.app.conn.commit()
                 self.app.delete_backup = False
-        self.update_dialog_codes_and_categories()
+                changed_tables = ["code_cat"]
+        self.update_dialog_codes_and_categories(changed_tables)
 
     def rename_category_or_code(self, selected):
         """ Rename a code or category. Checks that the proposed code or category name is
@@ -2631,7 +2584,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             cur.execute("update code_name set name=? where cid=?", (new_name, self.codes[found]['cid']))
             self.app.conn.commit()
             self.parent_textEdit.append(_("Code renamed: ") + f"{self.codes[found]['name']} ==> {new_name}")
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_name"])
             self.app.delete_backup = False
             return
 
@@ -2659,7 +2612,7 @@ class DialogCodeAV(QtWidgets.QDialog):
                         (new_name, self.categories[found]['catid']))
             self.app.conn.commit()
             self.parent_textEdit.append(_("Category renamed: ") + self.categories[found]['name'] + " ==> " + new_name)
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_cat"])
             self.app.delete_backup = False
 
     def change_code_color(self, selected):
@@ -2688,7 +2641,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         cur.execute("update code_name set color=? where cid=?",
                     (self.codes[found]['color'], self.codes[found]['cid']))
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
         self.app.delete_backup = False
 
     # Methods used with the textEdit transcribed text

--- a/src/qualcoder/view_av.py
+++ b/src/qualcoder/view_av.py
@@ -231,6 +231,9 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
         self.ui.treeWidget.itemClicked.connect(self.assign_selected_text_to_code)
         self.get_files()
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -1667,6 +1670,72 @@ class DialogCodeAV(QtWidgets.QDialog):
                 if isinstance(c, DialogReportCodeFrequencies):
                     c.get_data()
                     c.fill_tree()
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local media coding UI when project events affect it."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+
+        current_av_file_id = int(self.file_["id"]) if self.file_ is not None else None
+        current_text_file_id = int(self.transcription[0]) if self.transcription is not None else None
+        code_tree_changed = "code_cat" in tables or "code_name" in tables
+
+        refresh_segments = False
+        refresh_transcript = False
+        refresh_counts = False
+
+        if "code_av" in tables:
+            code_av_change = tables.get("code_av", {})
+            if not isinstance(code_av_change, dict):
+                code_av_change = {}
+            affected_file_ids = code_av_change.get("affected_file_ids", [])
+            if not isinstance(affected_file_ids, list):
+                affected_file_ids = []
+            if current_av_file_id is not None and (len(affected_file_ids) == 0 or current_av_file_id in affected_file_ids):
+                refresh_segments = True
+                refresh_counts = True
+
+        if "code_text" in tables:
+            code_text_change = tables.get("code_text", {})
+            if not isinstance(code_text_change, dict):
+                code_text_change = {}
+            affected_file_ids = code_text_change.get("affected_file_ids", [])
+            if not isinstance(affected_file_ids, list):
+                affected_file_ids = []
+            if current_text_file_id is not None and (len(affected_file_ids) == 0 or current_text_file_id in affected_file_ids):
+                refresh_transcript = True
+                refresh_segments = True
+                refresh_counts = True
+
+        if "code_name" in tables:
+            code_name_change = tables.get("code_name", {})
+            if not isinstance(code_name_change, dict):
+                code_name_change = {}
+            affected_code_ids = code_name_change.get("affected_code_ids", [])
+            if isinstance(affected_code_ids, list) and affected_code_ids:
+                segment_code_ids = {int(item["cid"]) for item in self.segments if item.get("cid") is not None}
+                transcript_code_ids = {int(item["cid"]) for item in self.code_text if item.get("cid") is not None}
+                if segment_code_ids.intersection(affected_code_ids):
+                    refresh_segments = True
+                if transcript_code_ids.intersection(affected_code_ids):
+                    refresh_transcript = True
+
+        if code_tree_changed:
+            self.get_codes_and_categories()
+            self.fill_tree()
+        elif not refresh_counts and not refresh_segments and not refresh_transcript:
+            return
+
+        if refresh_transcript:
+            self.get_coded_text_update_eventfilter_tooltips()
+        if refresh_segments and self.file_ is not None and self.media is not None:
+            self.load_segments()
+        if refresh_counts and not code_tree_changed:
+            self.fill_code_counts_in_tree()
 
     def keyPressEvent(self, event):
         """ This works best without the modifiers.

--- a/src/qualcoder/view_image.py
+++ b/src/qualcoder/view_image.py
@@ -201,6 +201,9 @@ class DialogCodeImage(QtWidgets.QDialog):
             pass
         self.ui.splitter.splitterMoved.connect(self.update_sizes)
         self.ui.splitter_2.splitterMoved.connect(self.update_sizes)
+        project_events = getattr(self.app, "project_events", None)
+        if project_events is not None and hasattr(project_events, "project_data_changed"):
+            project_events.project_data_changed.connect(self._on_project_data_changed)
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -1009,6 +1012,55 @@ class DialogCodeImage(QtWidgets.QDialog):
                 if isinstance(c, DialogReportCodeFrequencies):
                     c.get_data()
                     c.fill_tree()
+
+    def _on_project_data_changed(self, event):
+        """Refresh the local image coding UI when project events affect it."""
+
+        if not isinstance(event, dict):
+            return
+        tables = event.get("tables", {})
+        if not isinstance(tables, dict):
+            return
+
+        current_file_id = int(self.file_["id"]) if self.file_ is not None else None
+        code_tree_changed = "code_cat" in tables or "code_name" in tables
+        refresh_areas = False
+        refresh_counts = False
+        reload_areas = False
+
+        if "code_image" in tables:
+            code_image_change = tables.get("code_image", {})
+            if not isinstance(code_image_change, dict):
+                code_image_change = {}
+            affected_file_ids = code_image_change.get("affected_file_ids", [])
+            if not isinstance(affected_file_ids, list):
+                affected_file_ids = []
+            if current_file_id is not None and (len(affected_file_ids) == 0 or current_file_id in affected_file_ids):
+                refresh_areas = True
+                refresh_counts = True
+                reload_areas = True
+
+        if "code_name" in tables and self.code_areas:
+            code_name_change = tables.get("code_name", {})
+            if not isinstance(code_name_change, dict):
+                code_name_change = {}
+            affected_code_ids = code_name_change.get("affected_code_ids", [])
+            if isinstance(affected_code_ids, list) and affected_code_ids:
+                current_code_ids = {int(item["cid"]) for item in self.code_areas if item.get("cid") is not None}
+                refresh_areas = refresh_areas or bool(current_code_ids.intersection(affected_code_ids))
+
+        if code_tree_changed:
+            self.get_codes_and_categories()
+            self.fill_tree()
+        elif not refresh_areas and not refresh_counts:
+            return
+
+        if reload_areas:
+            self.get_coded_areas()
+        if refresh_areas:
+            self.redraw_scene()
+        if refresh_counts and not code_tree_changed:
+            self.fill_code_counts_in_tree()
 
     def redraw_scene(self):
         """ Resize image. Triggered by user change in slider. Or resize or move of a coded area.

--- a/src/qualcoder/view_image.py
+++ b/src/qualcoder/view_image.py
@@ -990,64 +990,33 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.draw_coded_areas()
         self.fill_code_counts_in_tree()
 
-    def update_dialog_codes_and_categories(self):
-        """ Update code and category tree here and in DialogReportCodes, ReportCoderComparisons, ReportCodeFrequencies
-        Using try except blocks for each instance, as instance may have been deleted. """
+    def update_dialog_codes_and_categories(self, tables: list[str] = []):
+        """Refresh the local dialog after code/category changes and optionally notify other dialogs.
+
+        Args:
+            tables: Optional list of changed database table names to emit to the project event bus.
+                Use an empty list for a local-only refresh without notifying other dialogs.
+        """
 
         self.get_codes_and_categories()
         self.fill_tree()
         self.get_coded_areas()
         self.draw_coded_areas()
 
-        contents = self.tab_reports.layout()
-        if contents:
-            for i in reversed(range(contents.count())):
-                c = contents.itemAt(i).widget()
-                if isinstance(c, DialogReportCodes):
-                    c.get_codes_categories_coders()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCoderComparisons):
-                    c.get_data()
-                    c.fill_tree()
-                if isinstance(c, DialogReportCodeFrequencies):
-                    c.get_data()
-                    c.fill_tree()
+        if self.app.project_events is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
-    def _on_project_data_changed(self, event):
+    def _on_project_data_changed(self, tables, source):
         """Refresh the local image coding UI when project events affect it."""
 
-        if not isinstance(event, dict):
+        if source is self or not isinstance(tables, list):
             return
-        tables = event.get("tables", {})
-        if not isinstance(tables, dict):
-            return
+        tables = set(tables)
 
-        current_file_id = int(self.file_["id"]) if self.file_ is not None else None
         code_tree_changed = "code_cat" in tables or "code_name" in tables
-        refresh_areas = False
-        refresh_counts = False
-        reload_areas = False
-
-        if "code_image" in tables:
-            code_image_change = tables.get("code_image", {})
-            if not isinstance(code_image_change, dict):
-                code_image_change = {}
-            affected_file_ids = code_image_change.get("affected_file_ids", [])
-            if not isinstance(affected_file_ids, list):
-                affected_file_ids = []
-            if current_file_id is not None and (len(affected_file_ids) == 0 or current_file_id in affected_file_ids):
-                refresh_areas = True
-                refresh_counts = True
-                reload_areas = True
-
-        if "code_name" in tables and self.code_areas:
-            code_name_change = tables.get("code_name", {})
-            if not isinstance(code_name_change, dict):
-                code_name_change = {}
-            affected_code_ids = code_name_change.get("affected_code_ids", [])
-            if isinstance(affected_code_ids, list) and affected_code_ids:
-                current_code_ids = {int(item["cid"]) for item in self.code_areas if item.get("cid") is not None}
-                refresh_areas = refresh_areas or bool(current_code_ids.intersection(affected_code_ids))
+        refresh_areas = "code_image" in tables or ("code_name" in tables and bool(self.code_areas))
+        refresh_counts = "code_image" in tables
+        reload_areas = "code_image" in tables
 
         if code_tree_changed:
             self.get_codes_and_categories()
@@ -1378,7 +1347,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             return
         category = ui.get_selected()
         cur.execute("update code_name set catid=? where cid=?", [category['catid'], cid])
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
 
     def show_codes_like(self):
         """ Show all codes if text parameter is empty.
@@ -1605,7 +1574,6 @@ class DialogCodeImage(QtWidgets.QDialog):
                 # event position is QPointF, itemAt requires toPoint
                 parent = self.ui.treeWidget.itemAt(event.position().toPoint())
                 self.item_moved_update_data(item, parent)
-                self.update_dialog_codes_and_categories()
                 return True
         if object_ is self.scene:
             if type(event) == QtWidgets.QGraphicsSceneMouseEvent and event.button() == Qt.MouseButton.LeftButton:
@@ -2025,7 +1993,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             cur.execute("update code_cat set supercatid=? where catid=?",
                         [self.categories[found]['supercatid'], self.categories[found]['catid']])
             self.app.conn.commit()
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_cat"])
             self.app.delete_backup = False
             return
 
@@ -2050,7 +2018,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             cur.execute("update code_name set catid=? where cid=?",
                         [self.codes[found]['catid'], self.codes[found]['cid']])
             self.app.conn.commit()
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_name"])
             self.app.delete_backup = False
 
     def recursive_non_merge_item(self, item, no_merge_list):
@@ -2095,7 +2063,6 @@ class DialogCodeImage(QtWidgets.QDialog):
                 if code['catid'] == catid:
                     cur.execute("update code_name set catid=? where catid=?", [category['catid'], catid])
             cur.execute("delete from code_cat where catid=?", [catid])
-            self.update_dialog_codes_and_categories()
             for cat in self.categories:
                 if cat['supercatid'] == catid:
                     cur.execute("update code_cat set supercatid=? where supercatid=?", [category['catid'], catid])
@@ -2112,7 +2079,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.app.conn.rollback()  # revert all changes
             self.update_dialog_codes_and_categories()
             raise
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
 
     def merge_codes(self, item, parent):
         """ Merge code with another code.
@@ -2172,7 +2139,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.app.conn.rollback()  # revert all changes
             raise
         self.parent_textEdit.append(msg)
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
         self.app.delete_backup = False
 
     def add_code(self, catid=None):
@@ -2197,7 +2164,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         cur.execute("insert into code_name (name,memo,owner,date,catid,color) values(?,?,?,?,?,?)",
                     (item['name'], item['memo'], item['owner'], item['date'], item['catid'], item['color']))
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
         self.parent_textEdit.append(_("New code: ") + item['name'])
         self.app.delete_backup = False
 
@@ -2220,7 +2187,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         cur.execute("insert into code_cat (name, memo, owner, date, supercatid) values(?,?,?,?,?)",
                     (item['name'], item['memo'], item['owner'], item['date'], supercatid))
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat"])
         self.parent_textEdit.append(_("New category: ") + item['name'])
         self.app.delete_backup = False
 
@@ -2261,7 +2228,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         cur.execute("delete from code_av where cid=?", [code_['cid'], ])
         cur.execute("delete from code_text where cid=?", [code_['cid'], ])
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
         self.app.delete_backup = False
 
     def delete_category(self, selected):
@@ -2292,13 +2259,15 @@ class DialogCodeImage(QtWidgets.QDialog):
         cur.execute(sql)
         self.app.conn.commit()
         self.parent_textEdit.append(_("Category deleted: ") + category['name'])
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
         self.app.delete_backup = False
 
     def add_edit_code_memo(self, selected):
         """ View and edit a memo.
         param:
             selected : QTreeWidgetItem """
+
+        changed_tables = []
 
         if selected.text(1)[0:3] == 'cid':
             found = -1
@@ -2322,6 +2291,7 @@ class DialogCodeImage(QtWidgets.QDialog):
                 cur.execute("update code_name set memo=? where cid=?", (memo, self.codes[found]['cid']))
                 self.app.conn.commit()
                 self.app.delete_backup = False
+                changed_tables = ["code_name"]
 
         if selected.text(1)[0:3] == 'cat':
             # Find the category in the list
@@ -2346,7 +2316,8 @@ class DialogCodeImage(QtWidgets.QDialog):
                 cur.execute("update code_cat set memo=? where catid=?", (memo, self.categories[found]['catid']))
                 self.app.conn.commit()
                 self.app.delete_backup = False
-        self.update_dialog_codes_and_categories()
+                changed_tables = ["code_cat"]
+        self.update_dialog_codes_and_categories(changed_tables)
 
     def rename_category_or_code(self, selected):
         """ Rename a code or category. Checks that the proposed code or category name is
@@ -2376,7 +2347,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             cur.execute("update code_name set name=? where cid=?", (new_name, self.codes[found]['cid']))
             self.app.conn.commit()
             old_name = self.codes[found]['name']
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_name"])
             self.parent_textEdit.append(_("Code renamed: ") +
                                         old_name + " ==> " + new_name)
             self.app.delete_backup = False
@@ -2410,7 +2381,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             # selected.setData(0, QtCore.Qt.DisplayRole, new_name)
             self.parent_textEdit.append(_("Category renamed from: ") +
                                         f"{old_name} ==> {new_name}")
-            self.update_dialog_codes_and_categories()
+            self.update_dialog_codes_and_categories(["code_cat"])
             self.app.delete_backup = False
 
     def change_code_color(self, selected):
@@ -2439,7 +2410,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         cur.execute("update code_name set color=? where cid=?",
                     (self.codes[found]['color'], self.codes[found]['cid']))
         self.app.conn.commit()
-        self.update_dialog_codes_and_categories()
+        self.update_dialog_codes_and_categories(["code_name"])
         self.app.delete_backup = False
 
 

--- a/src/qualcoder/view_image.py
+++ b/src/qualcoder/view_image.py
@@ -201,9 +201,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             pass
         self.ui.splitter.splitterMoved.connect(self.update_sizes)
         self.ui.splitter_2.splitterMoved.connect(self.update_sizes)
-        project_events = getattr(self.app, "project_events", None)
-        if project_events is not None and hasattr(project_events, "project_data_changed"):
-            project_events.project_data_changed.connect(self._on_project_data_changed)
+        self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -1007,7 +1005,12 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.app.project_events.emit_table_changes(tables, source=self)
 
     def _on_project_data_changed(self, tables, source):
-        """Refresh the local image coding UI when project events affect it."""
+        """Handle project change events from other dialogs.
+
+        Args:
+            tables: Changed database table names.
+            source: Event emitter, ignored when it is this dialog.
+        """
 
         if source is self or not isinstance(tables, list):
             return


### PR DESCRIPTION
### The Issue:

The existing `update_dialog_codes_and_categories()` method in the coding dialogs is an attempt to propagate changes made in one dialog throughout the app so that other dialogs can update as well, for example an open report. In its current form, however, this mechanism is quite limited:

- It updates only `DialogReportCodes`, `ReportCoderComparisons`, and `ReportCodeFrequencies`, but not the other report types that have been introduced since then.
- Many operations do not trigger an update, even though they may affect open reports. For example, new codings would affect the table of code co-occurrences and many other report types.
- Finally: I also need a reliable UI update mechanism for the AI feature extensions I am currently working on.

### My Proposal:

To address these issues, I suggest a more centralized approach based on PyQt signals:

a) A simple event bus in the QualCoder app object issues a custom `project_data_changed` signal:

```python
class ProjectEventBus(QtCore.QObject):
    """Application-wide event bus for project database changes.

    This is used to notify other dialogs (e.g. reports) of changes to the
    project database, so they can update their UI (e.g. the code tree).
    """

    project_data_changed = QtCore.pyqtSignal(list, object)

    def emit_table_changes(self, tables: list[str], source=None):
        """Emit one project-change event for changed database tables.

        Args:
            tables: List of database table names that changed. An empty list
                means that no project-wide event is emitted.
            source: Optional object identifying the emitter. Subscribers can
                compare this to themselves to ignore events originating from
                the same dialog instance.
        """

        if len(tables) == 0:
            return
        self.project_data_changed.emit(tables, source)
```

b) Each report dialog subscribes to this signal and updates its UI accordingly. For example, in `report_codes.py`:

```python
def _on_project_data_changed(self, tables, source):
    """Refresh the local code tree when project events change the code system."""

    if source is self or not isinstance(tables, list):
        return
    tables = set(tables)
    if "code_cat" not in tables and "code_name" not in tables:
        return
    self.code_names, self.categories = self.app.get_codes_categories()
    self.fill_tree()
```

For now, I have implemented this for all existing `update_dialog_codes_and_categories()` calls in the coding dialogs, which covers changes to the code system.

I have also added subscriber functions (`_on_project_data_changed()`) to the relevant dialogs. However, I left out the graph report and the code organizer dialog, because I am not yet sure whether, or how, those graphs should update when, for example, a code is deleted in a coding dialog.

A next step would be to emit the `project_data_changed` signal for changes to the `code_text`, `code_image`, and `code_av` tables as well. Before implementing that, though, I wanted to get your feedback on this approach.

Don't be overwhelmed by the fact that this PR touches so many files. The changes follow a very similar pattern in all the dialogs.