### PR TITLE
Fix new text file dialog widget reference

### DIFF
--- a/src/qualcoder/manage_files.py
+++ b/src/qualcoder/manage_files.py
@@ -1630,7 +1630,6 @@ class DialogManageFiles(QtWidgets.QDialog):
         id_ = cur.fetchone()[0]
         item['id'] = id_
         ui = DialogEditTextFile(self.app, id_)
-        ui.ui.textEdit.setAcceptRichText(False)
         ui.exec()
         icon, metadata, err_ = self.get_icon_and_metadata(id_)
         item['icon'] = icon


### PR DESCRIPTION
This was left over from the switch to QPlainTextEdit. It generates an error when creating a new blank text file. 