### PR TITLE
Project_data_changed event bus: dispatch also attribute changes

### DIFF
--- a/src/qualcoder/__main__.py
+++ b/src/qualcoder/__main__.py
@@ -143,6 +143,13 @@ class ProjectEventBus(QtCore.QObject):
 
     project_data_changed = QtCore.pyqtSignal(list, object)
 
+    def __init__(self, parent=None):
+        """Queue project change notifications until the next event-loop turn."""
+
+        super().__init__(parent)
+        self._pending_table_changes = []
+        self._dispatch_scheduled = False
+
     def emit_table_changes(self, tables: list[str] | None, source=None):
         """Emit one project-change event for changed database tables.
 
@@ -157,7 +164,21 @@ class ProjectEventBus(QtCore.QObject):
             return
         if len(tables) == 0:
             return
-        self.project_data_changed.emit(tables, source)
+        self._pending_table_changes.append((list(tables), source))
+        if self._dispatch_scheduled:
+            return
+        self._dispatch_scheduled = True
+        QtCore.QTimer.singleShot(0, self._dispatch_pending_table_changes)
+
+    @QtCore.pyqtSlot()
+    def _dispatch_pending_table_changes(self):
+        """Emit pending project-change events after the current UI callback returns."""
+
+        self._dispatch_scheduled = False
+        pending = self._pending_table_changes
+        self._pending_table_changes = []
+        for tables, source in pending:
+            self.project_data_changed.emit(tables, source)
 
 
 class App(object):

--- a/src/qualcoder/ai_help_index.py
+++ b/src/qualcoder/ai_help_index.py
@@ -517,7 +517,10 @@ class AiHelpIndex:
             tokens = re.findall(r"[A-Za-z0-9][A-Za-z0-9._:/+-]*", query)
             if len(tokens) == 0:
                 continue
-            token_clause = " AND ".join(f'"{token.replace("\"", "\"\"")}"' for token in tokens[:10])
+            token_clause = " AND ".join(
+                '"' + token.replace('"', '""') + '"'
+                for token in tokens[:10]
+            )
             if token_clause != "":
                 clauses.append("(" + token_clause + ")")
         if len(clauses) == 0:

--- a/src/qualcoder/attributes.py
+++ b/src/qualcoder/attributes.py
@@ -85,6 +85,12 @@ class DialogManageAttributes(QtWidgets.QDialog):
         for row in result:
             self.attributes.append(dict(zip(keys, row)))
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def count_selected_items(self):
         """ Update label with the count of selected items. """
 
@@ -144,6 +150,7 @@ class DialogManageAttributes(QtWidgets.QDialog):
             sql = "insert into attribute (name, value, id, attr_type, date, owner) values (?,?,?,?,?,?)"
             cur.execute(sql, (item['name'], "", id_[0], case_or_file, now_date, self.app.settings['codername']))
         self.app.conn.commit()
+        self._emit_project_table_changes(["attribute_type", "attribute"])
         self.fill_table_widget()
         self.parent_textEdit.append(f"{_('Attribute added: ')}{item['name']} -> {_(case_or_file)}")
 
@@ -170,6 +177,7 @@ class DialogManageAttributes(QtWidgets.QDialog):
                     cur.execute("delete from attribute where name = ?", (name,))
                     cur.execute("delete from attribute_type where name = ?", (name,))
         self.app.conn.commit()
+        self._emit_project_table_changes(["attribute_type", "attribute"])
         self.attributes = []
         cur.execute("select name, date, owner, memo, caseOrFile, valuetype from attribute_type")
         result = cur.fetchall()
@@ -196,6 +204,7 @@ class DialogManageAttributes(QtWidgets.QDialog):
                 cur = self.app.conn.cursor()
                 cur.execute("update attribute_type set memo=? where name=?", (memo, self.attributes[x]['name']))
                 self.app.conn.commit()
+                self._emit_project_table_changes(["attribute_type"])
             if memo == "":
                 self.ui.tableWidget.setItem(x, self.MEMO_COLUMN, QtWidgets.QTableWidgetItem())
             else:
@@ -224,6 +233,7 @@ class DialogManageAttributes(QtWidgets.QDialog):
             print(attr_name)
             cur.execute('update attribute_type set valuetype="character" where name=?', [attr_name])
             self.app.conn.commit()
+            self._emit_project_table_changes(["attribute_type"])
             self.get_attributes()
             self.fill_table_widget()
 
@@ -247,6 +257,7 @@ class DialogManageAttributes(QtWidgets.QDialog):
                 cur.execute("update attribute_type set name=? where name=?", (new_name, self.attributes[x]['name']))
                 cur.execute("update attribute set name=? where name=?", (new_name, self.attributes[x]['name']))
                 self.app.conn.commit()
+                self._emit_project_table_changes(["attribute_type", "attribute"])
                 self.parent_textEdit.append(
                     _("Attribute renamed from: ") + self.attributes[x]['name'] + _(" to ") + new_name)
                 self.attributes[x]['name'] = new_name

--- a/src/qualcoder/cases.py
+++ b/src/qualcoder/cases.py
@@ -217,6 +217,12 @@ class DialogCases(QtWidgets.QDialog):
         self.selected_case = None
         self.ui.textBrowser.clear()
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def insert_nonexisting_attribute_placeholders(self):
         """ Check attribute placeholder is present in attribute table.
         An error in earlier qualcoder versions did not fill these placeholders.
@@ -420,6 +426,7 @@ class DialogCases(QtWidgets.QDialog):
             sql = "insert into attribute (name, value, id, attr_type, date, owner) values (?,?,?,?,?,?)"
             cur.execute(sql, (name, "", id_[0], 'case', now_date, self.app.settings['codername']))
         self.app.conn.commit()
+        self._emit_project_table_changes(["attribute_type", "attribute"])
         self.load_cases_data()
         self.fill_table()
         self.parent_text_edit.append(_("Attribute added to cases: ") + f"{name}, {_('type:')} {value_type}")
@@ -515,6 +522,7 @@ class DialogCases(QtWidgets.QDialog):
                         cur.execute(sql, (fields[col], v[col], n_i[1], 'case',
                                           now_date, self.app.settings['codername']))
         self.app.conn.commit()
+        self._emit_project_table_changes(["cases", "attribute_type", "attribute"])
         self.load_cases_data()
         self.fill_table()
         msg = _("Cases and attributes imported from: ") + filepath
@@ -591,6 +599,7 @@ class DialogCases(QtWidgets.QDialog):
                         cur.execute(sql, (fields[col], v[col], n_i[1], 'case',
                                           now_date, self.app.settings['codername']))
         self.app.conn.commit()
+        self._emit_project_table_changes(["cases", "attribute_type", "attribute"])
         self.load_cases_data()
         self.fill_table()
         msg = _("Cases and attributes imported from: ") + filepath
@@ -717,6 +726,7 @@ class DialogCases(QtWidgets.QDialog):
             cur.execute("update attribute set value=?, date=?, owner=? where id=? and name=? and attr_type='case'",
                         (value, now_date, self.app.settings['codername'], self.cases[x]['caseid'], attribute_name))
             self.app.conn.commit()
+            self._emit_project_table_changes(["attribute"])
 
         # Update self.cases[attributes]
         # Add list of attribute values to files, order matches header columns

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -377,6 +377,8 @@ class DialogCodePdf(QtWidgets.QWidget):
 
         if ids is None:
             ids = []
+        selection_model = self.ui.listWidget.selectionModel()
+        selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
         self.ui.listWidget.clear()
         self.files = self.app.get_pdf_filenames(ids)
         # Fill additional details about each file in the memo
@@ -436,6 +438,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.file_ = None
         self.code_text = []  # Must be empty, before clearing textEdit, as next calls cursorChanged
         self.ui.plainTextEdit.setPlainText("")
+        del selection_blocker
 
     def update_file_tooltip(self):
         """ Create tooltip for file containing characters, codings and from: to: if partially loaded.
@@ -465,37 +468,68 @@ class DialogCodePdf(QtWidgets.QWidget):
             return
         items[0].setToolTip(tt)
 
-    def get_files_from_attributes(self):
+    def get_files_from_attributes(self, refresh_only: bool = False):
         """ Select files based on attribute selections.
         Attribute results are a dictionary of:
         first item is a Boolean AND or OR list item
         Followed by each attribute list item
+
+        Args:
+            refresh_only: Recompute an already active attribute filter without reopening
+                the selection dialog.
         """
+
+        if refresh_only and len(self.attributes) <= 1:
+            return
 
         # Clear ui
         self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
         ui = DialogSelectAttributeParameters(self.app)
-        ui.fill_parameters(self.attributes)
+        previous_attributes = deepcopy(self.attributes)
+        ui.fill_parameters(deepcopy(self.attributes))
         temp_attributes = deepcopy(self.attributes)
-        self.attributes = []
-        ok = ui.exec()
-        if not ok:
-            self.attributes = temp_attributes
-            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
-            self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
-            if self.attributes:
-                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
-            return
+        if refresh_only:
+            ui.make_parameter_list()
+            ui.get_results_case_ids()
+            ui.get_results_file_ids()
+            ui.get_results_message()
+        else:
+            self.attributes = []
+            ok = ui.exec()
+            if not ok:
+                self.attributes = temp_attributes
+                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
+                self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+                if self.attributes:
+                    self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
+                return
         self.attributes = ui.parameters
         if len(self.attributes) == 1:  # Boolean parameter, no attributes
+            if refresh_only and len(previous_attributes) > 1:
+                self.clear_file_filter()
+                return
             self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
             self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
             self.get_files()
             return
         if not ui.result_file_ids:
-            Message(self.app, _("Nothing found") + " " * 20, _("No matching files found")).exec()
-            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
-            self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+            if not refresh_only:
+                Message(self.app, _("Nothing found") + " " * 20, _("No matching files found")).exec()
+                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
+                self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+                return
+            selection_model = self.ui.listWidget.selectionModel()
+            selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
+            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
+            self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
+            self.ui.listWidget.clear()
+            self.files = []
+            self.file_ = None
+            self.code_text = []
+            self.ui.plainTextEdit.setPlainText("")
+            self.ui.pushButton_clear_filter_file.setVisible(True)
+            self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
+            del selection_blocker
             return
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
         self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
@@ -2769,6 +2803,8 @@ class DialogCodePdf(QtWidgets.QWidget):
         if source is self or not isinstance(tables, list):
             return
         tables = set(tables)
+        if ("attribute" in tables or "attribute_type" in tables) and len(self.attributes) > 1:
+            self.get_files_from_attributes(refresh_only=True)
 
         code_tree_changed = "code_cat" in tables or "code_name" in tables
         refresh_current_text = "code_text" in tables or ("code_name" in tables and bool(self.code_text))
@@ -3287,6 +3323,8 @@ class DialogCodePdf(QtWidgets.QWidget):
         """ File selection changed. """
 
         row = self.ui.listWidget.currentRow()
+        if row < 0 or row >= len(self.files):
+            return
         self.load_file(self.files[row])
 
     def load_file(self, file_):

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -367,16 +367,19 @@ class DialogCodePdf(QtWidgets.QWidget):
             except ValueError:
                 pass
 
-    def get_files(self, ids=None, sort:str = "name asc"):
+    def get_files(self, ids=None, sort:str = "name asc", preserve_current_file: bool = False):
         """ Get pdf files with additional details and fill list widget.
          Called by: init, get_files_from_attributes, show_files_like
          args:
          ids: list, fill with ids to limit file selection.
          sort : String Sort options, name asc, name, desc, case asc, case desc
+         preserve_current_file: Reload the currently displayed file after rebuilding
+             the list when it is still present in the filtered result set.
          """
 
         if ids is None:
             ids = []
+        preserved_file = deepcopy(self.file_) if preserve_current_file and self.file_ is not None else None
         selection_model = self.ui.listWidget.selectionModel()
         selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
         self.ui.listWidget.clear()
@@ -435,9 +438,21 @@ class DialogCodePdf(QtWidgets.QWidget):
             item = QtWidgets.QListWidgetItem(file_['name'])
             item.setToolTip(file_['tooltip'])
             self.ui.listWidget.addItem(item)
-        self.file_ = None
-        self.code_text = []  # Must be empty, before clearing textEdit, as next calls cursorChanged
-        self.ui.plainTextEdit.setPlainText("")
+        restored = False
+        if preserved_file is not None:
+            for file_ in self.files:
+                if file_['id'] != preserved_file['id']:
+                    continue
+                for key in ("start", "end", "start_line"):
+                    if key in preserved_file:
+                        file_[key] = preserved_file[key]
+                self.load_file(file_)
+                restored = True
+                break
+        if not restored:
+            self.file_ = None
+            self.code_text = []  # Must be empty, before clearing textEdit, as next calls cursorChanged
+            self.ui.plainTextEdit.setPlainText("")
         del selection_blocker
 
     def update_file_tooltip(self):
@@ -510,7 +525,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                 return
             self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
             self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
-            self.get_files()
+            self.get_files(preserve_current_file=True)
             return
         if not ui.result_file_ids:
             if not refresh_only:
@@ -533,7 +548,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             return
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
         self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
-        self.get_files(ui.result_file_ids)
+        self.get_files(ui.result_file_ids, preserve_current_file=True)
         self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter file <- L
         self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
 

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -1495,16 +1495,19 @@ class DialogCodeText(QtWidgets.QWidget):
         if item.isExpanded() and item.text(1) in self.app.collapsed_categories:
             self.app.collapsed_categories.remove(item.text(1))
 
-    def get_files(self, ids=None, sort="name asc"):
+    def get_files(self, ids=None, sort="name asc", preserve_current_file: bool = False):
         """ Get files with additional details and fill list widget.
          Called by: init, get_files_from_attributes, show_files_like
          Args:
             ids : list, fill with ids to limit file selection.
             sort : String Sort options, name asc, name, desc, case asc, case desc
+            preserve_current_file: Reload the currently displayed file after rebuilding
+                the list when it is still present in the filtered result set.
          """
 
         if ids is None:
             ids = []
+        preserved_file = deepcopy(self.file_) if preserve_current_file and self.file_ is not None else None
         selection_model = self.ui.listWidget.selectionModel()
         selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
         self.ui.listWidget.clear()
@@ -1567,9 +1570,21 @@ class DialogCodeText(QtWidgets.QWidget):
             item = QtWidgets.QListWidgetItem(file_['name'])
             item.setToolTip(file_['tooltip'])
             self.ui.listWidget.addItem(item)
-        self.file_ = None
-        self.code_text = []  # Must be before clearing textEdit, as next calls cursorChanged
-        self.ui.plainTextEdit.setPlainText("")
+        restored = False
+        if preserved_file is not None:
+            for file_ in self.files:
+                if file_['id'] != preserved_file['id']:
+                    continue
+                for key in ("start", "end", "start_line"):
+                    if key in preserved_file:
+                        file_[key] = preserved_file[key]
+                self.load_file(file_)
+                restored = True
+                break
+        if not restored:
+            self.file_ = None
+            self.code_text = []  # Must be before clearing textEdit, as next calls cursorChanged
+            self.ui.plainTextEdit.setPlainText("")
         del selection_blocker
 
     def update_file_tooltip(self):
@@ -1643,7 +1658,7 @@ class DialogCodeText(QtWidgets.QWidget):
                 return
             self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable', options=[{'scale_factor': 1.3}]))
             self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
-            self.get_files()
+            self.get_files(preserve_current_file=True)
             return
         if not ui.result_file_ids:
             if not refresh_only:
@@ -1666,7 +1681,7 @@ class DialogCodeText(QtWidgets.QWidget):
             return
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box', options=[{'scale_factor': 1.3}]))
         self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
-        self.get_files(ui.result_file_ids)
+        self.get_files(ui.result_file_ids, preserve_current_file=True)
         self.ui.pushButton_clear_filter_file.setVisible(True)
         self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")  # blue
 

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -1505,6 +1505,8 @@ class DialogCodeText(QtWidgets.QWidget):
 
         if ids is None:
             ids = []
+        selection_model = self.ui.listWidget.selectionModel()
+        selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
         self.ui.listWidget.clear()
         self.files = self.app.get_text_filenames(ids)
         # Fill additional details about each file in the memo
@@ -1568,6 +1570,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.file_ = None
         self.code_text = []  # Must be before clearing textEdit, as next calls cursorChanged
         self.ui.plainTextEdit.setPlainText("")
+        del selection_blocker
 
     def update_file_tooltip(self):
         """ Create tooltip for file containing characters, codings and from: to: if partially loaded.
@@ -1597,38 +1600,69 @@ class DialogCodeText(QtWidgets.QWidget):
             return
         items[0].setToolTip(tt)
 
-    def get_files_from_attributes(self):
+    def get_files_from_attributes(self, refresh_only: bool = False):
         """ Select files based on attribute selections.
         Attribute results are a dictionary of:
         first item is a Boolean AND or OR list item
         Followed by each attribute list item
+
+        Args:
+            refresh_only: Recompute an already active attribute filter without reopening
+                the selection dialog.
         """
+
+        if refresh_only and len(self.attributes) <= 1:
+            return
 
         # Clear ui
         self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
         ui = DialogSelectAttributeParameters(self.app)
-        ui.fill_parameters(self.attributes)
+        previous_attributes = deepcopy(self.attributes)
+        ui.fill_parameters(deepcopy(self.attributes))
         temp_attributes = deepcopy(self.attributes)
-        self.attributes = []
-        ok = ui.exec()
-        if not ok:
-            self.attributes = temp_attributes
-            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable', options=[{'scale_factor': 1.3}]))
-            self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
-            if self.attributes:
-                self.ui.pushButton_file_attributes.setIcon(
-                    qta.icon('mdi6.variable-box', options=[{'scale_factor': 1.3}]))
-            return
+        if refresh_only:
+            ui.make_parameter_list()
+            ui.get_results_case_ids()
+            ui.get_results_file_ids()
+            ui.get_results_message()
+        else:
+            self.attributes = []
+            ok = ui.exec()
+            if not ok:
+                self.attributes = temp_attributes
+                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable', options=[{'scale_factor': 1.3}]))
+                self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+                if self.attributes:
+                    self.ui.pushButton_file_attributes.setIcon(
+                        qta.icon('mdi6.variable-box', options=[{'scale_factor': 1.3}]))
+                return
         self.attributes = ui.parameters
         if len(self.attributes) == 1:  # Boolean parameter, no attributes
+            if refresh_only and len(previous_attributes) > 1:
+                self.clear_file_filter()
+                return
             self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable', options=[{'scale_factor': 1.3}]))
             self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
             self.get_files()
             return
         if not ui.result_file_ids:
-            Message(self.app, _("Nothing found") + " " * 20, _("No matching files found")).exec()
-            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable', options=[{'scale_factor': 1.3}]))
-            self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+            if not refresh_only:
+                Message(self.app, _("Nothing found") + " " * 20, _("No matching files found")).exec()
+                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable', options=[{'scale_factor': 1.3}]))
+                self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+                return
+            selection_model = self.ui.listWidget.selectionModel()
+            selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
+            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box', options=[{'scale_factor': 1.3}]))
+            self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
+            self.ui.listWidget.clear()
+            self.files = []
+            self.file_ = None
+            self.code_text = []
+            self.ui.plainTextEdit.setPlainText("")
+            self.ui.pushButton_clear_filter_file.setVisible(True)
+            self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
+            del selection_blocker
             return
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box', options=[{'scale_factor': 1.3}]))
         self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
@@ -5044,6 +5078,8 @@ class DialogCodeText(QtWidgets.QWidget):
         if source is self or not isinstance(tables, list):
             return
         tables = set(tables)
+        if ("attribute" in tables or "attribute_type" in tables) and len(self.attributes) > 1:
+            self.get_files_from_attributes(refresh_only=True)
         if "code_cat" not in tables and "code_name" not in tables:
             if "code_text" not in tables:
                 return
@@ -5713,6 +5749,8 @@ class DialogCodeText(QtWidgets.QWidget):
         """ File selection changed. """
 
         row = self.ui.listWidget.currentRow()
+        if row < 0 or row >= len(self.files):
+            return
         if not self.ui.checkBox_search_all_files.isChecked():
             self.ui.lineEdit_search.setText("")
             self.ui.pushButton_next.setEnabled(False)

--- a/src/qualcoder/manage_files.py
+++ b/src/qualcoder/manage_files.py
@@ -171,6 +171,55 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.ui.tableWidget.horizontalHeader().customContextMenuRequested.connect(self.table_header_menu)
         self.ui.tableWidget.horizontalHeader().setToolTip(_("Right click header row to hide columns"))
         self.load_file_data()
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
+    def _current_source_id(self):
+        """Return the currently focused source id, if any."""
+
+        row = self.ui.tableWidget.currentRow()
+        if row < 0:
+            return None
+        item = self.ui.tableWidget.item(row, self.ID_COLUMN)
+        if item is None:
+            return None
+        try:
+            return int(item.text())
+        except (TypeError, ValueError):
+            return None
+
+    def _restore_current_source(self, source_id):
+        """Restore the current table selection for one source id when possible."""
+
+        if source_id is None:
+            return
+        for row, source_item in enumerate(self.source):
+            if int(source_item.get("id", -1)) == int(source_id):
+                self.ui.tableWidget.setCurrentCell(row, self.NAME_COLUMN)
+                return
+
+    def _reload_after_attribute_change(self):
+        """Reload file data after an external attribute update."""
+
+        current_source_id = self._current_source_id()
+        self.load_file_data()
+        self._restore_current_source(current_source_id)
+
+    def _on_project_data_changed(self, tables, source):
+        """Refresh the file table when attributes change elsewhere."""
+
+        if source is self or not isinstance(tables, list):
+            return
+        changed_tables = set(tables)
+        if not changed_tables.intersection({"attribute", "attribute_type"}):
+            return
+        self._reload_after_attribute_change()
 
     def help(self):
         """ Open help for transcribe section in browser. """
@@ -1409,6 +1458,7 @@ class DialogManageFiles(QtWidgets.QDialog):
             logger.debug(str(e_))
             self.app.conn.rollback()  # Revert all changes
             raise
+        self._emit_project_table_changes(["attribute_type", "attribute"])
         self.load_file_data()
         self.fill_table()
         self.parent_text_edit.append(f'{_("Attribute added to files:")} {name}, {_("type")}: {value_type}')
@@ -1482,6 +1532,7 @@ class DialogManageFiles(QtWidgets.QDialog):
             cur.execute("update attribute set value=? where id=? and name=? and attr_type='file'",
                         (value, self.source[x]['id'], attribute_name))
             self.app.conn.commit()
+            self._emit_project_table_changes(["attribute"])
 
             # Update self.source[attributes]
             # Add list of attribute values to files, order matches header columns
@@ -1845,6 +1896,14 @@ class DialogManageFiles(QtWidgets.QDialog):
             msg += f"\n{key} - {value}"
 
         self.app.conn.commit()
+        changed_tables = {"source"}
+        if attr_cols:
+            changed_tables.update({"attribute_type", "attribute"})
+        if case_cols:
+            changed_tables.update({"cases", "case_text"})
+        if autocode_enabled:
+            changed_tables.update({"code_name", "code_text"})
+        self._emit_project_table_changes(sorted(changed_tables))
         msg += f"\n{count} " + _("rows imported.")
         self.app.delete_backup = False
         self.update_files_in_dialogs()

--- a/src/qualcoder/report_attributes.py
+++ b/src/qualcoder/report_attributes.py
@@ -242,6 +242,7 @@ class DialogSelectAttributeParameters(QtWidgets.QDialog):
 
         if not attribute_list:
             return
+        self.ui.tableWidget.blockSignals(True)
         first_attr = attribute_list.pop(0)
         radio_bool = first_attr[0]
         if radio_bool == "BOOLEAN_OR":
@@ -260,6 +261,7 @@ class DialogSelectAttributeParameters(QtWidgets.QDialog):
                     val_text = val_text.replace("'", "")
                     self.ui.tableWidget.item(x, self.VALUE_LIST_COLUMN).setText(val_text)
                     self.ui.tableWidget.cellWidget(x, self.OPERATOR_COLUMN).setCurrentText(a[3])
+        self.ui.tableWidget.blockSignals(False)
 
     def make_parameter_list(self):
         """ Make a parameter list where operator and value are entered.

--- a/src/qualcoder/report_comparison_table.py
+++ b/src/qualcoder/report_comparison_table.py
@@ -79,24 +79,8 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         self.code_selection_mode = "all"
         self.selected_category_ids = []
         self.files = self.app.get_text_filenames()
-        # Get attributes
-        sql = "select name, valuetype, caseOrFile,0,0 from attribute_type where caseOrFile!='journal'"
-        cur = self.app.conn.cursor()
-        cur.execute(sql)
         self.attributes = []
-        keys = 'true_name', 'valuetype', 'caseOrFile', 'min', 'max'
-        for row in cur.fetchall():
-            self.attributes.append(dict(zip(keys, row)))
-        for attribute in self.attributes:
-            attribute['name'] = f"{attribute['true_name']} [{attribute['caseOrFile']}]"
-            if attribute['valuetype'] == 'numeric':
-                sql = "select cast(value as real) from attribute where name=? and attr_type=? and value is not null order by cast(value as real) asc"
-                cur.execute(sql, [attribute['true_name'], attribute['caseOrFile']])
-                res = cur.fetchall()
-                range = [r[0] for r in res]
-                if range:
-                    attribute['min'] = range[0]
-                    attribute['max'] = range[-1]
+        self._load_attributes()
 
         self.data = []
         self.max_count = 0
@@ -141,6 +125,28 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         fresh_code_map = {code["cid"]: code for code in fresh_codes}
         self.codes = [fresh_code_map[cid] for cid in previous_selected_ids if cid in fresh_code_map]
 
+    def _load_attributes(self):
+        """Load the cached attribute metadata used for selection."""
+
+        sql = "select name, valuetype, caseOrFile,0,0 from attribute_type where caseOrFile!='journal'"
+        cur = self.app.conn.cursor()
+        cur.execute(sql)
+        attributes = []
+        keys = 'true_name', 'valuetype', 'caseOrFile', 'min', 'max'
+        for row in cur.fetchall():
+            attributes.append(dict(zip(keys, row)))
+        for attribute in attributes:
+            attribute['name'] = f"{attribute['true_name']} [{attribute['caseOrFile']}]"
+            if attribute['valuetype'] == 'numeric':
+                sql = "select cast(value as real) from attribute where name=? and attr_type=? and value is not null order by cast(value as real) asc"
+                cur.execute(sql, [attribute['true_name'], attribute['caseOrFile']])
+                result = cur.fetchall()
+                value_range = [r[0] for r in result]
+                if value_range:
+                    attribute['min'] = value_range[0]
+                    attribute['max'] = value_range[-1]
+        self.attributes = attributes
+
     def _on_project_data_changed(self, tables, source):
         """Handle project change events from other dialogs.
 
@@ -152,6 +158,8 @@ class DialogReportComparisonTable(QtWidgets.QDialog):
         if source is self or not isinstance(tables, list):
             return
         tables = set(tables)
+        if "attribute" in tables or "attribute_type" in tables:
+            self._load_attributes()
         watched_tables = {"code_cat", "code_name", "code_text", "code_av", "code_image"}
         if watched_tables.isdisjoint(tables):
             return

--- a/src/qualcoder/view_av.py
+++ b/src/qualcoder/view_av.py
@@ -444,6 +444,8 @@ class DialogCodeAV(QtWidgets.QDialog):
         keys = 'name', 'id', 'memo', 'owner', 'date', 'mediapath', 'av_text_id'
         for row in result:
             self.files.append(dict(zip(keys, row)))
+        selection_model = self.ui.listWidget.selectionModel()
+        selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
         self.ui.listWidget.clear()
         sql_case = "SELECT group_concat(cases.name) from cases join case_text on case_text.caseid=cases.caseid " \
                    "where case_text.fid=?"
@@ -476,38 +478,68 @@ class DialogCodeAV(QtWidgets.QDialog):
             item.setToolTip(file_['tooltip'])
             self.ui.listWidget.addItem(item)
         self.clear_file()
+        del selection_blocker
 
-    def get_files_from_attributes(self):
+    def get_files_from_attributes(self, refresh_only: bool = False):
         """ Select files based on attribute selections.
         Attribute results are a dictionary of:
         first item is a Boolean AND or OR list item
         Followed by each attribute list item
+
+        Args:
+            refresh_only: Recompute an already active attribute filter without reopening
+                the selection dialog.
         """
+
+        if refresh_only and len(self.attributes) <= 1:
+            return
 
         # Clear ui
         self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
         ui = DialogSelectAttributeParameters(self.app)
-        ui.fill_parameters(self.attributes)
+        previous_attributes = deepcopy(self.attributes)
+        ui.fill_parameters(deepcopy(self.attributes))
         temp_attributes = deepcopy(self.attributes)
-        self.attributes = []
-        ok = ui.exec()
-        if not ok:
-            self.attributes = temp_attributes
-            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
-            self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
-            if self.attributes:
-                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
-            return
+        if refresh_only:
+            ui.make_parameter_list()
+            ui.get_results_case_ids()
+            ui.get_results_file_ids()
+            ui.get_results_message()
+        else:
+            self.attributes = []
+            ok = ui.exec()
+            if not ok:
+                self.attributes = temp_attributes
+                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
+                self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+                if self.attributes:
+                    self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
+                return
         self.attributes = ui.parameters
         if len(self.attributes) == 1:
+            if refresh_only and len(previous_attributes) > 1:
+                self.clear_file_filter()
+                return
             self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
             self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
             self.get_files()
             return
         if not ui.result_file_ids:
-            Message(self.app, _("Nothing found") + " " * 20, _("No matching files found")).exec()
-            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
-            self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+            if not refresh_only:
+                Message(self.app, _("Nothing found") + " " * 20, _("No matching files found")).exec()
+                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
+                self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+                return
+            selection_model = self.ui.listWidget.selectionModel()
+            selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
+            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
+            self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
+            self.ui.listWidget.clear()
+            self.files = []
+            self.clear_file()
+            self.ui.pushButton_clear_filter_file.setVisible(True)
+            self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
+            del selection_blocker
             return
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
         self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
@@ -1044,7 +1076,10 @@ class DialogCodeAV(QtWidgets.QDialog):
 
         if len(self.files) == 0:
             return
-        itemname = self.ui.listWidget.currentItem().text()
+        current_item = self.ui.listWidget.currentItem()
+        if current_item is None:
+            return
+        itemname = current_item.text()
         for f in self.files:
             if f['name'] == itemname:
                 self.file_ = f
@@ -2008,6 +2043,8 @@ class DialogCodeAV(QtWidgets.QDialog):
         if source is self or not isinstance(tables, list):
             return
         tables = set(tables)
+        if ("attribute" in tables or "attribute_type" in tables) and len(self.attributes) > 1:
+            self.get_files_from_attributes(refresh_only=True)
 
         code_tree_changed = "code_cat" in tables or "code_name" in tables
 

--- a/src/qualcoder/view_charts.py
+++ b/src/qualcoder/view_charts.py
@@ -95,12 +95,7 @@ class ViewCharts(QDialog):
         self.ui.comboBox_coders.addItems(coders)
 
         self.attributes = []
-        cur.execute("select name, ifnull(memo,''), caseOrFile, valuetype from attribute_type")
-        result = cur.fetchall()
-        self.attributes = []
-        keys = 'name', 'memo', 'caseOrFile', 'valuetype'
-        for row in result:
-            self.attributes.append(dict(zip(keys, row)))
+        self._load_attributes()
         self.fill_combobox_attributes()
         self.ui.radioButton_file.clicked.connect(self.fill_combobox_attributes)
         self.ui.radioButton_case.clicked.connect(self.fill_combobox_attributes)
@@ -199,6 +194,47 @@ class ViewCharts(QDialog):
         if index == -1:
             index = 0
         self.ui.comboBox_stopwords.setCurrentIndex(index)
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
+
+    def _load_attributes(self):
+        """Load the cached attribute definitions used by the chart controls."""
+
+        cur = self.app.conn.cursor()
+        cur.execute("select name, ifnull(memo,''), caseOrFile, valuetype from attribute_type")
+        result = cur.fetchall()
+        self.attributes = []
+        keys = 'name', 'memo', 'caseOrFile', 'valuetype'
+        for row in result:
+            self.attributes.append(dict(zip(keys, row)))
+
+    def _refresh_attribute_controls(self):
+        """Refresh cached attribute controls without re-rendering charts."""
+
+        selected_char = self.ui.comboBox_char_attributes.currentText()
+        selected_num = self.ui.comboBox_num_attributes.currentText()
+        self._load_attributes()
+        self.fill_combobox_attributes()
+        self.ui.comboBox_char_attributes.blockSignals(True)
+        self.ui.comboBox_num_attributes.blockSignals(True)
+        char_index = self.ui.comboBox_char_attributes.findText(selected_char)
+        if char_index >= 0:
+            self.ui.comboBox_char_attributes.setCurrentIndex(char_index)
+        num_index = self.ui.comboBox_num_attributes.findText(selected_num)
+        if num_index >= 0:
+            self.ui.comboBox_num_attributes.setCurrentIndex(num_index)
+        self.ui.comboBox_char_attributes.blockSignals(False)
+        self.ui.comboBox_num_attributes.blockSignals(False)
+
+    def _on_project_data_changed(self, tables, source):
+        """Refresh chart attribute options when attribute metadata changes elsewhere."""
+
+        if source is self or not isinstance(tables, list):
+            return
+        changed_tables = set(tables)
+        if not changed_tables.intersection({"attribute", "attribute_type"}):
+            return
+        self._refresh_attribute_controls()
 
     def fill_files_combobox(self, text=""):
         files_combobox_list = [""]
@@ -1750,6 +1786,11 @@ class ViewCharts(QDialog):
         self.ui.comboBox_num_attributes.addItems(list_num)
         self.ui.comboBox_num_attributes.blockSignals(False)
         self.ui.comboBox_char_attributes.blockSignals(False)
+
+        if self.ui.comboBox_char_attributes.currentIndex() == -1 and len(list_char) > 0:
+            self.ui.comboBox_char_attributes.setCurrentIndex(0)
+        if self.ui.comboBox_num_attributes.currentIndex() == -1 and len(list_num) > 0:
+            self.ui.comboBox_num_attributes.setCurrentIndex(0)
 
     def character_attribute_charts(self):
         """ Character attributes are displayed as counts via bar charts. """

--- a/src/qualcoder/view_image.py
+++ b/src/qualcoder/view_image.py
@@ -380,6 +380,8 @@ class DialogCodeImage(QtWidgets.QDialog):
         if len(bad_link_sql) > 0:
             bad_link_sql = f' and id not in ({bad_link_sql[1:]}) '
 
+        selection_model = self.ui.listWidget.selectionModel()
+        selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
         self.ui.listWidget.clear()
         cur = self.app.conn.cursor()
         sql = "select name, id, memo, owner, date, mediapath, risid from source where "  # Missing parentheses <- L
@@ -435,38 +437,68 @@ class DialogCodeImage(QtWidgets.QDialog):
             item.setToolTip(file_['tooltip'])
             self.ui.listWidget.addItem(item)
         self.clear_file()
+        del selection_blocker
 
-    def get_files_from_attributes(self):
+    def get_files_from_attributes(self, refresh_only: bool = False):
         """ Select files based on attribute selections.
         Attribute results are a dictionary of:
         first item is a Boolean AND or OR list item
         Followed by each attribute list item
+
+        Args:
+            refresh_only: Recompute an already active attribute filter without reopening
+                the selection dialog.
         """
+
+        if refresh_only and len(self.attributes) <= 1:
+            return
 
         # Clear ui
         self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
         ui = DialogSelectAttributeParameters(self.app)
-        ui.fill_parameters(self.attributes)
+        previous_attributes = deepcopy(self.attributes)
+        ui.fill_parameters(deepcopy(self.attributes))
         temp_attributes = deepcopy(self.attributes)
-        self.attributes = []
-        ok = ui.exec()
-        if not ok:
-            self.attributes = temp_attributes
-            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
-            self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
-            if self.attributes:
-                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
-            return
+        if refresh_only:
+            ui.make_parameter_list()
+            ui.get_results_case_ids()
+            ui.get_results_file_ids()
+            ui.get_results_message()
+        else:
+            self.attributes = []
+            ok = ui.exec()
+            if not ok:
+                self.attributes = temp_attributes
+                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
+                self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+                if self.attributes:
+                    self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
+                return
         self.attributes = ui.parameters
         if len(self.attributes) == 1:
-            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
+            if refresh_only and len(previous_attributes) > 1:
+                self.clear_file_filter()
+                return
+            self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
             self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
             self.get_files()
             return
         if not ui.result_file_ids:
-            Message(self.app, _("Nothing found") + " " * 20, _("No matching files found")).exec()
+            if not refresh_only:
+                Message(self.app, _("Nothing found") + " " * 20, _("No matching files found")).exec()
+                self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
+                self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+                return
+            selection_model = self.ui.listWidget.selectionModel()
+            selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
             self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
-            self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
+            self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
+            self.ui.listWidget.clear()
+            self.files = []
+            self.clear_file()
+            self.ui.pushButton_clear_filter_file.setVisible(True)
+            self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
+            del selection_blocker
             return
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
         self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
@@ -949,7 +981,10 @@ class DialogCodeImage(QtWidgets.QDialog):
 
         if len(self.files) == 0:
             return
-        item_name = self.ui.listWidget.currentItem().text()
+        current_item = self.ui.listWidget.currentItem()
+        if current_item is None:
+            return
+        item_name = current_item.text()
         for f in self.files:
             if f['name'] == item_name:
                 self.file_ = f
@@ -1121,6 +1156,8 @@ class DialogCodeImage(QtWidgets.QDialog):
         if source is self or not isinstance(tables, list):
             return
         tables = set(tables)
+        if ("attribute" in tables or "attribute_type" in tables) and len(self.attributes) > 1:
+            self.get_files_from_attributes(refresh_only=True)
 
         code_tree_changed = "code_cat" in tables or "code_name" in tables
         refresh_areas = "code_image" in tables or ("code_name" in tables and bool(self.code_areas))


### PR DESCRIPTION
Up until now, the new project_data_changed event bus was only updating dialogs if code, categories or coding tables changed. This PR extends this mechanism to attribute changes: Dialogs that allow changing attributes now emit a project_data_changed event, and dialogs that show attributes are now consuming the event and update the UI. 