### PR TITLE
Persist code tree column widths

### DIFF
--- a/src/qualcoder/__main__.py
+++ b/src/qualcoder/__main__.py
@@ -752,6 +752,14 @@ class App(object):
                 'dialogcodecrossovers_w', 'dialogcodecrossovers_h',
                 'dialogcodecrossovers_splitter0', 'dialogcodecrossovers_splitter1',
                 'dialogmanagelinks_w', 'dialogmanagelinks_h',
+                'ai_search_tree_widths',
+                'dialogcodetext_tree_widths', 'dialogcodepdf_tree_widths',
+                'dialogcodeimage_tree_widths', 'dialogcodeav_tree_widths',
+                'dialogreport_code_summary_tree_widths', 'dialogreportcodes_tree_widths',
+                'dialogreportcodesbysegments_tree_widths', 'dialogreportcomparecoderfile_tree_widths',
+                'dialogreportexactmatches_tree_widths', 'dialogreportrelations_tree_widths',
+                'dialogreportcodefrequencies_tree_widths', 'dialogreportcodercomparisons_tree_widths',
+                'dialogcodecolorscheme_tree_widths',
                 'docfontsize', 'showids',
                 'dialogreport_file_summary_splitter0', 'dialogreport_file_summary_splitter0',
                 'dialogreport_code_summary_splitter0', 'dialogreport_code_summary_splitter0',
@@ -774,6 +782,8 @@ class App(object):
                     settings_data[key] = 50000
                 if key == 'showids':
                     settings_data[key] = False
+                if key.endswith('_tree_widths'):
+                    settings_data[key] = ""
                 if key == 'report_text_context_style':
                     settings_data[key] = "Bold"
                 if key == 'report_text_context_characters':
@@ -1082,6 +1092,20 @@ class App(object):
             'dialogreport_file_summary_splitter1': 100,
             'dialogreport_code_summary_splitter0': 100,
             'dialogreport_code_summary_splitter1': 100,
+            'ai_search_tree_widths': '',
+            'dialogcodetext_tree_widths': '',
+            'dialogcodepdf_tree_widths': '',
+            'dialogcodeimage_tree_widths': '',
+            'dialogcodeav_tree_widths': '',
+            'dialogreport_code_summary_tree_widths': '',
+            'dialogreportcodes_tree_widths': '',
+            'dialogreportcodesbysegments_tree_widths': '',
+            'dialogreportcomparecoderfile_tree_widths': '',
+            'dialogreportexactmatches_tree_widths': '',
+            'dialogreportrelations_tree_widths': '',
+            'dialogreportcodefrequencies_tree_widths': '',
+            'dialogreportcodercomparisons_tree_widths': '',
+            'dialogcodecolorscheme_tree_widths': '',
             'stylesheet': 'native',
             'report_text_context_chars': 150,
             'report_text_context-style': 'Bold',

--- a/src/qualcoder/ai_search_dialog.py
+++ b/src/qualcoder/ai_search_dialog.py
@@ -31,7 +31,7 @@ from .ai_prompts import PromptsList, DialogAiEditPrompts
 from .color_selector import TextColor
 from .report_attributes import DialogSelectAttributeParameters
 from .GUI.ui_ai_search import Ui_Dialog_AiSearch
-from .helpers import Message
+from .helpers import Message, init_persistent_tree_header, restore_persistent_tree_widths
 from .select_items import DialogSelectItems
 
 
@@ -122,6 +122,7 @@ class DialogAiSearch(QtWidgets.QDialog):
         self.ui.listWidget_cases.setStyleSheet(treefont)
         self.ui.listWidget_cases.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.ui.treeWidget.setSelectionMode(QtWidgets.QTreeWidget.SelectionMode.SingleSelection)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'ai_search_tree_widths')
         if self.ui.tabWidget.isTabVisible(0):  # code
             self.fill_tree(selected_id, selected_is_code) 
         # prompts
@@ -189,8 +190,6 @@ class DialogAiSearch(QtWidgets.QDialog):
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -298,7 +297,11 @@ class DialogAiSearch(QtWidgets.QDialog):
         if self.tree_sort_option == "all desc":
             self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
         self.fill_code_counts_in_tree()
-        self.ui.treeWidget.expandAll()    
+        self.ui.treeWidget.expandAll()
+        restore_persistent_tree_widths(
+            self.ui.treeWidget,
+            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
+        )
 
     def fill_code_counts_in_tree(self):
         """ Count instances of each code from all visible or selected coders and all files. """

--- a/src/qualcoder/code_color_scheme.py
+++ b/src/qualcoder/code_color_scheme.py
@@ -32,6 +32,7 @@ from PyQt6.QtGui import QBrush
 
 from .color_selector import colors, colors_red_weak, colors_red_blind, colors_green_weak, colors_green_blind, TextColor
 from .GUI.ui_dialog_code_colours import Ui_Dialog_code_colors
+from .helpers import init_persistent_tree_header, restore_persistent_tree_widths
 
 
 path = os.path.abspath(os.path.dirname(__file__))
@@ -74,6 +75,7 @@ class DialogCodeColorScheme(QtWidgets.QDialog):
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         #self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
         self.ui.treeWidget.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.MultiSelection)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodecolorscheme_tree_widths')
         self.ui.pushButton_clear_selection_codes.pressed.connect(self.ui.treeWidget.clearSelection)
         self.ui.pushButton_clear_selection.pressed.connect(self.ui.tableWidget.clearSelection)
         self.ui.tableWidget.setTabKeyNavigation(False)
@@ -151,8 +153,6 @@ class DialogCodeColorScheme(QtWidgets.QDialog):
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -252,6 +252,7 @@ class DialogCodeColorScheme(QtWidgets.QDialog):
                 item = it.value()
                 count += 1
         self.ui.treeWidget.expandAll()
+        restore_persistent_tree_widths(self.ui.treeWidget)
 
     def update_selected_colors(self):
         """ Update colour list. Prior to applying colors. """

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -50,7 +50,8 @@ from .code_in_all_files import DialogCodeInAllFiles
 from .color_selector import DialogColorSelect
 from .color_selector import colors, TextColor, colour_ranges, show_codes_of_colour_range
 from .confirm_delete import DialogConfirmDelete
-from .helpers import Message, ExportDirectoryPathDialog, ToolTipEventFilter, CodeResizeHandle
+from .helpers import Message, ExportDirectoryPathDialog, ToolTipEventFilter, CodeResizeHandle, \
+    init_persistent_tree_header, restore_persistent_tree_widths
 from .GUI.ui_dialog_code_pdf import Ui_Dialog_code_pdf
 from .memo import DialogMemo
 from .coder_names import DialogCoderNames
@@ -243,10 +244,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
         self.ui.treeWidget.itemPressed.connect(self.fill_code_label)
-        # Codes-tree header menu
-        self.ui.treeWidget.header().setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
-        self.ui.treeWidget.header().customContextMenuRequested.connect(self.codes_tree_header_menu)
-        self.tree_column_widths_auto_resize = True
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodepdf_tree_widths')
 
         self.ui.textEdit_2.setReadOnly(True)  # Code examples
         self.ui.splitter.setSizes([150, 400, 150])
@@ -582,12 +580,6 @@ class DialogCodePdf(QtWidgets.QWidget):
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
-
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -697,6 +689,10 @@ class DialogCodePdf(QtWidgets.QWidget):
         if self.tree_sort_option == "all desc":
             self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
         self.fill_code_counts_in_tree()
+        restore_persistent_tree_widths(
+            self.ui.treeWidget,
+            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
+        )
 
     def fill_code_counts_in_tree(self):
         """ Calculate the frequency of each code and category for this coder and the selected file.
@@ -771,19 +767,6 @@ class DialogCodePdf(QtWidgets.QWidget):
 
         if column == 2:
             self.add_edit_cat_or_code_memo(item)
-
-    def codes_tree_header_menu(self, position: int):
-        """ treeWidget resize mode - resize to contents or interactive. """
-
-        menu = QtWidgets.QMenu(self)
-        action_resize = menu.addAction(_("Toggle automatic resize"))
-        action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
-        if action == action_resize:
-            self.tree_column_widths_auto_resize = not self.tree_column_widths_auto_resize
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
     def get_collapsed(self, item):
         """ On category collapse or expansion signal, find the collapsed parent category items.

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -53,7 +53,7 @@ from .code_in_all_files import DialogCodeInAllFiles
 from .color_selector import DialogColorSelect, colour_ranges, colors, TextColor, show_codes_of_colour_range
 from .confirm_delete import DialogConfirmDelete
 from .helpers import Message, DialogGetStartAndEndMarks, ExportDirectoryPathDialog, NumberBar, CodeResizeHandle, \
-    ToolTipEventFilter
+    ToolTipEventFilter, init_persistent_tree_header, restore_persistent_tree_widths
 from .GUI.ui_dialog_code_text import Ui_Dialog_code_text
 from .memo import DialogMemo
 from .report_attributes import DialogSelectAttributeParameters
@@ -709,10 +709,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
         self.ui.treeWidget.itemPressed.connect(self.fill_code_label_with_selected_code)
-        # Codes-tree header menu
-        self.ui.treeWidget.header().setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
-        self.ui.treeWidget.header().customContextMenuRequested.connect(self.codes_tree_header_menu)
-        self.tree_column_widths_auto_resize = True
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodetext_tree_widths')
 
         self.ui.splitter.setSizes([150, 400, 0])  # 3 values; right pane starts collapsed <- L
         try:
@@ -1618,17 +1615,10 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.treeWidget.clear()
         self.ui.treeWidget.setColumnCount(4)
         self.ui.treeWidget.setHeaderLabels([_("Name"), _("Id"), _("Memo"), _("Count")])
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
-        self.ui.treeWidget.header().resizeSection(0, 400)
         if not self.app.settings['showids']:
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
-        self.ui.treeWidget.header().setStretchLastSection(False)
 
         # Add top level categories
         remove_list = []
@@ -1739,6 +1729,10 @@ class DialogCodeText(QtWidgets.QWidget):
         if self.tree_sort_option == "all desc":
             self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
         self.fill_code_counts_in_tree()
+        restore_persistent_tree_widths(
+            self.ui.treeWidget,
+            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
+        )
 
     def fill_code_counts_in_tree(self):
         """ Calculate the frequency of each code and category for this coder and the selected file.
@@ -1826,19 +1820,6 @@ class DialogCodeText(QtWidgets.QWidget):
 
         if column == 2:
             self.add_edit_cat_or_code_memo(item)
-
-    def codes_tree_header_menu(self, position):
-        """ treeWidget resize mode - resize to contents or interactive. """
-
-        menu = QtWidgets.QMenu(self)
-        action_resize = menu.addAction(_("Toggle automatic resize"))
-        action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
-        if action == action_resize:
-            self.tree_column_widths_auto_resize = not self.tree_column_widths_auto_resize
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
     def get_codes_and_categories(self):
         """ Called from init, delete category/code.

--- a/src/qualcoder/helpers.py
+++ b/src/qualcoder/helpers.py
@@ -125,6 +125,209 @@ def file_typer(mediapath):
     return "text"
 
 
+def init_persistent_tree_header(tree_widget, app, settings_key):
+    """Configure a tree header for interactive widths that persist in config.ini."""
+
+    header = tree_widget.header()
+    header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
+    header.setStretchLastSection(False)
+    tree_widget._qc_tree_widths_settings_key = settings_key
+    if getattr(tree_widget, "_qc_tree_widths_initialized", False):
+        return
+
+    tree_widget._qc_tree_widths_app = app
+    tree_widget._qc_restoring_tree_widths = False
+    tree_widget._qc_tree_widths_ready = False
+    tree_widget._qc_tree_widths_pending_restore = False
+    save_timer = QtCore.QTimer(tree_widget)
+    save_timer.setSingleShot(True)
+    save_timer.setInterval(300)
+    def _flush_config(*_args):
+        app.write_config_ini(app.settings, app.ai_models)
+
+    save_timer.timeout.connect(_flush_config)
+    tree_widget._qc_tree_widths_save_timer = save_timer
+
+    def _save_widths(_logical_index, _old_size, _new_size):
+        if getattr(tree_widget, "_qc_restoring_tree_widths", False):
+            return
+        if not getattr(tree_widget, "_qc_tree_widths_ready", False):
+            return
+        save_persistent_tree_widths(tree_widget)
+        tree_widget._qc_tree_widths_save_timer.start()
+
+    header.sectionResized.connect(_save_widths)
+    tree_widget.destroyed.connect(_flush_config)
+    event_filter = PersistentTreeWidthEventFilter(tree_widget)
+    tree_widget.installEventFilter(event_filter)
+    tree_widget._qc_tree_widths_event_filter = event_filter
+    tree_widget._qc_tree_widths_initialized = True
+
+
+def save_persistent_tree_widths(tree_widget):
+    """Save the current widths of all tree columns to app settings."""
+
+    app = getattr(tree_widget, "_qc_tree_widths_app", None)
+    settings_key = getattr(tree_widget, "_qc_tree_widths_settings_key", "")
+    if app is None or settings_key == "":
+        return
+    widths = []
+    header = tree_widget.header()
+    for index in range(tree_widget.columnCount()):
+        widths.append(str(header.sectionSize(index)))
+    app.settings[settings_key] = ",".join(widths)
+
+
+def _normalized_tree_minimum_widths(minimum_widths):
+    """Return minimum widths as a dict keyed by column index."""
+
+    if minimum_widths is None:
+        return {}
+    if isinstance(minimum_widths, dict):
+        return minimum_widths
+    return dict(enumerate(minimum_widths))
+
+
+def _tree_widths_look_uninitialized(tree_widget, widths, default_width_factors):
+    """Detect fallback Qt header widths saved before the widget had a real size."""
+
+    if default_width_factors is None or len(widths) != tree_widget.columnCount():
+        return False
+    normalized = []
+    for index, width in enumerate(widths):
+        if tree_widget.isColumnHidden(index):
+            normalized.append(0)
+        else:
+            normalized.append(width)
+    visible_default_count = sum(1 for width in normalized if width == 100)
+    return visible_default_count >= 2 and all(width in (0, 100) for width in normalized)
+
+
+class PersistentTreeWidthEventFilter(QtCore.QObject):
+    """Apply deferred tree widths once the widget has a real size."""
+
+    def eventFilter(self, watched, event):
+        if watched is None:
+            return False
+        if not getattr(watched, "_qc_tree_widths_pending_restore", False):
+            return False
+        if event.type() in (
+                QtCore.QEvent.Type.Show,
+                QtCore.QEvent.Type.Resize,
+                QtCore.QEvent.Type.LayoutRequest):
+            QtCore.QTimer.singleShot(0, lambda: _apply_pending_tree_widths(watched))
+        return False
+
+
+def _apply_pending_tree_widths(tree_widget):
+    """Apply deferred default widths if the tree is ready for sizing."""
+
+    if not getattr(tree_widget, "_qc_tree_widths_pending_restore", False):
+        return
+    _apply_default_tree_widths(
+        tree_widget,
+        minimum_widths=getattr(tree_widget, "_qc_pending_tree_minimum_widths", {}),
+        default_width_factors=getattr(tree_widget, "_qc_pending_tree_default_width_factors", None)
+    )
+
+
+def _apply_default_tree_widths(tree_widget, minimum_widths=None, default_width_factors=None):
+    """Apply initial column widths after the widget has a usable viewport size."""
+
+    if tree_widget.columnCount() == 0:
+        return
+
+    header = tree_widget.header()
+    available_width = tree_widget.viewport().width()
+    if not tree_widget.isVisible() or available_width < 250:
+        return
+
+    minimum_widths = _normalized_tree_minimum_widths(minimum_widths)
+    tree_widget._qc_restoring_tree_widths = True
+    try:
+        for index in range(tree_widget.columnCount()):
+            tree_widget.resizeColumnToContents(index)
+        if default_width_factors is not None:
+            visible_factors = {}
+            reserved_width = 0
+            for index in range(tree_widget.columnCount()):
+                if tree_widget.isColumnHidden(index):
+                    continue
+                if index not in default_width_factors:
+                    reserved_width += header.sectionSize(index)
+                    continue
+                factor = default_width_factors[index]
+                if factor is None:
+                    continue
+                visible_factors[index] = factor
+            total_factor = sum(visible_factors.values())
+            if total_factor > 0:
+                flexible_width = max(available_width - reserved_width, 100)
+                allocated_width = 0
+                factor_columns = list(visible_factors.items())
+                for position, (index, factor) in enumerate(factor_columns):
+                    if position == len(factor_columns) - 1:
+                        target_width = max(flexible_width - allocated_width, 1)
+                    else:
+                        target_width = max(1, int(round(flexible_width * (factor / total_factor))))
+                        allocated_width += target_width
+                    minimum_width = minimum_widths.get(index)
+                    if minimum_width is not None:
+                        target_width = max(target_width, minimum_width)
+                    header.resizeSection(index, target_width)
+        for index, width in minimum_widths.items():
+            if width is not None and index < tree_widget.columnCount() and not tree_widget.isColumnHidden(index):
+                header.resizeSection(index, max(header.sectionSize(index), width))
+        tree_widget._qc_tree_widths_ready = True
+        tree_widget._qc_tree_widths_pending_restore = False
+        save_persistent_tree_widths(tree_widget)
+    finally:
+        tree_widget._qc_restoring_tree_widths = False
+
+
+def restore_persistent_tree_widths(tree_widget, minimum_widths=None, default_width_factors=None):
+    """Restore saved tree column widths or size to contents on first use."""
+
+    app = getattr(tree_widget, "_qc_tree_widths_app", None)
+    settings_key = getattr(tree_widget, "_qc_tree_widths_settings_key", "")
+    if app is None or settings_key == "":
+        return
+
+    header = tree_widget.header()
+    header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
+    header.setStretchLastSection(False)
+
+    minimum_widths = _normalized_tree_minimum_widths(minimum_widths)
+    tree_widget._qc_restoring_tree_widths = True
+    try:
+        saved_widths = app.settings.get(settings_key, "")
+        widths = []
+        if saved_widths:
+            try:
+                widths = [int(value) for value in saved_widths.split(",") if value != ""]
+            except ValueError:
+                widths = []
+        if len(widths) == tree_widget.columnCount() and not _tree_widths_look_uninitialized(
+            tree_widget, widths, default_width_factors
+        ):
+            for index, width in enumerate(widths):
+                if width > 0:
+                    minimum_width = minimum_widths.get(index)
+                    if minimum_width is not None:
+                        width = max(width, minimum_width)
+                    header.resizeSection(index, width)
+            tree_widget._qc_tree_widths_ready = True
+            tree_widget._qc_tree_widths_pending_restore = False
+            return
+        tree_widget._qc_tree_widths_ready = False
+        tree_widget._qc_tree_widths_pending_restore = True
+        tree_widget._qc_pending_tree_minimum_widths = minimum_widths
+        tree_widget._qc_pending_tree_default_width_factors = default_width_factors
+        QtCore.QTimer.singleShot(0, lambda: _apply_pending_tree_widths(tree_widget))
+    finally:
+        tree_widget._qc_restoring_tree_widths = False
+
+
 class Message(QtWidgets.QMessageBox):
     """ This is called a lot , but is styled to font size """
 

--- a/src/qualcoder/report_code_summary.py
+++ b/src/qualcoder/report_code_summary.py
@@ -34,6 +34,7 @@ from PyQt6.QtCore import Qt
 from .code_in_all_files import DialogCodeInAllFiles
 from .color_selector import TextColor
 from .GUI.ui_dialog_report_code_summary import Ui_Dialog_code_summary
+from .helpers import init_persistent_tree_header, restore_persistent_tree_widths
 from .stopwords import *
 
 # If VLC not installed, it will not crash
@@ -76,10 +77,10 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
         self.ui.treeWidget.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogreport_code_summary_tree_widths')
         # Tree variables
         self.contains_long_names = False
         self.truncated_code_names = True
-        self.tree_column_widths_auto_resize = True
 
         languages = ["  ", "Deutsch de", "English en", "Español es", "Français fr", "Italiano it", "Português pt"]
         for lang in languages:
@@ -149,8 +150,6 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -264,6 +263,10 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
                 count += 1
         self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
         self.fill_code_counts_in_tree()
+        restore_persistent_tree_widths(
+            self.ui.treeWidget,
+            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
+        )
 
     def fill_code_counts_in_tree(self):
         """ Count instances of each code.
@@ -316,7 +319,6 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
         action_truncate_names = None
         if self.contains_long_names and self.truncated_code_names is False:
             action_truncate_names = menu.addAction(_("Truncate names"))
-        action_resize = menu.addAction(_("Toggle automatic column resize"))
         action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
         if action is None:
             return
@@ -340,12 +342,6 @@ class DialogReportCodeSummary(QtWidgets.QDialog):
         if action == action_truncate_names:
             self.truncated_code_names = True
             self.fill_tree()
-        if action == action_resize:
-            self.tree_column_widths_auto_resize = not self.tree_column_widths_auto_resize
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
     def recursive_get_branch_codes(self, item, branch_codes):
         """ Set all children of this item to be expanded or collapsed.

--- a/src/qualcoder/report_codes.py
+++ b/src/qualcoder/report_codes.py
@@ -44,7 +44,7 @@ from .color_selector import TextColor
 from .confirm_delete import DialogConfirmDelete
 from .GUI.ui_dialog_report_codings import Ui_Dialog_reportCodings
 from .helpers import Message, msecs_to_hours_mins_secs, DialogCodeInImage, DialogCodeInAV, DialogCodeInText, \
-    ExportDirectoryPathDialog
+    ExportDirectoryPathDialog, init_persistent_tree_header, restore_persistent_tree_widths
 from .memo import DialogMemo
 from .report_attributes import DialogSelectAttributeParameters
 from .ris import Ris
@@ -120,6 +120,7 @@ class DialogReportCodes(QtWidgets.QDialog):
         self.ui.listWidget_cases.installEventFilter(self)  # For H key
         self.ui.listWidget_cases.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.ui.treeWidget.setSelectionMode(QtWidgets.QTreeWidget.SelectionMode.ExtendedSelection)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogreportcodes_tree_widths')
         self.ui.comboBox_coders.insertItems(0, self.coders)
         self.fill_tree()
         # These signals after the tree is filled the first time
@@ -440,8 +441,6 @@ class DialogReportCodes(QtWidgets.QDialog):
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -547,6 +546,10 @@ class DialogReportCodes(QtWidgets.QDialog):
                 count += 1
         self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
         self.fill_code_counts_in_tree()
+        restore_persistent_tree_widths(
+            self.ui.treeWidget,
+            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
+        )
 
     def fill_code_counts_in_tree(self):
         """ Count instances of each code from all coders and all files. """

--- a/src/qualcoder/report_codes_by_segments.py
+++ b/src/qualcoder/report_codes_by_segments.py
@@ -33,7 +33,7 @@ from PyQt6.QtGui import QBrush
 from .code_in_all_files import DialogCodeInAllFiles
 from .color_selector import TextColor
 from .GUI.ui_report_codes_by_segments import Ui_DialogSegmentCodings
-from .helpers import Message
+from .helpers import Message, init_persistent_tree_header, restore_persistent_tree_widths
 from .report_attributes import DialogSelectAttributeParameters
 
 
@@ -90,10 +90,10 @@ class DialogCodesBySegments(QtWidgets.QDialog):
         self.ui.listWidget_cases.customContextMenuRequested.connect(self.listwidget_cases_menu)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogreportcodesbysegments_tree_widths')
         # Tree variables
         self.contains_long_names = False
         self.truncated_code_names = True
-        self.tree_column_widths_auto_resize = True
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -382,8 +382,6 @@ class DialogCodesBySegments(QtWidgets.QDialog):
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -496,6 +494,10 @@ class DialogCodesBySegments(QtWidgets.QDialog):
                 count += 1
         self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
         self.fill_code_counts_in_tree()
+        restore_persistent_tree_widths(
+            self.ui.treeWidget,
+            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
+        )
 
     def fill_code_counts_in_tree(self):
         """ Count instances of each code from all coders and all files. """
@@ -544,7 +546,6 @@ class DialogCodesBySegments(QtWidgets.QDialog):
         action_truncate_names = None
         if self.contains_long_names and not self.truncated_code_names:
             action_truncate_names = menu.addAction(_("Truncate names"))
-        action_resize = menu.addAction(_("Toggle automatic column resize"))
         action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
         if action is None:
             return
@@ -596,12 +597,6 @@ class DialogCodesBySegments(QtWidgets.QDialog):
         if action == action_truncate_names:
             self.truncated_code_names = True
             self.fill_tree()
-        if action == action_resize:
-            self.tree_column_widths_auto_resize = not self.tree_column_widths_auto_resize
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
     def recursive_get_branch_codes(self, item, branch_codes):
         """ Set all children of this item to be expanded or collapsed.

--- a/src/qualcoder/report_compare_coder_file.py
+++ b/src/qualcoder/report_compare_coder_file.py
@@ -32,7 +32,8 @@ from PyQt6.QtGui import QBrush
 from .color_selector import TextColor
 from .GUI.ui_dialog_code_context_image import Ui_Dialog_code_context_image
 from .GUI.ui_dialog_report_compare_coder_file import Ui_Dialog_reportCompareCoderFile
-from .helpers import Message, msecs_to_hours_mins_secs, ExportDirectoryPathDialog
+from .helpers import Message, msecs_to_hours_mins_secs, ExportDirectoryPathDialog, init_persistent_tree_header, \
+    restore_persistent_tree_widths
 from .information import DialogInformation
 from .report_attributes import DialogSelectAttributeParameters
 from .select_items import DialogSelectItems
@@ -94,6 +95,7 @@ class DialogCompareCoderByFile(QtWidgets.QDialog):
         self.ui.treeWidget.setStyleSheet(font)
         self.ui.listWidget_files.setStyleSheet(font)
         self.ui.treeWidget.setSelectionMode(QtWidgets.QTreeWidget.SelectionMode.SingleSelection)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogreportcomparecoderfile_tree_widths')
         self.ui.listWidget_files.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.listWidget_files.customContextMenuRequested.connect(self.file_menu)
         self.ui.comboBox_coders.insertItems(0, self.coders)
@@ -904,8 +906,6 @@ class DialogCompareCoderByFile(QtWidgets.QDialog):
         self.ui.treeWidget.hideColumn(1)
         if self.app.settings['showids']:
             self.ui.treeWidget.showColumn(1)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -977,6 +977,7 @@ class DialogCompareCoderByFile(QtWidgets.QDialog):
                 item = it.value()
         self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
         # self.ui.treeWidget.expandAll()
+        restore_persistent_tree_widths(self.ui.treeWidget)
 
 
 class DialogDualCodedImage(QtWidgets.QDialog):

--- a/src/qualcoder/report_exact_matches.py
+++ b/src/qualcoder/report_exact_matches.py
@@ -33,7 +33,7 @@ from PyQt6.QtGui import QBrush
 from .code_in_all_files import DialogCodeInAllFiles
 from .color_selector import TextColor
 from .GUI.ui_report_matching_segments import Ui_DialogMatchingTextSegments
-from .helpers import DialogCodeInText, Message
+from .helpers import DialogCodeInText, Message, init_persistent_tree_header, restore_persistent_tree_widths
 from .report_attributes import DialogSelectAttributeParameters
 
 path = os.path.abspath(os.path.dirname(__file__))
@@ -94,6 +94,7 @@ class DialogReportExactTextMatches(QtWidgets.QDialog):
         self.ui.treeWidget.setSelectionMode(QtWidgets.QTreeWidget.SelectionMode.ExtendedSelection)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogreportexactmatches_tree_widths')
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -644,8 +645,6 @@ class DialogReportExactTextMatches(QtWidgets.QDialog):
         header = [_("Code Tree"), _("Id")]
         self.ui.treeWidget.setColumnCount(len(header))
         self.ui.treeWidget.setHeaderLabels(header)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -719,6 +718,7 @@ class DialogReportExactTextMatches(QtWidgets.QDialog):
                 it += 1
                 item = it.value()
         # self.ui.treeWidget.expandAll()
+        restore_persistent_tree_widths(self.ui.treeWidget)
 
     def tree_menu(self, position):
         """ Context menu for treewidget code/category items.

--- a/src/qualcoder/report_relations.py
+++ b/src/qualcoder/report_relations.py
@@ -37,7 +37,8 @@ from PyQt6.QtGui import QBrush
 
 from .color_selector import TextColor
 from .GUI.ui_dialog_code_relations import Ui_Dialog_CodeRelations
-from .helpers import DialogCodeInText, ExportDirectoryPathDialog, Message
+from .helpers import DialogCodeInText, ExportDirectoryPathDialog, Message, init_persistent_tree_header, \
+    restore_persistent_tree_widths
 from .report_attributes import DialogSelectAttributeParameters
 from .select_items import DialogSelectItems
 
@@ -108,6 +109,7 @@ class DialogReportRelations(QtWidgets.QDialog):
         self.ui.treeWidget.setSelectionMode(QtWidgets.QTreeWidget.SelectionMode.ExtendedSelection)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogreportrelations_tree_widths')
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -1146,8 +1148,6 @@ class DialogReportRelations(QtWidgets.QDialog):
         header = [_("Code Tree"), _("Id")]
         self.ui.treeWidget.setColumnCount(len(header))
         self.ui.treeWidget.setHeaderLabels(header)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -1221,4 +1221,5 @@ class DialogReportRelations(QtWidgets.QDialog):
                     c['catid'] = -1  # make unmatchable
                 it += 1
                 item = it.value()
+        restore_persistent_tree_widths(self.ui.treeWidget)
         # self.ui.treeWidget.expandAll()

--- a/src/qualcoder/reports.py
+++ b/src/qualcoder/reports.py
@@ -36,7 +36,7 @@ from .code_in_all_files import DialogCodeInAllFiles
 from .color_selector import TextColor
 from .GUI.ui_dialog_report_comparisons import Ui_Dialog_reportComparisons
 from .GUI.ui_dialog_report_code_frequencies import Ui_Dialog_reportCodeFrequencies
-from .helpers import Message, ExportDirectoryPathDialog
+from .helpers import Message, ExportDirectoryPathDialog, init_persistent_tree_header, restore_persistent_tree_widths
 from .information import DialogInformation
 from .report_attributes import DialogSelectAttributeParameters
 from .select_items import DialogSelectItems
@@ -58,7 +58,6 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
         self.coded = []  # Used to refactor name
         self.truncated_code_names = True
         self.contains_long_names = False
-        self.tree_column_widths_auto_resize = True
         self.file_ids = []
         self.get_data()
         self.calculate_code_frequencies()
@@ -78,6 +77,7 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
         font = f'font: {self.app.settings["treefontsize"]}pt "{self.app.settings["font"]}";'
         self.ui.treeWidget.setStyleSheet(font)
         self.ui.treeWidget.setSelectionMode(QtWidgets.QTreeWidget.SelectionMode.ExtendedSelection)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogreportcodefrequencies_tree_widths')
         self.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
@@ -438,8 +438,6 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -533,6 +531,7 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
                 it += 1
                 item = it.value()
         self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
+        restore_persistent_tree_widths(self.ui.treeWidget)
 
     def tree_menu(self, position):
         menu = QtWidgets.QMenu()
@@ -552,8 +551,6 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
         if selected is not None and selected.text(1)[0:3] == 'cat':
             action_cat_show_coded_files = menu.addAction(_("Show coded files"))
             action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
-        action_resize = menu.addAction(_("Toggle automatic column resize"))
-
         action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
         if action is None:
             return
@@ -583,12 +580,6 @@ class DialogReportCodeFrequencies(QtWidgets.QDialog):
             expand_toggle = not selected.isExpanded()
             self.recursive_expand_collapse_branch(selected, expand_toggle)
             return
-        if action == action_resize:
-            self.tree_column_widths_auto_resize = not self.tree_column_widths_auto_resize
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
     def recursive_get_branch_codes(self, item, branch_codes):
         """ Set all children of this item to be expanded or collapsed.
@@ -632,7 +623,6 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
         self.categories = []
         self.truncated_code_names = True
         self.contains_long_names = False
-        self.tree_column_widths_auto_resize = True
         self.get_data()
         QtWidgets.QDialog.__init__(self)
         self.ui = Ui_Dialog_reportComparisons()
@@ -655,6 +645,7 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
         self.ui.treeWidget.setSelectionMode(QtWidgets.QTreeWidget.SelectionMode.ExtendedSelection)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogreportcodercomparisons_tree_widths')
         self.ui.comboBox_coders.insertItems(0, self.coders)
         self.ui.comboBox_coders.currentTextChanged.connect(self.coder_selected)
         if len(self.coders) == 3:  # includes empty slot
@@ -973,8 +964,6 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
         self.ui.treeWidget.hideColumn(1)
         if self.app.settings['showids']:
             self.ui.treeWidget.showColumn(1)
-        self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -1055,6 +1044,7 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
                 it += 1
                 item = it.value()
         self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
+        restore_persistent_tree_widths(self.ui.treeWidget)
 
     def tree_menu(self, position):
         menu = QtWidgets.QMenu()
@@ -1074,8 +1064,6 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
         if selected is not None and selected.text(1)[0:3] == 'cat':
             action_cat_show_coded_files = menu.addAction(_("Show coded files"))
             action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
-        action_resize = menu.addAction(_("Toggle automatic column resize"))
-
         action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
         if action is None:
             return
@@ -1101,12 +1089,6 @@ class DialogReportCoderComparisons(QtWidgets.QDialog):
         if action == action_expand_collapse:
             expand_toggle = not selected.isExpanded()
             self.recursive_expand_collapse_branch(selected, expand_toggle)
-        if action == action_resize:
-            self.tree_column_widths_auto_resize = not self.tree_column_widths_auto_resize
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
     def recursive_get_branch_codes(self, item, branch_codes):
         """ Set all children of this item to be expanded or collapsed.

--- a/src/qualcoder/view_av.py
+++ b/src/qualcoder/view_av.py
@@ -43,7 +43,8 @@ from .color_selector import DialogColorSelect, colors, TextColor, colour_ranges,
 from .confirm_delete import DialogConfirmDelete
 from .GUI.ui_dialog_code_av import Ui_Dialog_code_av
 from .GUI.ui_dialog_view_av import Ui_Dialog_view_av
-from .helpers import msecs_to_hours_mins_secs, Message, ToolTipEventFilter, CodeResizeHandle
+from .helpers import msecs_to_hours_mins_secs, Message, ToolTipEventFilter, CodeResizeHandle, \
+    init_persistent_tree_header, restore_persistent_tree_widths
 from .memo import DialogMemo
 from .report_attributes import DialogSelectAttributeParameters
 from .select_items import DialogSelectItems
@@ -221,11 +222,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
         self.ui.treeWidget.itemClicked.connect(self.tree_item_clicked)  # open memo, or assign text to code
-
-        # Codes-tree header menu
-        self.ui.treeWidget.header().setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
-        self.ui.treeWidget.header().customContextMenuRequested.connect(self.codes_tree_header_menu)
-        self.tree_column_widths_auto_resize = True
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodeav_tree_widths')
         self.get_files()
         self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
         self.fill_tree()
@@ -549,11 +546,6 @@ class DialogCodeAV(QtWidgets.QDialog):
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
-        self.ui.treeWidget.header().setStretchLastSection(False)
 
         # Add top level categories
         remove_list = []
@@ -667,6 +659,10 @@ class DialogCodeAV(QtWidgets.QDialog):
         if self.tree_sort_option == "all desc":
             self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
         self.fill_code_counts_in_tree()
+        restore_persistent_tree_widths(
+            self.ui.treeWidget,
+            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
+        )
 
     def fill_code_counts_in_tree(self):
         """ Calculate the frequency of each code and category for this coder and the selected file.
@@ -752,19 +748,6 @@ class DialogCodeAV(QtWidgets.QDialog):
         selected_text = self.ui.plainTextEdit.textCursor().selectedText()
         if len(selected_text) > 0:
             self.mark()
-
-    def codes_tree_header_menu(self, position):
-        """ treeWidget resize mode - resize to contents or interactive. """
-
-        menu = QtWidgets.QMenu(self)
-        action_resize = menu.addAction(_("Toggle automatic resize"))
-        action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
-        if action == action_resize:
-            self.tree_column_widths_auto_resize = not self.tree_column_widths_auto_resize
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
     def get_collapsed(self, item):
         """ On category collapse or expansion signal, find the collapsed parent category items.

--- a/src/qualcoder/view_image.py
+++ b/src/qualcoder/view_image.py
@@ -46,7 +46,7 @@ from .confirm_delete import DialogConfirmDelete
 from .GUI.ui_dialog_code_image import Ui_Dialog_code_image
 from .GUI.ui_dialog_view_image import Ui_Dialog_view_image
 from .move_resize_rectangle import DialogMoveResizeRectangle
-from .helpers import ExportDirectoryPathDialog, Message
+from .helpers import ExportDirectoryPathDialog, Message, init_persistent_tree_header, restore_persistent_tree_widths
 from .memo import DialogMemo
 from .report_attributes import DialogSelectAttributeParameters
 from .ris import Ris
@@ -138,11 +138,8 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.ui.listWidget.installEventFilter(self)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
-        # Codes-tree header menu
-        self.ui.treeWidget.header().setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
-        self.ui.treeWidget.header().customContextMenuRequested.connect(self.codes_tree_header_menu)
         self.ui.treeWidget.itemClicked.connect(self.tree_item_clicked)
-        self.tree_column_widths_auto_resize = True
+        init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodeimage_tree_widths')
         # Header widgets
         self.ui.pushButton_zoom_in.setIcon(qta.icon('mdi6.magnify-plus-outline', options=[{'scale_factor': 1.4}]))
         self.ui.pushButton_zoom_in.pressed.connect(self.zoom_in)
@@ -489,11 +486,6 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.ui.treeWidget.setColumnHidden(1, True)
         else:
             self.ui.treeWidget.setColumnHidden(1, False)
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
-        self.ui.treeWidget.header().setStretchLastSection(False)
         # Add top level categories
         remove_list = []
         for c in cats:
@@ -606,6 +598,10 @@ class DialogCodeImage(QtWidgets.QDialog):
         if self.tree_sort_option == "all desc":
             self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
         self.fill_code_counts_in_tree()
+        restore_persistent_tree_widths(
+            self.ui.treeWidget,
+            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
+        )
 
     def fill_code_counts_in_tree(self):
         """ Calculate the frequency of each code and category for all visible coders and the selected file.
@@ -680,19 +676,6 @@ class DialogCodeImage(QtWidgets.QDialog):
 
         if column == 2:
             self.add_edit_code_memo(item)
-
-    def codes_tree_header_menu(self, position):
-        """ treeWidget resize mode - resize to contents or interactive. """
-
-        menu = QtWidgets.QMenu(self)
-        action_resize = menu.addAction(_("Toggle automatic resize"))
-        action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
-        if action == action_resize:
-            self.tree_column_widths_auto_resize = not self.tree_column_widths_auto_resize
-        if self.tree_column_widths_auto_resize:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        else:
-            self.ui.treeWidget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
     def get_collapsed(self, item):
         """ On category collapse or expansion signal, find the collapsed parent category items.


### PR DESCRIPTION
Default width of the "Name" column is 70%. 
Allows resizing by the user. Sizes are stored in config.ini.

fixes https://github.com/ccbogel/QualCoder/issues/1322