### PR TITLE
Update manage_files.py

### DIFF
--- a/src/qualcoder/manage_files.py
+++ b/src/qualcoder/manage_files.py
@@ -2225,6 +2225,14 @@ class DialogManageFiles(QtWidgets.QDialog):
             Message(self.app, _("Warning"),
                     _("Cannot import ") + str(import_file) + "\nPlease check if the file is empty.", "warning").exec()
             return
+        # normalise line endings and strip BOM so the stored fulltext matches
+        # exactly what QPlainTextEdit will display. Qt converts \r\n and lone \r
+        # into \n on setPlainText(), and a leftover BOM adds a char; either makes
+        # stored positions drift past the editor length (setPosition out of range,
+        # frozen highlight on resize). <- L
+        text_ = text_.replace("\r\n", "\n").replace("\r", "\n")
+        if text_ and text_[0] == "\ufeff":
+            text_ = text_[1:]
         # Final checks: check for duplicated filename and update model, widget and database
         name_split = import_file.split("/")
         filename = name_split[-1]

--- a/src/qualcoder/manage_files.py
+++ b/src/qualcoder/manage_files.py
@@ -2230,9 +2230,10 @@ class DialogManageFiles(QtWidgets.QDialog):
         # into \n on setPlainText(), and a leftover BOM adds a char; either makes
         # stored positions drift past the editor length (setPosition out of range,
         # frozen highlight on resize). <- L
-        text_ = text_.replace("\r\n", "\n").replace("\r", "\n")
-        if text_ and text_[0] == "\ufeff":
-            text_ = text_[1:]
+        if os.path.splitext(import_file)[1].lower() != '.pdf': # skip PDF 
+            text_ = text_.replace("\r\n", "\n").replace("\r", "\n")
+            if text_ and text_[0] == "\ufeff":
+                text_ = text_[1:]
         # Final checks: check for duplicated filename and update model, widget and database
         name_split = import_file.split("/")
         filename = name_split[-1]


### PR DESCRIPTION
Some files store line breaks as \r\n (Windows style) and sometimes include an invisible character at the start (BOM). When displaying them, Qt cleans these up automatically, so the visible text ends up shorter than what was saved. 
That small mismatch makes the code positions point past the end of the text, and the highlight freezes. 
The fix cleans up those line breaks and the BOM at import time, before saving. That way the saved text and the displayed text have the same length, and positions no longer overflow. It only applies to newly imported files; files imported earlier still carry the mismatch, which is why it's worth keeping the defensive clamp in code_text as well.