### PR TITLE
fix: correct broken absolute imports to relative imports for GUI modules

### DIFF
--- a/src/qualcoder/edit_textfile.py
+++ b/src/qualcoder/edit_textfile.py
@@ -29,7 +29,7 @@ import qtawesome as qta  # see: https://pictogrammers.com/library/mdi/
 import re
 import unicodedata
 
-from GUI.ui_edit_text import Ui_Dialog_edit_text
+from .GUI.ui_edit_text import Ui_Dialog_edit_text
 from .helpers import MarkdownHighlighter
 
 path = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Hi 👋  

I hit a crash when launching QualCoder from source on Linux: it fails immediately with `ModuleNotFoundError: No module named 'GUI'`. After following the traceback, I noticed line 32 in `src/qualcoder/edit_textfile.py` is using an absolute import that Python can't resolve in the `src/` layout:

```python
# Before
from GUI.ui_edit_text import Ui_Dialog_edit_text
```

I've updated it to a proper relative import:

```python
# After
from .GUI.ui_edit_text import Ui_Dialog_edit_text
```

It’s a one-line, zero-behavior-change fix that should stop the startup crash. I’d be really grateful if you could give it a quick test on your end or run it through your usual dev workflow to make sure it doesn't introduce any regressions.

It should launch straight into the UI without throwing the import error.

Thanks so much for keeping QualCoder running, and for your time reviewing this! Let me know if you'd like any adjustments or if there's a preferred way to handle this. Happy to help!