### PR TITLE
Code tree controller (for review)

### DIFF
--- a/src/qualcoder/code_av.py
+++ b/src/qualcoder/code_av.py
@@ -17,8 +17,8 @@ If not, see <https://www.gnu.org/licenses/>.
 Author: Colin Curtain (ccbogel)
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
-https://qualcoder.org/
 https://qualcoder-org.github.io
+https://qualcoder.org/
 """
 
 import sqlite3
@@ -29,7 +29,6 @@ import logging
 import os
 import platform
 import qtawesome as qta  # see: https://pictogrammers.com/library/mdi/
-from random import randint
 import re
 import subprocess
 import time
@@ -38,13 +37,13 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QBrush, QColor
 
-from .add_item_name import DialogAddItemName
 from .code_in_all_files import DialogCodeInAllFiles
-from .color_selector import DialogColorSelect, colors, TextColor, colour_ranges, show_codes_of_colour_range
+from .code_tree import CodeTreeController
+from .color_selector import TextColor, colour_ranges, show_codes_of_colour_range
 from .confirm_delete import DialogConfirmDelete
 from .GUI.ui_dialog_code_av import Ui_Dialog_code_av
 from .helpers import msecs_to_hours_mins_secs, Message, ToolTipEventFilter, CodeResizeHandle, \
-    init_persistent_tree_header, restore_persistent_tree_widths, ExportDirectoryPathDialog
+    init_persistent_tree_header, ExportDirectoryPathDialog
 from .memo import DialogMemo
 from .report_attributes import DialogSelectAttributeParameters
 from .select_items import DialogSelectItems
@@ -226,12 +225,23 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.ui.treeWidget.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.InternalMove)
         self.ui.treeWidget.viewport().installEventFilter(self)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
+        # Shared code tree controller: tree loading, common context menu, drag and drop
+        # reparenting, F2-F6 shortcuts and category branch deletion live in code_tree.py,
+        # so the four coding pages no longer duplicate this logic by hand. <- L
+        self.code_tree = CodeTreeController(self.app, self.ui.treeWidget, self)
+        self.ui.treeWidget.customContextMenuRequested.connect(self.code_tree.tree_menu)
+        self.code_tree.fill_counts_callback = self.fill_code_counts_in_tree
+        self.code_tree.coded_files_callback = self.coded_media_dialog
+        self.code_tree.find_code_callback = self.find_code_in_tree
+        self.code_tree.show_codes_like_callback = self.show_codes_like
+        self.code_tree.show_codes_of_colour_callback = self.show_codes_of_color
+        self.code_tree.codes_changed.connect(self.update_dialog_codes_and_categories)
+
         self.ui.treeWidget.itemClicked.connect(self.tree_item_clicked)  # open memo, or assign text to code
         init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodeav_tree_widths')
         self.get_files()
         self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
-        self.fill_tree()
+        self.code_tree.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
         self.ui.treeWidget.itemExpanded.connect(self.get_collapsed)
@@ -579,169 +589,6 @@ class DialogCodeAV(QtWidgets.QDialog):
         # Set the scene to the top
         self.ui.graphicsView.verticalScrollBar().setValue(0)
 
-    def fill_tree(self):
-        """ Fill tree widget, top level items are main categories and unlinked codes. """
-
-        cats = deepcopy(self.categories)
-        codes = deepcopy(self.codes)
-        self.ui.treeWidget.clear()
-        self.ui.treeWidget.setColumnCount(4)
-        self.ui.treeWidget.setHeaderLabels([_("Name"), _("Id"), _("Memo"), _("Count")])
-        if not self.app.settings['showids']:
-            self.ui.treeWidget.setColumnHidden(1, True)
-        else:
-            self.ui.treeWidget.setColumnHidden(1, False)
-
-        # Add top level categories
-        remove_list = []
-        for c in cats:
-            if c['supercatid'] is None:
-                memo = ""
-                if c['memo'] != "":
-                    memo = "Memo"
-                top_item = QtWidgets.QTreeWidgetItem([c['name'], f"catid:{c['catid']}", memo])
-                top_item.setToolTip(0, '')
-                if len(c['name']) > 52:
-                    top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                    top_item.setToolTip(0, c['name'])
-                top_item.setToolTip(2, c['memo'])
-                self.ui.treeWidget.addTopLevelItem(top_item)
-                if f"catid:{c['catid']}" in self.app.collapsed_categories:
-                    top_item.setExpanded(False)
-                else:
-                    top_item.setExpanded(True)
-                remove_list.append(c)
-        for item in remove_list:
-            cats.remove(item)
-
-        ''' Add child categories. Look at each unmatched category, iterate through tree
-        to add as child, then remove matched categories from the list. '''
-        count = 0
-        while len(cats) > 0 and count < 10000:
-            remove_list = []
-            for c in cats:
-                it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-                item = it.value()
-                count2 = 0
-                while item and count2 < 10000:  # while there is an item in the list
-                    if item.text(1) == f"catid:{c['supercatid']}":
-                        memo = ""
-                        if c['memo'] != "":
-                            memo = "Memo"
-                        child = QtWidgets.QTreeWidgetItem([c['name'], f"catid:{c['catid']}", memo])
-                        child.setToolTip(0, '')
-                        if len(c['name']) > 52:
-                            child.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                            child.setToolTip(0, c['name'])
-                        child.setToolTip(2, c['memo'])
-                        item.addChild(child)
-                        if f"catid:{c['catid']}" in self.app.collapsed_categories:
-                            child.setExpanded(False)
-                        else:
-                            child.setExpanded(True)
-                        remove_list.append(c)
-                    it += 1
-                    item = it.value()
-                    count2 += 1
-            if not remove_list:
-                break  # cycle or dangling parent: leftovers placed at top level below
-            for item in remove_list:
-                cats.remove(item)
-            count += 1
-        # Fallback: never lose a category. Any with a missing/cyclic parent goes to top level. <- L
-        for c in cats:
-            memo = _("Memo") if c['memo'] != "" else ""
-            top_item = QtWidgets.QTreeWidgetItem([c['name'], 'catid:' + str(c['catid']), memo])
-            top_item.setToolTip(2, c['memo'])
-            top_item.setToolTip(0, '')
-            if len(c['name']) > 52:
-                top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                top_item.setToolTip(0, c['name'])
-            self.ui.treeWidget.addTopLevelItem(top_item)
-
-        # Add codes, with sub-code nesting. A code is top level only when it has neither a
-        # parent category (catid) nor a parent code (supercid). The rest are nested under
-        # their category (catid:) or under their parent code (cid:). <- L
-
-        def _make_code_item(code_dict):
-            """ Build a styled tree item for a code. Sub-codes share this styling. <- L """
-            memo_ = _("Memo") if code_dict['memo'] != "" else ""
-            code_item = QtWidgets.QTreeWidgetItem([code_dict['name'], f"cid:{code_dict['cid']}", memo_])
-            code_item.setToolTip(2, code_dict['memo'])
-            code_item.setToolTip(0, '')
-            if len(code_dict['name']) > 52:
-                code_item.setText(0, f"{code_dict['name'][:25]}..{code_dict['name'][-25:]}")
-                code_item.setToolTip(0, code_dict['name'])
-            code_item.setBackground(0, QBrush(QColor(code_dict['color']), Qt.BrushStyle.SolidPattern))
-            code_item.setForeground(0, QBrush(QColor(TextColor(code_dict['color']).recommendation)))
-            code_item.setFlags(
-                Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable |
-                Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsDragEnabled)
-            return code_item
-
-        # Index every node already in the tree (categories) by its id text for O(1) lookup. <- L
-        node_index = {}
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node_index[it.value().text(1)] = it.value()
-            it += 1
-        # Top level codes: no category and no parent code.
-        remove_items = []
-        for c in codes:
-            if c['catid'] is None and c.get('supercid') is None:
-                node = _make_code_item(c)
-                self.ui.treeWidget.addTopLevelItem(node)
-                node_index[f"cid:{c['cid']}"] = node
-                remove_items.append(c)
-        for c in remove_items:
-            codes.remove(c)
-        # Remaining codes: nest under category or parent code. Iterate because a parent code
-        # may itself be a not-yet-placed sub-code. Each pass places every code whose parent
-        # already exists; the loop ends when all are placed or no further progress is possible.
-        count = 0
-        while codes and count < 10000:
-            remove_items = []
-            for c in codes:
-                if c.get('supercid') is not None:
-                    parent_key = f"cid:{c['supercid']}"
-                else:
-                    parent_key = f"catid:{c['catid']}"
-                parent_node = node_index.get(parent_key)
-                if parent_node is not None:
-                    node = _make_code_item(c)
-                    parent_node.addChild(node)
-                    node_index[f"cid:{c['cid']}"] = node
-                    remove_items.append(c)
-            if not remove_items:
-                break  # remaining codes have a missing/cyclic parent: placed at top level below
-            for c in remove_items:
-                codes.remove(c)
-            count += 1
-        # Fallback: never lose a code. Any code with a dangling parent goes to top level. <- L
-        for c in codes:
-            node = _make_code_item(c)
-            self.ui.treeWidget.addTopLevelItem(node)
-            node_index[f"cid:{c['cid']}"] = node
-
-        if self.tree_sort_option == "all asc":
-            self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
-        if self.tree_sort_option == "all desc":
-            self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
-        # Show the code tree expanded from the start: sub-code branches are visible by default;
-        # categories the user had collapsed are restored to their collapsed state. <- L
-        self.ui.treeWidget.expandAll()
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node = it.value()
-            if node.text(1) in self.app.collapsed_categories:
-                node.setExpanded(False)
-            it += 1
-        self.fill_code_counts_in_tree()
-        restore_persistent_tree_widths(
-            self.ui.treeWidget,
-            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
-        )
-
     def fill_code_counts_in_tree(self):
         """ Calculate the frequency of each code and category for this coder and the selected file.
         Add a list item to each code that can be used to display in treeWidget.
@@ -861,7 +708,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         Assign selected text on left-click on code in tree. """
 
         if column == 2:
-            self.add_edit_code_memo(item)
+            self.code_tree.add_edit_cat_or_code_memo(item)
             return
         if item.text(1)[0:3] == 'cat':
             return
@@ -1618,171 +1465,6 @@ class DialogCodeAV(QtWidgets.QDialog):
             txt = _("Segment: ") + str(self.segment['start']) + " - " + self.segment['end']
             self.ui.label_segment.setText(txt)
 
-    def tree_menu(self, position):
-        """ Context menu for treeWidget items.
-        Add, rename, memo, move or delete code or category. Change code color. """
-
-        menu = QtWidgets.QMenu()
-        menu.setStyleSheet(f"QMenu {{font-size:{self.app.settings['fontsize']}pt}} ")
-        selected = self.ui.treeWidget.currentItem()
-        action_color = None
-        action_assign_segment = None
-        action_show_coded_media = None
-        action_move_code = None
-        if self.segment['end_msecs'] is not None and self.segment['start_msecs'] is not None:
-            action_assign_segment = menu.addAction("Assign segment to code")
-        action_add_code_to_category = None
-        action_add_category_to_category = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_add_code_to_category = menu.addAction(_("Add new code to category"))
-            action_add_category_to_category = menu.addAction(_("Add a new category to category"))
-        action_add_code = menu.addAction(_("Add a new code"))
-        action_add_category = menu.addAction(_("Add a new category"))
-        action_add_subcode = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_add_subcode = menu.addAction(_("Add a new sub-code to code"))  # <- L
-        action_expand_collapse = None
-        action_cat_show_coded_files = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
-            action_cat_show_coded_files = menu.addAction(_("Show coded files"))
-        if selected is not None and selected.text(1)[0:3] == 'cid' and selected.childCount() > 0:
-            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))  # <- L
-        modify_menu = menu.addMenu(_("Modify"))
-        action_rename = modify_menu.addAction(_("Rename F2"))
-        action_edit_memo = modify_menu.addAction(_("View or edit memo"))
-        action_merge_category = None
-        action_move_category = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_merge_category = modify_menu.addAction(_("Merge category into category"))
-            action_move_category = modify_menu.addAction(_("Move category under category"))
-        action_delete = modify_menu.addAction(_("Delete"))
-        action_move_multi_codes = None
-        action_merge_code_into_code = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_color = modify_menu.addAction(_("Change code color"))
-            action_move_code = modify_menu.addAction(_("Move code to"))
-            action_move_multi_codes = modify_menu.addAction(_("Move multiple codes"))
-            action_merge_code_into_code = modify_menu.addAction(_("Merge code into code"))  # <- L
-            action_show_coded_media = menu.addAction(_("Show coded files"))
-        action_find_code = menu.addAction(_("Find code"))
-        filter_menu = menu.addMenu(_("Filter"))
-        action_show_codes_like = filter_menu.addAction(_("Show codes like") + ": " + self.show_codes_like_filter)
-        action_show_codes_of_colour = filter_menu.addAction(_("Show codes of colour") + ": " + self.show_codes_colour_filter)
-        sort_menu = menu.addMenu(_("Sort"))
-        action_all_asc = sort_menu.addAction(_("Sort ascending"))
-        action_all_desc = sort_menu.addAction(_("Sort descending"))
-        action_cat_then_code_asc = sort_menu.addAction(_("Sort category then code ascending"))
-        action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
-        if action is None:
-            return
-        if action == action_show_codes_of_colour:
-            self.show_codes_of_color()
-            return
-        if action == action_all_asc:
-            self.tree_sort_option = "all asc"
-            self.fill_tree()
-            return
-        if action == action_all_desc:
-            self.tree_sort_option = "all desc"
-            self.fill_tree()
-            return
-        if action == action_cat_then_code_asc:
-            self.tree_sort_option = "cat and code asc"
-            self.fill_tree()
-            return
-        if action == action_show_codes_like:
-            self.show_codes_like()
-            return
-        if action == action_find_code:
-            self.find_code_in_tree()
-            return
-        if selected is not None and selected.text(1)[0:3] == 'cid' and action == action_color:
-            self.change_code_color(selected)
-            return
-        if selected is not None and action == action_move_code:
-            self.move_code(selected)
-            return
-        if action == action_move_multi_codes:
-            self.move_multiple_codes()
-            return
-        if action == action_merge_code_into_code and selected is not None:
-            self.merge_code_into_code(selected)  # <- L
-            return
-        if action == action_add_category_to_category:
-            catid = int(selected.text(1).split(":")[1])
-            self.add_category(catid)
-            return
-        if action == action_add_category:
-            self.add_category()
-            return
-        if action == action_add_code:
-            self.add_code()
-            return
-        if action == action_move_category:
-            catid = int(selected.text(1).split(":")[1])
-            self.move_category(catid)
-            return
-        if action == action_merge_category:
-            catid = int(selected.text(1).split(":")[1])
-            self.merge_category(catid)
-            return
-        if action == action_add_code_to_category:
-            catid = int(selected.text(1).split(":")[1])
-            self.add_code(catid)
-            return
-        if action == action_add_subcode and selected is not None:
-            supercid = int(selected.text(1).split(":")[1])  # <- L
-            self.add_code(supercid=supercid)
-            return
-        if action == action_expand_collapse:
-            expand_toggle = not selected.isExpanded()
-            self.recursive_expand_collapse_branch(selected, expand_toggle)
-            return
-        if selected is not None and action == action_rename:
-            self.rename_category_or_code(selected)
-        if selected is not None and action == action_edit_memo:
-            self.add_edit_code_memo(selected)
-        if selected is not None and action == action_delete:
-            self.delete_category_or_code(selected)
-        if action == action_assign_segment:
-            self.assign_segment_to_code(selected)
-        if action == action_cat_show_coded_files:
-            branch_codes = self.recursive_get_branch_codes(selected, [])
-            self.coded_media_dialog(branch_codes, selected.text(0))
-            return
-        if selected is not None and action == action_show_coded_media:
-            to_find = int(selected.text(1)[4:])
-            found = next((code for code in self.codes if code['cid'] == to_find), None)
-            if found:
-                self.coded_media_dialog(found)
-
-    def recursive_get_branch_codes(self, item, branch_codes):
-        """ Set all children of this item to be expanded or collapsed.
-        Recurse through all child categories. """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            if item.child(i).text(1)[0:3] == "cid":
-                cid = int(item.child(i).text(1)[4:])
-                for code_ in self.codes:
-                    if cid == code_['cid']:
-                        branch_codes.append(code_)
-                        break
-                self.recursive_get_branch_codes(item.child(i), branch_codes)  # also gather sub-codes nested under this code (supercid) <- L
-            if item.child(i).text(1)[0:3] == "cat":
-                self.recursive_get_branch_codes(item.child(i), branch_codes)
-        return branch_codes
-
-    def recursive_expand_collapse_branch(self, item, expand_toggle):
-        """ Set all children of this item to be expanded or collapsed.
-        Recurse through all child categories. """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            item.setExpanded(expand_toggle)
-            self.recursive_expand_collapse_branch(item.child(i), expand_toggle)
-
     def coded_media_dialog(self, code_dict, category_name:str = ""):
         """ Display all coded media for this code, in a separate modal dialog.
         Coded media comes from ALL files for this coder.
@@ -1796,146 +1478,6 @@ class DialogCodeAV(QtWidgets.QDialog):
 
         DialogCodeInAllFiles(self.app, code_dict, "File", category_name)
         self.update_dialog_codes_and_categories(["code_name", "code_cat", "code_text", "code_av", "code_image"])
-
-    def move_multiple_codes(self):
-        """ Move multiple codes to another category. """
-
-        cur = self.app.conn.cursor()
-        cur.execute("select code_name.name, code_cat.name, cid from code_name left join code_cat on "
-                    "code_cat.catid=code_name.catid order by upper(code_cat.name) asc, upper(code_name.name) asc")
-        res = cur.fetchall()
-        code_list = []
-        for r in res:
-            name = r[0]
-            if r[1] is not None:
-                name = r[1] + " ← " + r[0]
-            code_list.append({'name': name, 'cid': r[2]})
-        ui = DialogSelectItems(self.app, code_list, _("Select codes"), "multi")
-        ok = ui.exec()
-        if not ok:
-            return
-        selected_codes = ui.get_selected()
-        cur.execute("select name, catid from code_cat order by upper(name)")
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        for s in selected_codes:
-            # Moving to a category (or to blank) removes any sub-code nesting. <- L
-            cur.execute("update code_name set catid=?, supercid=null where cid=?", [category['catid'], s['cid']])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Code moved.") + s['name'].replace(" ← ", "/") + " → " + category['name'])
-        self.update_dialog_codes_and_categories(["code_name"])
-
-    def move_code(self, selected):
-        """ Move code to another category or to no category.
-        Uses a list selection.
-        param:
-            selected : QTreeWidgetItem
-         """
-
-        items_list = [{'name': " ", 'catid': -1, 'cid': -1}]  # Default blank item
-        iterator = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while iterator.value():
-            can_append = True
-            item = iterator.value()
-            depth = 0
-            current = item
-            # Get depth and if circular reference present
-            while current.parent() is not None:
-                if current.text(1) == selected.text(1):
-                    can_append = False
-                current = current.parent()
-                depth += 1
-            prefix = ""
-            if depth > 0:
-                prefix = "  " * (depth - 1) * 2 + "└─"  # U2514 U2500
-            name = prefix + item.text(0)
-            cid = -1
-            catid = -1
-            if "cid" in item.text(1):
-                cid = int(item.text(1)[4:])
-            else:
-                catid = int(item.text(1)[6:])
-                name += " " + _("[CATEGORY]")
-            # Check the same item is not the same selected item
-            if item.text(1) == selected.text(1) and item.text(2) == selected.text(2):
-                can_append = False
-            memo = item.toolTip(2)
-            if can_append:
-                items_list.append({'name': name, 'catid': catid, 'cid': cid, 'memo': memo})
-            iterator += 1
-        ui = DialogSelectItems(self.app, items_list, _("Select blank or category or code"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        destination = ui.get_selected()
-        # print(destination)
-        selected_cid = int(selected.text(1)[4:])
-        cur = self.app.conn.cursor()
-        if destination['catid'] == -1 and destination['cid'] == -1:  # move to top level
-            cur.execute("update code_name set catid=null, supercid=null where cid=?", [selected_cid])
-        elif destination['cid'] > 0:  # Move under another code
-            cur.execute("update code_name set catid=null, supercid=? where cid=?", [destination['cid'], selected_cid])
-        else:  # Move under a category
-            cur.execute("update code_name set catid=?, supercid=null where cid=?", [destination['catid'], selected_cid])
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_name"])
-
-        '''cid = int(selected.text(1)[4:])
-        cur = self.app.conn.cursor()
-        cur.execute("select name, catid from code_cat order by name")
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        # Moving to a category (or to blank) removes any sub-code nesting. <- L
-        cur.execute("update code_name set catid=?, supercid=null where cid=?", [category['catid'], cid])
-        self.update_dialog_codes_and_categories(["code_name"])'''
-
-    def move_category(self, catid: int):
-        """ Select another category to move this category underneath.
-        Args:
-            catid : Integer category identifier
-        """
-
-        do_not_merge_list = []
-        do_not_merge_list = self.recursive_non_merge_item(self.ui.treeWidget.currentItem(), do_not_merge_list)
-        do_not_merge_list.append(str(catid))
-        do_not_merge_ids_string = f"({','.join(do_not_merge_list)})"
-        sql = "select name, catid, supercatid from code_cat where catid not in "
-        sql += do_not_merge_ids_string + " order by name"
-        cur = self.app.conn.cursor()
-        cur.execute(sql)
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        current_cat_name = self.ui.treeWidget.currentItem().text(0)
-        if category['name'] == '':
-            cur.execute("update code_cat set supercatid=Null where catid=?", [catid])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → Top level")
-        else:
-            cur.execute("update code_cat set supercatid=? where catid=?", [category['catid'], catid])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → " + category['name'])
-        self.update_dialog_codes_and_categories()
 
     def show_codes_like(self, preset=None):
         """ Show all codes if text is empty.
@@ -2077,7 +1619,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         """
 
         self.get_codes_and_categories()
-        self.fill_tree()
+        self.code_tree.fill_tree()
         self.load_segments()
         self.unlight()
         self.highlight()
@@ -2108,7 +1650,7 @@ class DialogCodeAV(QtWidgets.QDialog):
 
         if code_tree_changed:
             self.get_codes_and_categories()
-            self.fill_tree()
+            self.code_tree.fill_tree()
         elif not refresh_counts and not refresh_segments and not refresh_transcript:
             return
 
@@ -2181,7 +1723,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             selected = self.ui.treeWidget.currentItem()
             if selected is not None and selected.text(1)[0:3] == 'cat':
                 supercatid = int(selected.text(1)[6:])
-            self.add_category(supercatid)
+            self.code_tree.add_category(supercatid)
             return
         # Glue segment to currently selected code and open segment memo
         if key == QtCore.Qt.Key.Key_G and self.segment['start_msecs'] is not None and \
@@ -2214,11 +1756,10 @@ class DialogCodeAV(QtWidgets.QDialog):
         if key == QtCore.Qt.Key.Key_Minus and mods == QtCore.Qt.KeyboardModifier.AltModifier:
             self.rewind_30_seconds()
             return
-        # Rename code or category
-        if self.ui.treeWidget.hasFocus() and key == QtCore.Qt.Key.Key_F2:
-            selected = self.ui.treeWidget.currentItem()
-            self.rename_category_or_code(selected)
-            return
+        # Tree widget menu item keys F2 - F6, handled by the shared controller. <- L
+        if self.ui.treeWidget.hasFocus():
+            if self.code_tree.handle_key_press(event):
+                return
         # Ctrl 0 to 9
         if mods & QtCore.Qt.KeyboardModifier.ControlModifier:
             #  Ctrl + P pause/play toggle
@@ -2414,7 +1955,7 @@ class DialogCodeAV(QtWidgets.QDialog):
                 item = self.ui.treeWidget.currentItem()
                 # event position is QPointF, itemAt requires toPoint
                 parent = self.ui.treeWidget.itemAt(event.position().toPoint())
-                self.item_moved_update_data(item, parent)
+                self.code_tree.item_moved_update_data(item, parent)
                 return True
             # Scroll the tree when dragged item it as top or bottom edges
             if event.type() == QtCore.QEvent.Type.DragMove:
@@ -2717,629 +2258,19 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.ui.label_segment.setText(_("Segment:"))
         self.ui.pushButton_coding.setText(_("Start segment"))
 
-    def _category_is_descendant(self, candidate_catid, ancestor_catid):
-        """ Return True if candidate_catid is ancestor_catid or one of its descendant
-        sub-categories. Used to prevent cycles when moving a category under another. <- L """
-        if candidate_catid == ancestor_catid:
-            return True
-        children = {}
-        for c in self.categories:
-            sup = c.get('supercatid')
-            if sup is not None:
-                children.setdefault(sup, []).append(c['catid'])
-        stack = list(children.get(ancestor_catid, []))
-        seen = set()
-        while stack:
-            catid = stack.pop()
-            if catid == candidate_catid:
-                return True
-            if catid in seen:
-                continue
-            seen.add(catid)
-            stack.extend(children.get(catid, []))
-        return False
-
-    def item_moved_update_data(self, item, parent):
-        """ Called from drop event in treeWidget view port.
-        identify code or category to move.
-        Also merge codes if one code is dropped on another code.
-        param:
-            item: QTreeWidgetItem
-            parent: QTreeWidgetItem """
-
-        # Find the category in the list
-        if item.text(1)[0:3] == 'cat':
-            found = -1  # use -1 sentinel, not None <- L
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(item.text(1)[6:]):
-                    found = i
-            if found == -1:  # check against sentinel, not falsy
-                return
-            if parent is None:
-                self.categories[found]['supercatid'] = None
-            else:
-                if parent.text(1).split(':')[0] == 'cid':
-                    # parent is code (leaf) cannot add child
-                    return
-                supercatid = int(parent.text(1).split(':')[1])
-                if supercatid == self.categories[found]['catid']:
-                    # Cannot be its own parent.
-                    return
-                # Guard against cycles: moving a category under one of its own sub-categories
-                # would make the branch disappear and corrupt the tree. <- L
-                if self._category_is_descendant(supercatid, self.categories[found]['catid']):
-                    Message(self.app, _("Cannot move category"),
-                            _("Cannot move a category under one of its own sub-categories.")).exec()
-                    return
-                self.categories[found]['supercatid'] = supercatid
-            cur = self.app.conn.cursor()
-            cur.execute("update code_cat set supercatid=? where catid=?",
-                        [self.categories[found]['supercatid'], self.categories[found]['catid']])
-            self.app.conn.commit()
-            self.update_dialog_codes_and_categories(["code_cat"])
-            return
-
-        # Find the code in the list
-        if item.text(1)[0:3] == 'cid':
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(item.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            if parent is None:
-                # Move code to top level: clear both parents. <- L
-                self.codes[found]['catid'] = None
-                self.codes[found]['supercid'] = None
-            else:
-                if parent.text(1).split(':')[0] == 'cid':
-                    parent_cid = int(parent.text(1).split(':')[1])
-                    # Ctrl held while dropping a code on a code merges (previous behaviour);
-                    # otherwise the code is nested as a sub-code. <- L
-                    ctrl = bool(QtWidgets.QApplication.keyboardModifiers() &
-                                QtCore.Qt.KeyboardModifier.ControlModifier)
-                    if ctrl:
-                        self.merge_codes(self.codes[found], parent)
-                        return
-                    if parent_cid == self.codes[found]['cid']:
-                        return  # cannot nest under itself
-                    if self._code_is_descendant(parent_cid, self.codes[found]['cid']):
-                        Message(self.app, _("Cannot nest code"),
-                                _("Cannot move a code under one of its own sub-codes.")).exec()
-                        return
-                    # Nest as a sub-code (mutually exclusive with category). <- L
-                    self.codes[found]['supercid'] = parent_cid
-                    self.codes[found]['catid'] = None
-                else:
-                    # Dropped onto a category. <- L
-                    catid = int(parent.text(1).split(':')[1])
-                    self.codes[found]['catid'] = catid
-                    self.codes[found]['supercid'] = None
-            cur = self.app.conn.cursor()
-            cur.execute("update code_name set catid=?, supercid=? where cid=?",
-                        [self.codes[found]['catid'], self.codes[found].get('supercid'),
-                         self.codes[found]['cid']])
-            self.app.conn.commit()
-            self.update_dialog_codes_and_categories(["code_name"])
-            self.app.delete_backup = False
-
-    def _code_is_descendant(self, candidate_cid, ancestor_cid):
-        """ Return True if candidate_cid is ancestor_cid or one of its descendant sub-codes.
-        Used to prevent cycles when nesting a code under another code. <- L """
-        if candidate_cid == ancestor_cid:
-            return True
-        children = {}
-        for c in self.codes:
-            sup = c.get('supercid')
-            if sup is not None:
-                children.setdefault(sup, []).append(c['cid'])
-        stack = list(children.get(ancestor_cid, []))
-        seen = set()
-        while stack:
-            cid = stack.pop()
-            if cid == candidate_cid:
-                return True
-            if cid in seen:
-                continue
-            seen.add(cid)
-            stack.extend(children.get(cid, []))
-        return False
-
-    def recursive_non_merge_item(self, item, no_merge_list):
-        """ Find matching item to be the current selected item.
-        Recurse through any child categories.
-        Tried to use QTreeWidget.finditems - but this did not find matching item text
-        Called by: textEdit recent codes menu option
-        Required for: merge_category()
-        param:
-            item: QTreeWidgetItem
-            no_merge_list: list of ?
-        """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            if item.child(i).text(1)[0:3] == "cat":
-                no_merge_list.append(item.child(i).text(1)[6:])
-            self.recursive_non_merge_item(item.child(i), no_merge_list)
-        return no_merge_list
-
-    def merge_category(self, catid):
-        """ Select another category to merge this category into.
-        param:
-            catid: Integer  category identifier """
-
-        do_not_merge_list = []
-        do_not_merge_list = self.recursive_non_merge_item(self.ui.treeWidget.currentItem(), do_not_merge_list)
-        do_not_merge_list.append(str(catid))
-        do_not_merge_ids_str = "(" + ",".join(do_not_merge_list) + ")"
-        sql = "select name, catid, supercatid from code_cat where catid not in "
-        sql += do_not_merge_ids_str + " order by name"
-        cur = self.app.conn.cursor()
-        cur.execute(sql)
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        try:
-            # Always record merge info in target category memo  # <- L
-            source_cat = None
-            for c in self.categories:
-                if c['catid'] == catid:
-                    source_cat = c
-                    break
-            if source_cat is not None and category['catid'] is not None:
-                target_cat = None
-                for c in self.categories:
-                    if c['catid'] == category['catid']:
-                        target_cat = c
-                        break
-                if target_cat is not None:
-                    merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
-                    source_memo = (source_cat.get('memo', '') or '').strip()
-                    source_owner = source_cat.get('owner', self.app.settings['codername'])
-                    merged_block = f"\n\n[{_('Merged from category:')} {source_cat['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"
-                    if source_memo:
-                        merged_block += f"\n{source_memo}"
-                    target_memo = target_cat.get('memo', '') or ''
-                    new_memo = (target_memo + merged_block).strip()
-                    cur.execute("update code_cat set memo=? where catid=?", [new_memo, category['catid']])
-                    target_cat['memo'] = new_memo
-            for code in self.codes:
-                if code['catid'] == catid:
-                    cur.execute("update code_name set catid=? where catid=?", [category['catid'], catid])
-            cur.execute("delete from code_cat where catid=?", [catid])
-            for cat in self.categories:
-                if cat['supercatid'] == catid:
-                    cur.execute("update code_cat set supercatid=? where supercatid=?", [category['catid'], catid])
-            # Clear any orphan supercatids
-            sql = "select supercatid from code_cat where supercatid not in (select catid from code_cat)"
-            cur.execute(sql)
-            orphans = cur.fetchall()
-            sql = "update code_cat set supercatid=Null where supercatid=?"
-            for orphan in orphans:
-                cur.execute(sql, [orphan[0]])
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            logger.warning(e_)
-            self.app.conn.rollback()  # revert all changes
-            self.update_dialog_codes_and_categories()
-            raise            
-        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
-
-    def merge_code_into_code(self, selected):
-        """ Merge the selected code into another code chosen from a list.
-        Reuses merge_codes (the same logic used by drag-and-drop with Ctrl). The source code
-        and all of its descendant sub-codes are excluded from the candidate targets to avoid
-        creating a supercid cycle when merging a code into one of its own sub-codes. <- L
-        param:
+    def delete_category_or_code(self, selected):
+        """ Determine if selected item is a code or category before deletion.
+        Category deletion now cascades down the whole branch, matching the
+        Delete category branch option propagated from the text coding page. <- L
+        Args:
             selected: QTreeWidgetItem
         """
-
-        if selected is None or selected.text(1)[0:3] != 'cid':
-            return
-        src_cid = int(selected.text(1)[4:])
-        source_code = next((c for c in self.codes if c['cid'] == src_cid), None)
-        if source_code is None:
-            return
-        # Candidate targets: every code that is not the source nor a descendant of the source.
-        target_list = []
-        for c in self.codes:
-            if not self._code_is_descendant(c['cid'], src_cid):
-                target_list.append({'name': c['name'], 'cid': c['cid']})
-        if not target_list:
-            Message(self.app, _("Merge code into code"),
-                    _("There is no other code to merge into.")).exec()
-            return
-        target_list = sorted(target_list, key=lambda x: x['name'].lower())
-        ui = DialogSelectItems(self.app, target_list, _("Select code to merge into"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        target = ui.get_selected()
-        if not target:
-            return
-        # merge_codes expects the target as a QTreeWidgetItem, so find it in the tree.
-        target_item = None
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node = it.value()
-            if node.text(1) == f"cid:{target['cid']}":
-                target_item = node
-                break
-            it += 1
-        if target_item is None:
-            return
-        self.merge_codes(source_code, target_item)
-
-    def merge_codes(self, item, parent):
-        """ Merge code with another code .
-        Called by item_moved_update_data when a code is moved onto another code.
-        param:
-            item: QTreeWidgetItem
-            parent: QTreeWidgetItem """
-
-        # Check item dropped on itself. Error can occur on Ubuntu 22.04.
-        if item['name'] == parent.text(0):
-            return
-        # Prevent a supercid cycle <- L
-        target_cid = int(parent.text(1).split(':')[1])
-        if self._code_is_descendant(target_cid, item['cid']):
-            Message(self.app, _("Cannot merge code"),
-                    _("Cannot merge a code into itself or one of its own sub-codes.")).exec()
-            return
-        msg_ = _("Merge code: ") + item['name'] + " ==> " + parent.text(0)
-        reply = QtWidgets.QMessageBox.question(self, _('Merge codes'),
-                                               msg_, QtWidgets.QMessageBox.StandardButton.Yes,
-                                               QtWidgets.QMessageBox.StandardButton.No)
-        if reply == QtWidgets.QMessageBox.StandardButton.No:
-            return
-        cur = self.app.conn.cursor()
-        old_cid = item['cid']
-        new_cid = int(parent.text(1).split(':')[1])
-        # Always record merge info in target code memo <- L
-        target_code = None
-        for c in self.codes:
-            if c['cid'] == new_cid:
-                target_code = c
-                break
-        if target_code is not None:
-            merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
-            source_memo = item.get('memo', '').strip()
-            source_owner = item.get('owner', self.app.settings['codername'])
-            merged_block = f"\n\n[{_('Merged from code:')} {item['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"
-            if source_memo:
-                merged_block += f"\n{source_memo}"
-            target_memo = target_code.get('memo', '') or ''
-            new_memo = (target_memo + merged_block).strip()
-            cur.execute("update code_name set memo=? where cid=?", [new_memo, new_cid])
-            target_code['memo'] = new_memo
-        # Update cid for each coded segment in text, av, image. Delete where there is an Integrity error
-        ct_sql = "select ctid from code_text where cid=?"
-        cur.execute(ct_sql, [old_cid])
-        ct_res = cur.fetchall()
-        try:
-            for ct in ct_res:
-                try:
-                    cur.execute("update code_text set cid=? where ctid=?", [new_cid, ct[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_text where ctid=?", [ct[0]])
-            av_sql = "select avid from code_av where cid=?"
-            cur.execute(av_sql, [old_cid])
-            av_res = cur.fetchall()
-            for av in av_res:
-                try:
-                    cur.execute("update code_av set cid=? where avid=?", [new_cid, av[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_av where avid=?", [av[0]])
-            img_sql = "select imid from code_image where cid=?"
-            cur.execute(img_sql, [old_cid])
-            img_res = cur.fetchall()
-            for img in img_res:
-                try:
-                    cur.execute("update code_image set cid=? where imid=?", [new_cid, img[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_image where imid=?", [img[0]])
-            # Re-parent the merged code's sub-codes onto the target code (no orphans). <- L
-            cur.execute("update code_name set supercid=?, catid=null where supercid=?", [new_cid, old_cid])
-            cur.execute("delete from code_name where cid=?", [old_cid, ])
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            logger.warning(e_)
-            self.app.conn.rollback()  # revert all changes
-            raise                
-        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
-        self.parent_textEdit.append(msg_)
-        self.load_segments()
-
-    def add_code(self, catid=None, supercid=None):
-        """  Use add_item dialog to get new code text. Add_code_name dialog checks for
-        duplicate code name. A random color is selected for the code.
-        New code is added to data and database.
-        param:
-            catid : None to add to without category, catid to add to to category.
-            supercid : None, or Integer to add the code as a sub-code of another code. <- L """
-
-        # Mutual exclusivity: a sub-code never belongs to a category as well. <- L
-        if supercid is not None:
-            catid = None
-        ui = DialogAddItemName(self.app, self.codes, _("Add new code"), _("New code name"))
-        ui.exec()
-        new_name = ui.get_new_name()
-        if new_name is None:
-            return
-        code_color = colors[randint(0, len(colors) - 1)]
-        item = {'name': new_name, 'memo': "", 'owner': self.app.settings['codername'],
-                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S"), 'catid': catid,
-                'color': code_color, 'supercid': supercid}
-        cur = self.app.conn.cursor()
-        cur.execute("insert into code_name (name,memo,owner,date,catid,color,supercid) values(?,?,?,?,?,?,?)",
-                    (item['name'], item['memo'], item['owner'], item['date'], item['catid'], item['color'],
-                     item['supercid']))
-        self.app.conn.commit()
-        self.parent_textEdit.append(_("Code added: ") + item['name'])
-        self.update_dialog_codes_and_categories(["code_name"])
-        self.app.delete_backup = False
-
-    def add_category(self, supercatid=None):
-        """ Add a new category.
-        Note: the addItem dialog does the checking for duplicate category names
-        param:
-            supercatid : None to add without category, supercatid to add to category. """
-
-        ui = DialogAddItemName(self.app, self.categories, _("Category"), _("Category name"))
-        ui.exec()
-        new_name = ui.get_new_name()
-        if new_name is None:
-            return
-        item = {'name': new_name, 'cid': None, 'memo': "",
-                'owner': self.app.settings['codername'],
-                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")}
-        cur = self.app.conn.cursor()
-        cur.execute("insert into code_cat (name, memo, owner, date, supercatid) values(?,?,?,?,?)",
-                    (item['name'], item['memo'], item['owner'], item['date'], supercatid))
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_cat"])
-        self.app.delete_backup = False
-
-    def delete_category_or_code(self, selected):
-        """ Determine if category or code is to be deleted.
-        param:
-            selected: QTreeWidgetItem """
-
         if selected.text(1)[0:3] == 'cat':
-            self.delete_category(selected)
-            return  # avoid error as selected is now None
+            self.code_tree.delete_category_branch(selected)
+            return  # Avoid error as selected is now None
         if selected.text(1)[0:3] == 'cid':
-            self.delete_code(selected)
+            self.code_tree.delete_code(selected)
 
-    def delete_code(self, selected):
-        """ Find code, remove from database, refresh and code_name data and fill
-        treeWidget.
-        param:
-            selected: QTreeWidgetItem """
-
-        # find the code_in the list, check to delete
-        found = -1
-        for i in range(0, len(self.codes)):
-            if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                found = i
-        if found == -1:
-            return
-        code_ = self.codes[found]
-        ui = DialogConfirmDelete(self.app, _("Code: ") + selected.text(0))
-        ok = ui.exec()
-        if not ok:
-            return
-        cur = self.app.conn.cursor()
-        # Re-parent this code's sub-codes so they are not orphaned by the deletion. <- L
-        if code_.get('supercid') is not None:
-            # Was itself a sub-code: lift its children to the grandparent code.
-            cur.execute("update code_name set supercid=? where supercid=?", [code_['supercid'], code_['cid']])
-        else:
-            # Was top level (possibly under a category): move children into that category (or top level).
-            cur.execute("update code_name set supercid=null, catid=? where supercid=?",
-                        [code_['catid'], code_['cid']])
-        cur.execute("delete from code_name where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_av where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_image where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_text where cid=?", [code_['cid'], ])
-        self.app.conn.commit()
-        self.parent_textEdit.append(_("Code deleted: ") + code_['name'])
-        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
-        self.app.delete_backup = False
-
-    def delete_category(self, selected):
-        """ Find category, remove from database, refresh categories and code data
-        and fill treeWidget.
-        param:
-            selected: QTreeWidgetItem """
-
-        found = -1
-        for i in range(0, len(self.categories)):
-            if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                found = i
-        if found == -1:
-            return
-        category = self.categories[found]
-        ui = DialogConfirmDelete(self.app, _("Category: ") + selected.text(0))
-        ok = ui.exec()
-        if not ok:
-            return
-        cur = self.app.conn.cursor()
-        cur.execute("update code_name set catid=null where catid=?", [category['catid'], ])
-        cur.execute("update code_cat set supercatid=null where catid = ?", [category['catid'], ])
-        cur.execute("delete from code_cat where catid = ?", [category['catid'], ])
-        self.app.conn.commit()
-        # An extra check. Fix 'lost' categories if present.
-        sql = "update code_cat set supercatid=null where supercatid is not null and supercatid not in " \
-              "(select catid from code_cat)"
-        cur.execute(sql)
-        self.app.conn.commit()
-        self.parent_textEdit.append(_("Category deleted: ") + category['name'])
-        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
-        self.app.delete_backup = False
-
-    def add_edit_code_memo(self, selected):
-        """ View and edit a memo to a code.
-        param:
-            selected: QTreeWidgetItem """
-
-        changed_tables = []
-
-        if selected.text(1)[0:3] == 'cid':
-            # find the code in the list
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            ui = DialogMemo(self.app, _("Memo for Code ") + self.codes[found]['name'],
-                            self.codes[found]['memo'])
-            ui.exec()
-            memo = ui.memo
-            if memo == "":
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
-            else:
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
-            # Update codes list and database
-            if memo != self.codes[found]['memo']:
-                self.codes[found]['memo'] = memo
-                cur = self.app.conn.cursor()
-                cur.execute("update code_name set memo=? where cid=?", (memo, self.codes[found]['cid']))
-                self.app.conn.commit()
-                self.app.delete_backup = False
-                changed_tables = ["code_name"]
-
-        if selected.text(1)[0:3] == 'cat':
-            # Find the category in the list
-            found = -1  # use -1 sentinel <- L
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                    found = i
-            if found == -1:  # check against sentinel
-                return
-            ui = DialogMemo(self.app, _("Memo for Category ") + self.categories[found]['name'],
-                            self.categories[found]['memo'])
-            ui.exec()
-            memo = ui.memo
-            if memo == "":
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
-            else:
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
-            # Update codes list and database
-            if memo != self.categories[found]['memo']:
-                self.categories[found]['memo'] = memo
-                cur = self.app.conn.cursor()
-                cur.execute("update code_cat set memo=? where catid=?", (memo, self.categories[found]['catid']))
-                self.app.conn.commit()
-                self.app.delete_backup = False
-                changed_tables = ["code_cat"]
-        self.update_dialog_codes_and_categories(changed_tables)
-
-    def rename_category_or_code(self, selected):
-        """ Rename a code or category. Checks that the proposed code or category name is
-        not currently in use.
-        param:
-            selected: QTreeWidgetItem """
-
-        if selected.text(1)[0:3] == 'cid':
-            found_code = None
-            check_codes = []
-            for code_ in self.codes:
-                if code_['cid'] == int(selected.text(1)[4:]):
-                    found_code = code_
-                else:
-                    check_codes.append(code_)
-            ui = DialogAddItemName(self.app, check_codes, _("Rename code"), _("Code name"))
-            ui.ui.lineEdit.setText(found_code['name'])
-            ui.exec()
-            new_name = ui.get_new_name()
-            if new_name is None or new_name == found_code['name']:
-                return
-            # Find the code in the list
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            # update codes list and database
-            cur = self.app.conn.cursor()
-            cur.execute("update code_name set name=? where cid=?", (new_name, self.codes[found]['cid']))
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Code renamed: ") + f"{self.codes[found]['name']} ==> {new_name}")
-            self.update_dialog_codes_and_categories(["code_name"])
-            self.app.delete_backup = False
-            return
-
-        if selected.text(1)[0:3] == 'cat':
-            found_cat = None
-            check_categories = []
-            for category in self.categories:
-                if category['catid'] == int(selected.text(1)[6:]):
-                    found_cat = category
-                else:
-                    check_categories.append(category)
-            ui = DialogAddItemName(self.app, check_categories, _("Rename category"), _("Category name"))
-            ui.ui.lineEdit.setText(found_cat['name'])
-            ui.exec()
-            new_name = ui.get_new_name()
-            if new_name is None or new_name == found_cat['name']:
-                return
-            # Find the category in the list
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            # update category list and database
-            cur = self.app.conn.cursor()
-            cur.execute("update code_cat set name=? where catid=?",
-                        (new_name, self.categories[found]['catid']))
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Category renamed: ") + self.categories[found]['name'] + " ==> " + new_name)
-            self.update_dialog_codes_and_categories(["code_cat"])
-            self.app.delete_backup = False
-
-    def change_code_color(self, selected):
-        """ Change the color of the currently selected code.
-        param:
-            selected: QTreeWidgetItem """
-
-        cid = int(selected.text(1)[4:])
-        found = -1
-        for i in range(0, len(self.codes)):
-            if self.codes[i]['cid'] == cid:
-                found = i
-        if found == -1:
-            return
-        ui = DialogColorSelect(self.app, self.codes[found])
-        ok = ui.exec()
-        if not ok:
-            return
-        new_color = ui.get_color()
-        if new_color is None:
-            return
-        selected.setBackground(0, QBrush(QColor(new_color), Qt.BrushStyle.SolidPattern))
-        # update codes list and database
-        self.codes[found]['color'] = new_color
-        cur = self.app.conn.cursor()
-        cur.execute("update code_name set color=? where cid=?",
-                    (self.codes[found]['color'], self.codes[found]['cid']))
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_name"])
-        self.app.delete_backup = False
-
-    # Methods used with the textEdit transcribed text
     def unlight(self):
         """ Remove all text highlighting from current file. """
 

--- a/src/qualcoder/code_av.py
+++ b/src/qualcoder/code_av.py
@@ -666,7 +666,9 @@ class DialogCodeAV(QtWidgets.QDialog):
         # until only top categories are left
         sub_categories = copy(categories)
         counter = 0
-        while len(sub_categories) > 0 or counter < 10000:
+        # 'and', not 'or': with 'or' the 10,000 guard never fires (cycle in code_cat =
+        # infinite loop) and healthy data still spins 10,000 empty passes.
+        while len(sub_categories) > 0 and counter < 10000:
             leaf_list = []
             branch_list = []
             for cat in sub_categories:

--- a/src/qualcoder/code_av.py
+++ b/src/qualcoder/code_av.py
@@ -71,7 +71,6 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app = app
         self.parent_textEdit = parent_text_edit
         self.tab_reports = tab_reports
-        self.tree_sort_option = "all asc"  # Options: all desc, cat then code asc
         self.files = []
         self.attributes = []  # Show selected files in list widget
         self.file_ = None  # Current file
@@ -2257,19 +2256,6 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.segment['seltext'] = ""
         self.ui.label_segment.setText(_("Segment:"))
         self.ui.pushButton_coding.setText(_("Start segment"))
-
-    def delete_category_or_code(self, selected):
-        """ Determine if selected item is a code or category before deletion.
-        Category deletion now cascades down the whole branch, matching the
-        Delete category branch option propagated from the text coding page. <- L
-        Args:
-            selected: QTreeWidgetItem
-        """
-        if selected.text(1)[0:3] == 'cat':
-            self.code_tree.delete_category_branch(selected)
-            return  # Avoid error as selected is now None
-        if selected.text(1)[0:3] == 'cid':
-            self.code_tree.delete_code(selected)
 
     def unlight(self):
         """ Remove all text highlighting from current file. """

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -100,7 +100,6 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.code_text = []  # The coded text segments
         self.codes, self.categories = self.app.get_codes_categories()
         self.get_recent_codes()  # After codes obtained!
-        self.tree_sort_option = "all asc"  # all desc, cat then code asc
         self.annotations = self.app.get_annotations()
         self.autocode_history = []
         self.default_new_code_color = None
@@ -2038,19 +2037,6 @@ class DialogCodePdf(QtWidgets.QWidget):
             return
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
-
-    def delete_category_or_code(self, selected):
-        """ Determine if selected item is a code or category before deletion.
-        Category deletion now cascades down the whole branch, matching the
-        Delete category branch option propagated from the text coding page.
-        Args:
-            selected: QTreeWidgetItem
-        """
-        if selected.text(1)[0:3] == 'cat':
-            self.code_tree.delete_category_branch(selected)
-            return  # Avoid error as selected is now None
-        if selected.text(1)[0:3] == 'cid':
-            self.code_tree.delete_code(selected)
 
     def file_menu(self, position):
         """ Context menu for listWidget files to get to the next file and

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -17,6 +17,7 @@ If not, see <https://www.gnu.org/licenses/>.
 Author: Colin Curtain (ccbogel)
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -34,7 +35,6 @@ from pdfminer.psparser import PSLiteral  # Partly using for color conversion
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdfdocument import PDFDocument  # for PDF meta information
 import qtawesome as qta  # see: https://pictogrammers.com/library/mdi/
-from random import randint
 import re
 import sqlite3
 from statistics import median
@@ -45,13 +45,12 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QBrush, QColor
 
-from .add_item_name import DialogAddItemName
 from .code_in_all_files import DialogCodeInAllFiles
+from .code_tree import CodeTreeController
 from .color_selector import DialogColorSelect
-from .color_selector import colors, TextColor, colour_ranges, show_codes_of_colour_range
-from .confirm_delete import DialogConfirmDelete
+from .color_selector import TextColor, colour_ranges, show_codes_of_colour_range
 from .helpers import Message, ExportDirectoryPathDialog, ToolTipEventFilter, CodeResizeHandle, \
-    init_persistent_tree_header, restore_persistent_tree_widths
+    init_persistent_tree_header
 from .GUI.ui_dialog_code_pdf import Ui_Dialog_code_pdf
 from .memo import DialogMemo
 from .coder_names import DialogCoderNames
@@ -243,7 +242,18 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.ui.treeWidget.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.InternalMove)
         self.ui.treeWidget.viewport().installEventFilter(self)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
+        # Shared code tree controller: tree loading, common context menu, drag and drop
+        # reparenting, F2-F6 shortcuts and category branch deletion live in code_tree.py,
+        # so the four coding pages no longer duplicate this logic by hand.
+        self.code_tree = CodeTreeController(self.app, self.ui.treeWidget, self)
+        self.ui.treeWidget.customContextMenuRequested.connect(self.code_tree.tree_menu)
+        self.code_tree.fill_counts_callback = self.fill_code_counts_in_tree
+        self.code_tree.coded_files_callback = self.coded_media_dialog
+        self.code_tree.find_code_callback = self.find_code_in_tree
+        self.code_tree.show_codes_like_callback = self.show_codes_like
+        self.code_tree.show_codes_of_colour_callback = self.show_codes_of_color
+        self.code_tree.codes_changed.connect(self._on_code_tree_changed)
+
         self.ui.treeWidget.itemPressed.connect(self.fill_code_label)
         init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodepdf_tree_widths')
 
@@ -272,7 +282,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.get_files()
 
         self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
-        self.fill_tree()
+        self.code_tree.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
         self.ui.treeWidget.itemExpanded.connect(self.get_collapsed)
@@ -549,7 +559,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable-box'))
         self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
         self.get_files(ui.result_file_ids, preserve_current_file=True)
-        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter file <- L
+        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter file
         self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
 
     def fill_code_label(self):
@@ -616,168 +626,6 @@ class DialogCodePdf(QtWidgets.QWidget):
                 non_expanded.append(item.child(i).text(1))
             self.tree_traverse_for_non_expanded(item.child(i), non_expanded)
 
-    def fill_tree(self):
-        """ Fill tree widget, top level items are main categories and unlinked codes.
-        The Count column counts the number of times that code has been used by selected coder in selected file.
-        Keep record of non-expanded items, then re-enact these items when treee fill is called again. """
-
-        cats = deepcopy(self.categories)
-        codes = deepcopy(self.codes)
-        self.ui.treeWidget.clear()
-        self.ui.treeWidget.setColumnCount(4)
-        self.ui.treeWidget.setHeaderLabels([_("Name"), _("Id"), _("Memo"), _("Count")])
-        if not self.app.settings['showids']:
-            self.ui.treeWidget.setColumnHidden(1, True)
-        else:
-            self.ui.treeWidget.setColumnHidden(1, False)
-        # Add top level categories
-        remove_list = []
-        for c in cats:
-            if c['supercatid'] is None:
-                memo = ""
-                if c['memo'] != "":
-                    memo = _("Memo")
-                top_item = QtWidgets.QTreeWidgetItem([c['name'], f'catid:{c["catid"]}', memo])
-                top_item.setToolTip(2, c['memo'])
-                top_item.setToolTip(0, '')
-                if len(c['name']) > 52:
-                    top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                    top_item.setToolTip(0, c['name'])
-                self.ui.treeWidget.addTopLevelItem(top_item)
-                if f"catid:{c['catid']}" in self.app.collapsed_categories:
-                    top_item.setExpanded(False)
-                else:
-                    top_item.setExpanded(True)
-                remove_list.append(c)
-        for item in remove_list:
-            cats.remove(item)
-        ''' Add child categories. look at each unmatched category, iterate through tree
-         to add as child, then remove matched categories from the list '''
-        count = 0
-        while len(cats) > 0 and count < 10000:
-            remove_list = []
-            for c in cats:
-                it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-                item = it.value()
-                count2 = 0
-                while item and count2 < 10000:  # while there is an item in the list
-                    if item.text(1) == f'catid:{c["supercatid"]}':
-                        memo = ""
-                        if c['memo'] != "":
-                            memo = _("Memo")
-                        child = QtWidgets.QTreeWidgetItem([c['name'], f'catid:{c["catid"]}', memo])
-                        child.setToolTip(2, c['memo'])
-                        child.setToolTip(0, '')
-                        if len(c['name']) > 52:
-                            child.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                            child.setToolTip(0, c['name'])
-                        item.addChild(child)
-                        if f"catid:{c['catid']}" in self.app.collapsed_categories:
-                            child.setExpanded(False)
-                        else:
-                            child.setExpanded(True)
-                        remove_list.append(c)
-                    it += 1
-                    item = it.value()
-                    count2 += 1
-            if not remove_list:
-                break  # cycle or dangling parent: leftovers placed at top level below
-            for item in remove_list:
-                cats.remove(item)
-            count += 1
-        # Fallback: never lose a category. Any with a missing/cyclic parent goes to top level. <- L
-        for c in cats:
-            memo = _("Memo") if c['memo'] != "" else ""
-            top_item = QtWidgets.QTreeWidgetItem([c['name'], 'catid:' + str(c['catid']), memo])
-            top_item.setToolTip(2, c['memo'])
-            top_item.setToolTip(0, '')
-            if len(c['name']) > 52:
-                top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                top_item.setToolTip(0, c['name'])
-            self.ui.treeWidget.addTopLevelItem(top_item)
-        # Add codes, with sub-code nesting. A code is top level only when it has neither a
-        # parent category (catid) nor a parent code (supercid). The rest are nested under
-        # their category (catid:) or under their parent code (cid:). <- L
-
-        def _make_code_item(code_dict):
-            """ Build a styled tree item for a code. Sub-codes share this styling. <- L """
-            memo_ = _("Memo") if code_dict['memo'] != "" else ""
-            code_item = QtWidgets.QTreeWidgetItem([code_dict['name'], f"cid:{code_dict['cid']}", memo_])
-            code_item.setToolTip(2, code_dict['memo'])
-            code_item.setToolTip(0, '')
-            if len(code_dict['name']) > 52:
-                code_item.setText(0, f"{code_dict['name'][:25]}..{code_dict['name'][-25:]}")
-                code_item.setToolTip(0, code_dict['name'])
-            code_item.setBackground(0, QBrush(QColor(code_dict['color']), Qt.BrushStyle.SolidPattern))
-            code_item.setForeground(0, QBrush(QColor(TextColor(code_dict['color']).recommendation)))
-            code_item.setFlags(
-                Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable |
-                Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsDragEnabled)
-            return code_item
-
-        # Index every node already in the tree (categories) by its id text for O(1) lookup. <- L
-        node_index = {}
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node_index[it.value().text(1)] = it.value()
-            it += 1
-        # Top level codes: no category and no parent code.
-        remove_items = []
-        for c in codes:
-            if c['catid'] is None and c.get('supercid') is None:
-                node = _make_code_item(c)
-                self.ui.treeWidget.addTopLevelItem(node)
-                node_index[f"cid:{c['cid']}"] = node
-                remove_items.append(c)
-        for c in remove_items:
-            codes.remove(c)
-        # Remaining codes: nest under category or parent code. Iterate because a parent code
-        # may itself be a not-yet-placed sub-code. Each pass places every code whose parent
-        # already exists; the loop ends when all are placed or no further progress is possible.
-        count = 0
-        while codes and count < 10000:
-            remove_items = []
-            for c in codes:
-                if c.get('supercid') is not None:
-                    parent_key = f"cid:{c['supercid']}"
-                else:
-                    parent_key = f"catid:{c['catid']}"
-                parent_node = node_index.get(parent_key)
-                if parent_node is not None:
-                    node = _make_code_item(c)
-                    parent_node.addChild(node)
-                    node_index[f"cid:{c['cid']}"] = node
-                    remove_items.append(c)
-            if not remove_items:
-                break  # remaining codes have a missing/cyclic parent: placed at top level below
-            for c in remove_items:
-                codes.remove(c)
-            count += 1
-        # Fallback: never lose a code. Any code with a dangling parent goes to top level. <- L
-        for c in codes:
-            node = _make_code_item(c)
-            self.ui.treeWidget.addTopLevelItem(node)
-            node_index[f"cid:{c['cid']}"] = node
-
-        if self.tree_sort_option == "all asc":
-            self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
-        if self.tree_sort_option == "all desc":
-            self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
-        # Show the code tree expanded from the start: sub-code branches are visible by default;
-        # categories the user had collapsed are restored to their collapsed state. <- L
-        self.ui.treeWidget.expandAll()
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node = it.value()
-            if node.text(1) in self.app.collapsed_categories:
-                node.setExpanded(False)
-            it += 1
-        self.fill_code_counts_in_tree()
-        restore_persistent_tree_widths(
-            self.ui.treeWidget,
-            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
-        )
-
     def fill_code_counts_in_tree(self):
         """ Calculate the frequency of each code and category for this coder and the selected file.
         Add a list item to each code that can be used to display in treeWidget.
@@ -800,7 +648,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             code_counts.append([c['cid'], result[0], result[1]])
 
         # Sub-code roll-up. Build own counts, the parent/children maps and an effective
-        # category for each code (a sub-code is attributed to its top ancestor's category). <- L
+        # category for each code (a sub-code is attributed to its top ancestor's category).
         own_count = {cc[0]: cc[2] for cc in code_counts}
         code_by_cid = {c['cid']: c for c in self.codes}
         children_of = {}
@@ -810,7 +658,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                 children_of.setdefault(sup, []).append(c['cid'])
 
         def _effective_catid(cid):
-            """ Resolve a (possibly nested) code to the catid of its top ancestor code. <- L """
+            """ Resolve a (possibly nested) code to the catid of its top ancestor code. """
             seen = set()
             cur_c = code_by_cid.get(cid)
             while cur_c is not None and cur_c['cid'] not in seen:
@@ -828,7 +676,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         total_cache = {}
 
         def _code_total(cid):
-            """ Code count rolled up with all descendant sub-codes. Memoized, cycle-safe. <- L """
+            """ Code count rolled up with all descendant sub-codes. Memoized, cycle-safe. """
             if cid in total_cache:
                 return total_cache[cid]
             total_cache[cid] = own_count.get(cid, 0)  # seed guards against cycles
@@ -843,7 +691,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         for category in categories:
             category['count'] = 0
         # Add each code's own count to its effective category (sub-codes roll up to the
-        # category of their top ancestor code, not to a raw catid that is None). <- L
+        # category of their top ancestor code, not to a raw catid that is None).
         for category in categories:
             for code in code_counts:
                 if eff_catid.get(code[0]) == category['catid']:
@@ -893,7 +741,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         """ Use to quicky open memo. """
 
         if column == 2:
-            self.add_edit_cat_or_code_memo(item)
+            self.code_tree.add_edit_cat_or_code_memo(item)
 
     def get_collapsed(self, item):
         """ On category collapse or expansion signal, find the collapsed parent category items.
@@ -1246,9 +1094,9 @@ class DialogCodePdf(QtWidgets.QWidget):
 
         codes_copy = deepcopy(self.codes)
         if not in_vivo:
-            self.add_code()
+            self.code_tree.add_code()
         else:
-            self.add_code(catid=None, code_name=self.ui.plainTextEdit.textCursor().selectedText())
+            self.code_tree.add_code(catid=None, code_name=self.ui.plainTextEdit.textCursor().selectedText())
         new_code = None
         for c in self.codes:
             if c not in codes_copy:
@@ -1466,381 +1314,6 @@ class DialogCodePdf(QtWidgets.QWidget):
         cb = QtWidgets.QApplication.clipboard()
         cb.setText(selected_text)
 
-    def tree_menu(self, position):
-        """ Context menu for treewidget code/category items.
-        Add, rename, memo, move or delete code or category. Change code color.
-        Assign selected text to current hovered code. """
-
-        menu = QtWidgets.QMenu()
-        menu.setStyleSheet(f"QMenu {{font-size:{self.app.settings['fontsize']}pt}} ")
-        selected = self.ui.treeWidget.currentItem()
-        action_add_code_to_category = None
-        action_add_category_to_category = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_add_code_to_category = menu.addAction(_("Add new code to category"))
-            action_add_category_to_category = menu.addAction(_("Add a new category to category"))
-        action_add_code = menu.addAction(_("Add a new code"))
-        action_add_category = menu.addAction(_("Add a new category"))
-        action_add_subcode = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_add_subcode = menu.addAction(_("Add a new sub-code to code"))  # <- L
-        action_expand_collapse = None
-        action_cat_show_coded_files = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
-            action_cat_show_coded_files = menu.addAction(_("Show coded files"))
-        if selected is not None and selected.text(1)[0:3] == 'cid' and selected.childCount() > 0:
-            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))  # <- L
-        modify_menu = menu.addMenu(_("Modify"))
-        action_rename = modify_menu.addAction(_("Rename F2"))
-        action_edit_memo = modify_menu.addAction(_("View or edit memo"))
-        action_merge_category = None
-        action_move_category = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_merge_category = modify_menu.addAction(_("Merge category into category"))
-            action_move_category = modify_menu.addAction(_("Move category under category"))
-        action_delete = modify_menu.addAction(_("Delete"))
-        action_color = None
-        action_show_coded_media = None
-        action_move_code = None
-        action_move_multi_codes = None
-        action_merge_code_into_code = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_color = modify_menu.addAction(_("Change code color"))
-            action_show_coded_media = menu.addAction(_("Show coded files"))
-            action_move_code = modify_menu.addAction(_("Move code to"))
-            action_move_multi_codes = modify_menu.addAction(_("Move multiple codes"))
-            action_merge_code_into_code = modify_menu.addAction(_("Merge code into code"))  # <- L
-        filter_menu = menu.addMenu(_("Filter"))
-        action_show_codes_like = filter_menu.addAction(_("Show codes like") + ": " + self.show_codes_like_filter)
-        action_show_codes_of_colour = filter_menu.addAction(_("Show codes of colour") + ": " + self.show_codes_colour_filter)
-        sort_menu = menu.addMenu(_("Sort"))
-        action_all_asc = sort_menu.addAction(_("Sort ascending"))
-        action_all_desc = sort_menu.addAction(_("Sort descending"))
-        action_cat_then_code_asc = sort_menu.addAction(_("Sort category then code ascending"))
-        action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
-        if action is not None:
-            if action == action_show_codes_of_colour:
-                self.show_codes_of_color()
-                return
-            if action == action_all_asc:
-                self.tree_sort_option = "all asc"
-                self.fill_tree()
-                return
-            if action == action_all_desc:
-                self.tree_sort_option = "all desc"
-                self.fill_tree()
-                return
-            if action == action_cat_then_code_asc:
-                self.tree_sort_option = "cat and code asc"
-                self.fill_tree()
-                return
-            if action == action_expand_collapse:
-                expand_toggle = not selected.isExpanded()
-                self.recursive_expand_collapse_branch(selected, expand_toggle)
-                return
-            if action == action_show_codes_like:
-                self.show_codes_like()
-                return
-            if selected is not None and action == action_color:
-                self.change_code_color(selected)
-                return
-            if action == action_add_category:
-                self.add_category()
-                return
-            if action == action_add_code:
-                self.add_code()
-                return
-            if action == action_merge_category:
-                catid = int(selected.text(1).split(":")[1])
-                self.merge_category(catid)
-                return
-            if action == action_move_category:
-                catid = int(selected.text(1).split(":")[1])
-                self.move_category(catid)
-                return
-            if action == action_add_code_to_category:
-                catid = int(selected.text(1).split(":")[1])
-                self.add_code(catid)
-                return
-            if action == action_add_subcode and selected is not None:
-                supercid = int(selected.text(1).split(":")[1])  # <- L
-                self.add_code(supercid=supercid)
-                return
-            if action == action_add_category_to_category:
-                catid = int(selected.text(1).split(":")[1])
-                self.add_category(catid)
-                return
-            if selected is not None and action == action_move_code:
-                self.move_code(selected)
-                return
-            if action == action_move_multi_codes:
-                self.move_multiple_codes()
-                return
-            if action == action_merge_code_into_code and selected is not None:
-                self.merge_code_into_code(selected)  # <- L
-                return
-            if selected is not None and action == action_rename:
-                self.rename_category_or_code(selected)
-                return
-            if selected is not None and action == action_edit_memo:
-                self.add_edit_cat_or_code_memo(selected)
-                return
-            if selected is not None and action == action_delete:
-                self.delete_category_or_code(selected)
-                return
-            if action == action_cat_show_coded_files:
-                branch_codes = self.recursive_get_branch_codes(selected, [])
-                self.coded_media_dialog(branch_codes, selected.text(0))
-                return
-            if selected is not None and action == action_show_coded_media:
-                to_find = int(selected.text(1)[4:])
-                found = next((code for code in self.codes if code['cid'] == to_find), None)
-                if found:
-                    self.coded_media_dialog(found)
-
-    def recursive_get_branch_codes(self, item, branch_codes):
-        """ Set all children of this item to be expanded or collapsed.
-        Recurse through all child categories. """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            if item.child(i).text(1)[0:3] == "cid":
-                cid = int(item.child(i).text(1)[4:])
-                for code_ in self.codes:
-                    if cid == code_['cid']:
-                        branch_codes.append(code_)
-                        break
-                self.recursive_get_branch_codes(item.child(i), branch_codes)  # Also gather sub-codes nested under this code (supercid) <- L
-            if item.child(i).text(1)[0:3] == "cat":
-                self.recursive_get_branch_codes(item.child(i), branch_codes)
-        return branch_codes
-
-    def recursive_expand_collapse_branch(self, item, expand_toggle):
-        """ Set all children of this item to be expanded or collapsed.
-        Recurse through all child categories.
-        Arge:
-            item : QTreeWidgetItem
-            expand_toggle : Bool
-        """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            item.setExpanded(expand_toggle)
-            self.recursive_expand_collapse_branch(item.child(i), expand_toggle)
-
-    def recursive_non_merge_item(self, item, no_merge_list):
-        """ Find matching item to be the current selected item.
-        Recurse through any child categories.
-        Tried to use QTreeWidget.finditems - but this did not find matching item text
-        Called by: textEdit recent codes menu option
-        Required for: merge_category()
-        Args:
-                item : QTreeWidgetItem
-                no_merge_list : list of treeitems
-        """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            if item.child(i).text(1)[0:3] == "cat":
-                no_merge_list.append(item.child(i).text(1)[6:])
-            self.recursive_non_merge_item(item.child(i), no_merge_list)
-        return no_merge_list
-
-    def move_category(self, catid: int):
-        """ Select another category to move this category underneath.
-        Args:
-            catid : Integer category identifier
-        """
-
-        do_not_merge_list = []
-        do_not_merge_list = self.recursive_non_merge_item(self.ui.treeWidget.currentItem(), do_not_merge_list)
-        do_not_merge_list.append(str(catid))
-        do_not_merge_ids_string = f"({','.join(do_not_merge_list)})"
-        sql = "select name, catid, supercatid from code_cat where catid not in "
-        sql += do_not_merge_ids_string + " order by name"
-        cur = self.app.conn.cursor()
-        cur.execute(sql)
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        current_cat_name = self.ui.treeWidget.currentItem().text(0)
-        if category['name'] == '':
-            cur.execute("update code_cat set supercatid=Null where catid=?", [catid])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → Top level")
-        else:
-            cur.execute("update code_cat set supercatid=? where catid=?", [category['catid'], catid])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → " + category['name'])
-        self.update_dialog_codes_and_categories()
-
-    def merge_category(self, catid: int):
-        """ Select another category to merge this category into.
-        Args:
-            catid : Integer category identifier
-        """
-
-        do_not_merge_list = []
-        do_not_merge_list = self.recursive_non_merge_item(self.ui.treeWidget.currentItem(), do_not_merge_list)
-        do_not_merge_list.append(str(catid))
-        do_not_merge_ids_string = "(" + ",".join(do_not_merge_list) + ")"
-        sql = "select name, catid, supercatid from code_cat where catid not in "
-        sql += do_not_merge_ids_string + " order by name"
-        cur = self.app.conn.cursor()
-        cur.execute(sql)
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        try:
-            # Always record merge info in target category memo <- L
-            source_cat = None
-            for c in self.categories:
-                if c['catid'] == catid:
-                    source_cat = c
-                    break
-            if source_cat is not None and category['catid'] is not None:
-                target_cat = None
-                for c in self.categories:
-                    if c['catid'] == category['catid']:
-                        target_cat = c
-                        break
-                if target_cat is not None:
-                    merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
-                    source_memo = (source_cat.get('memo', '') or '').strip()
-                    source_owner = source_cat.get('owner', self.app.settings['codername'])
-                    merged_block = f"\n\n[{_('Merged from category:')} {source_cat['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"
-                    if source_memo:
-                        merged_block += f"\n{source_memo}"
-                    target_memo = target_cat.get('memo', '') or ''
-                    new_memo = (target_memo + merged_block).strip()
-                    cur.execute("update code_cat set memo=? where catid=?", [new_memo, category['catid']])
-                    target_cat['memo'] = new_memo
-            for code in self.codes:
-                if code['catid'] == catid:
-                    cur.execute("update code_name set catid=? where catid=?", [category['catid'], catid])
-            cur.execute("delete from code_cat where catid=?", [catid])
-            for cat in self.categories:
-                if cat['supercatid'] == catid:
-                    cur.execute("update code_cat set supercatid=? where supercatid=?", [category['catid'], catid])
-            # Clear any orphan supercatids
-            sql = "select supercatid from code_cat where supercatid not in (select catid from code_cat)"
-            cur.execute(sql)
-            orphans = cur.fetchall()
-            sql = "update code_cat set supercatid=Null where supercatid=?"
-            for orphan in orphans:
-                cur.execute(sql, [orphan[0]])
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            self.app.conn.rollback()  # Revert all changes
-            self.update_dialog_codes_and_categories()
-            raise
-        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
-
-    def move_multiple_codes(self):
-        """ Move multiple codes to another category. """
-
-        cur = self.app.conn.cursor()
-        cur.execute("select code_name.name, code_cat.name, cid from code_name left join code_cat on "
-                    "code_cat.catid=code_name.catid order by upper(code_cat.name) asc, upper(code_name.name) asc")
-        res = cur.fetchall()
-        code_list = []
-        for r in res:
-            name = r[0]
-            if r[1] is not None:
-                name = r[1] + " ← " + r[0]
-            code_list.append({'name': name, 'cid': r[2]})
-        ui = DialogSelectItems(self.app, code_list, _("Select codes"), "multi")
-        ok = ui.exec()
-        if not ok:
-            return
-        selected_codes = ui.get_selected()
-        cur.execute("select name, catid from code_cat order by upper(name)")
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        for s in selected_codes:
-            # Moving to a category (or to blank) removes any sub-code nesting. <- L
-            cur.execute("update code_name set catid=?, supercid=null where cid=?", [category['catid'], s['cid']])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Code moved.") + s['name'].replace(" ← ", "/") + " → " + category['name'])
-        self.update_dialog_codes_and_categories(["code_name"])
-
-
-    def move_code(self, selected):
-        """ Move code to another category or to no category.
-        Uses a list selection.
-        Args:
-            selected : QTreeWidgetItem
-         """
-
-        items_list = [{'name': " ", 'catid': -1, 'cid': -1}]  # Default blank item
-        iterator = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while iterator.value():
-            can_append = True
-            item = iterator.value()
-            depth = 0
-            current = item
-            # Get depth and if circular reference present
-            while current.parent() is not None:
-                if current.text(1) == selected.text(1):
-                    can_append = False
-                current = current.parent()
-                depth += 1
-            prefix = ""
-            if depth > 0:
-                prefix = "  " * (depth - 1) * 2 + "└─"  # U2514 U2500
-            name = prefix + item.text(0)
-            cid = -1
-            catid = -1
-            if "cid" in item.text(1):
-                cid = int(item.text(1)[4:])
-            else:
-                catid = int(item.text(1)[6:])
-                name += " " + _("[CATEGORY]")
-            # Check the same item is not the same selected item
-            if item.text(1) == selected.text(1) and item.text(2) == selected.text(2):
-                can_append = False
-            memo = item.toolTip(2)
-            if can_append:
-                items_list.append({'name': name, 'catid': catid, 'cid': cid, 'memo': memo})
-            iterator += 1
-        ui = DialogSelectItems(self.app, items_list, _("Select blank or category or code"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        destination = ui.get_selected()
-        # print(destination)
-        selected_cid = int(selected.text(1)[4:])
-        cur = self.app.conn.cursor()
-        if destination['catid'] == -1 and destination['cid'] == -1:  # move to top level
-            cur.execute("update code_name set catid=null, supercid=null where cid=?", [selected_cid])
-        elif destination['cid'] > 0:  # Move under another code
-            cur.execute("update code_name set catid=null, supercid=? where cid=?", [destination['cid'], selected_cid])
-        else:  # Move under a category
-            cur.execute("update code_name set catid=?, supercid=null where cid=?", [destination['catid'], selected_cid])
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_name"])
-
     def show_important_coded(self):
         """ Show codes flagged as important.
         Applies to both text edit and graphic scene. """
@@ -1962,7 +1435,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         """ Find all children codes of this item that match or not and hide or unhide based on 'text'.
         Recurse through all child categories and sub-codes. A code stays visible if it matches or
         if any of its descendant sub-codes matches, so a match is never hidden under a
-        non-matching parent code. Returns True if this item or any descendant matches. <- L
+        non-matching parent code. Returns True if this item or any descendant matches.
         Called by: show_codes_like
         Args:
             item: a QTreeWidgetItem
@@ -1975,7 +1448,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         for i in range(child_count):
             child = item.child(i)
             is_code = "cid:" in child.text(1)
-            # Recurse first so we know whether any descendant matches. <- L
+            # Recurse first so we know whether any descendant matches.
             descendant_match = self.recursive_traverse(child, text_, case_sensitive)
             if text_ == "":
                 if is_code:
@@ -2056,7 +1529,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                 if search_text in code_['name']:
                     matches.append(code_)
             iterator += 1
-        if not matches:  # check matches list, not item (item is always the last tree iterator value) <- L
+        if not matches:  # check matches list, not item (item is always the last tree iterator value)
             Message(self.app, _("Match not found"), _("No code with matching text found.")).exec()
             return
 
@@ -2118,7 +1591,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         key = event.key()
         mods = event.modifiers()
 
-        # Esc hides any active resize handles <- L
+        # Esc hides any active resize handles
         if key == QtCore.Qt.Key.Key_Escape:
             if hasattr(self, 'active_handles') and self.active_handles:
                 self.hide_resize_handles()
@@ -2132,11 +1605,10 @@ class DialogCodePdf(QtWidgets.QWidget):
         if key == QtCore.Qt.Key.Key_Z and mods == QtCore.Qt.KeyboardModifier.ControlModifier:
             self.undo_last_unmarked_code()
             return
-        # Rename code or category
-        if self.ui.treeWidget.hasFocus() and key == QtCore.Qt.Key.Key_F2:
-            selected = self.ui.treeWidget.currentItem()
-            self.rename_category_or_code(selected)
-            return
+        # Tree widget menu item keys F2 - F6, handled by the shared controller.
+        if self.ui.treeWidget.hasFocus():
+            if self.code_tree.handle_key_press(event):
+                return
         # New category
         if key == QtCore.Qt.Key.Key_C:
             # if category already selected, add new category to that
@@ -2144,7 +1616,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             selected = self.ui.treeWidget.currentItem()
             if selected is not None and selected.text(1)[0:3] == 'cat':
                 supercatid = int(selected.text(1)[6:])
-            self.add_category(supercatid)
+            self.code_tree.add_category(supercatid)
             return
 
         # Ctrl 0 to 9
@@ -2317,12 +1789,12 @@ class DialogCodePdf(QtWidgets.QWidget):
         Called by: textEdit cursor position changed. """
 
         # Only hide handles if the cursor leaves the coded segment that owns them,
-        # so they stay visible while the user clicks inside the same segment <- L
+        # so they stay visible while the user clicks inside the same segment
         if hasattr(self, 'active_handles') and self.active_handles:
             pos = self.ui.plainTextEdit.textCursor().position() + self.file_['start']
             owner = self.active_handles[0].code_item
             cursor_has_selection = self.ui.plainTextEdit.textCursor().hasSelection()
-            # Hide if a selection is made, or the cursor is outside the owning segment <- L
+            # Hide if a selection is made, or the cursor is outside the owning segment
             if cursor_has_selection or not (owner['pos0'] <= pos <= owner['pos1']):
                 self.hide_resize_handles()
 
@@ -2378,7 +1850,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                 item = self.ui.treeWidget.currentItem()
                 # event position is QPointF, itemAt requires toPoint
                 parent = self.ui.treeWidget.itemAt(event.position().toPoint())
-                self.item_moved_update_data(item, parent)
+                self.code_tree.item_moved_update_data(item, parent)
                 return True
             # Scroll the tree when dragged item it as top or bottom edges
             if event.type() == QtCore.QEvent.Type.DragMove:
@@ -2514,314 +1986,14 @@ class DialogCodePdf(QtWidgets.QWidget):
         DialogCodeInAllFiles(self.app, code_dict, "File", category_name)
         self.get_coded_text_update_eventfilter_tooltips()
 
-    def _category_is_descendant(self, candidate_catid, ancestor_catid):
-        """ Return True if candidate_catid is ancestor_catid or one of its descendant
-        sub-categories. Used to prevent cycles when moving a category under another. <- L """
-        if candidate_catid == ancestor_catid:
-            return True
-        children = {}
-        for c in self.categories:
-            sup = c.get('supercatid')
-            if sup is not None:
-                children.setdefault(sup, []).append(c['catid'])
-        stack = list(children.get(ancestor_catid, []))
-        seen = set()
-        while stack:
-            catid = stack.pop()
-            if catid == candidate_catid:
-                return True
-            if catid in seen:
-                continue
-            seen.add(catid)
-            stack.extend(children.get(catid, []))
-        return False
-
-    def item_moved_update_data(self, item, parent):
-        """ Called from drop event in treeWidget view port.
-        identify code or category to move.
-        Also merge codes if one code is dropped on another code.
+    def _on_code_tree_changed(self, tables):
+        """ Refresh after a change made through the shared code tree controller.
+        The pdf page also re-renders its page overlays.
         Args:
-            item : QTreeWidgetItem
-            parent : QTreeWidgetItem
+            tables: List of changed database table names
         """
-
-        # find the category in the list
-        if item.text(1)[0:3] == 'cat':
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(item.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            if parent is None:
-                self.categories[found]['supercatid'] = None
-            else:
-                if parent.text(1).split(':')[0] == 'cid':
-                    # parent is code (leaf) cannot add child
-                    return
-                supercatid = int(parent.text(1).split(':')[1])
-                if supercatid == self.categories[found]['catid']:
-                    # Cannot be its own parent.
-                    return
-                # Guard against cycles: moving a category under one of its own sub-categories
-                # would make the branch disappear and corrupt the tree. <- L
-                if self._category_is_descendant(supercatid, self.categories[found]['catid']):
-                    Message(self.app, _("Cannot move category"),
-                            _("Cannot move a category under one of its own sub-categories.")).exec()
-                    return
-                self.categories[found]['supercatid'] = supercatid
-            cur = self.app.conn.cursor()
-            cur.execute("update code_cat set supercatid=? where catid=?",
-                        [self.categories[found]['supercatid'], self.categories[found]['catid']])
-            self.app.conn.commit()
-            self.update_dialog_codes_and_categories(["code_cat"])
-            self.app.delete_backup = False
-            return
-
-        # find the code in the list
-        if item.text(1)[0:3] == 'cid':
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(item.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            if parent is None:
-                # Move code to top level: clear both parents. <- L
-                self.codes[found]['catid'] = None
-                self.codes[found]['supercid'] = None
-            else:
-                if parent.text(1).split(':')[0] == 'cid':
-                    parent_cid = int(parent.text(1).split(':')[1])
-                    # Ctrl held while dropping a code on a code merges (previous behaviour);
-                    # otherwise the code is nested as a sub-code. <- L
-                    ctrl = bool(QtWidgets.QApplication.keyboardModifiers() &
-                                QtCore.Qt.KeyboardModifier.ControlModifier)
-                    if ctrl:
-                        self.merge_codes(self.codes[found], parent)
-                        return
-                    if parent_cid == self.codes[found]['cid']:
-                        return  # cannot nest under itself
-                    if self._code_is_descendant(parent_cid, self.codes[found]['cid']):
-                        Message(self.app, _("Cannot nest code"),
-                                _("Cannot move a code under one of its own sub-codes.")).exec()
-                        return
-                    # Nest as a sub-code (mutually exclusive with category). <- L
-                    self.codes[found]['supercid'] = parent_cid
-                    self.codes[found]['catid'] = None
-                else:
-                    # Dropped onto a category. <- L
-                    catid = int(parent.text(1).split(':')[1])
-                    self.codes[found]['catid'] = catid
-                    self.codes[found]['supercid'] = None
-
-            cur = self.app.conn.cursor()
-            cur.execute("update code_name set catid=?, supercid=? where cid=?",
-                        [self.codes[found]['catid'], self.codes[found].get('supercid'),
-                         self.codes[found]['cid']])
-            self.app.conn.commit()
-            self.app.delete_backup = False
-            self.update_dialog_codes_and_categories(["code_name"])
-
-    def _code_is_descendant(self, candidate_cid, ancestor_cid):
-        """ Return True if candidate_cid is ancestor_cid or one of its descendant sub-codes.
-        Used to prevent cycles when nesting a code under another code. <- L """
-        if candidate_cid == ancestor_cid:
-            return True
-        children = {}
-        for c in self.codes:
-            sup = c.get('supercid')
-            if sup is not None:
-                children.setdefault(sup, []).append(c['cid'])
-        stack = list(children.get(ancestor_cid, []))
-        seen = set()
-        while stack:
-            cid = stack.pop()
-            if cid == candidate_cid:
-                return True
-            if cid in seen:
-                continue
-            seen.add(cid)
-            stack.extend(children.get(cid, []))
-        return False
-
-    def merge_code_into_code(self, selected):
-        """ Merge the selected code into another code chosen from a list.
-        Reuses merge_codes (the same logic used by drag-and-drop with Ctrl). The source code
-        and all of its descendant sub-codes are excluded from the candidate targets to avoid
-        creating a supercid cycle when merging a code into one of its own sub-codes. <- L
-        Args:
-            selected: QTreeWidgetItem
-        """
-
-        if selected is None or selected.text(1)[0:3] != 'cid':
-            return
-        src_cid = int(selected.text(1)[4:])
-        source_code = next((c for c in self.codes if c['cid'] == src_cid), None)
-        if source_code is None:
-            return
-        # Candidate targets: every code that is not the source nor a descendant of the source.
-        target_list = []
-        for c in self.codes:
-            if not self._code_is_descendant(c['cid'], src_cid):
-                target_list.append({'name': c['name'], 'cid': c['cid']})
-        if not target_list:
-            Message(self.app, _("Merge code into code"),
-                    _("There is no other code to merge into.")).exec()
-            return
-        target_list = sorted(target_list, key=lambda x: x['name'].lower())
-        ui = DialogSelectItems(self.app, target_list, _("Select code to merge into"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        target = ui.get_selected()
-        if not target:
-            return
-        # merge_codes expects the target as a QTreeWidgetItem, so find it in the tree.
-        target_item = None
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node = it.value()
-            if node.text(1) == f"cid:{target['cid']}":
-                target_item = node
-                break
-            it += 1
-        if target_item is None:
-            return
-        self.merge_codes(source_code, target_item)
-
-    def merge_codes(self, item, parent):
-        """ Merge code with another code.
-        Called by item_moved_update_data when a code is moved onto another code.
-                param:
-            item : QTreeWidgetItem
-            parent : QTreeWidgetItem
-        """
-
-        # Check item dropped on itself. Error can occur on Ubuntu 22.04.
-        if item['name'] == parent.text(0):
-            return
-        # Prevent a supercid cycle <- L
-        target_cid = int(parent.text(1).split(':')[1])
-        if self._code_is_descendant(target_cid, item['cid']):
-            Message(self.app, _("Cannot merge code"),
-                    _("Cannot merge a code into itself or one of its own sub-codes.")).exec()
-            return
-        msg = '<p style="font-size:' + str(self.app.settings['fontsize']) + 'px">'
-        msg += _("Merge code: ") + item['name'] + _(" into code: ") + parent.text(0) + '</p>'
-        reply = QtWidgets.QMessageBox.question(self, _('Merge codes'),
-                                               msg, QtWidgets.QMessageBox.StandardButton.Yes,
-                                               QtWidgets.QMessageBox.StandardButton.No)
-        if reply == QtWidgets.QMessageBox.StandardButton.No:
-            return
-        cur = self.app.conn.cursor()
-        old_cid = item['cid']
-        new_cid = int(parent.text(1).split(':')[1])
-        # Always record merge info in target code memo <- L
-        target_code = None
-        for c in self.codes:
-            if c['cid'] == new_cid:
-                target_code = c
-                break
-        if target_code is not None:
-            merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
-            source_memo = item.get('memo', '').strip()
-            source_owner = item.get('owner', self.app.settings['codername'])
-            merged_block = f"\n\n[{_('Merged from code:')} {item['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"
-            if source_memo:
-                merged_block += f"\n{source_memo}"
-            target_memo = target_code.get('memo', '') or ''
-            new_memo = (target_memo + merged_block).strip()
-            cur.execute("update code_name set memo=? where cid=?", [new_memo, new_cid])
-            target_code['memo'] = new_memo
-
-        # Update cid for each coded segment in text, av, image. Delete where there is an Integrity error
-        ct_sql = "select ctid from code_text where cid=?"
-        cur.execute(ct_sql, [old_cid])
-        ct_res = cur.fetchall()
-        try:
-            for ct in ct_res:
-                try:
-                    cur.execute("update code_text set cid=? where ctid=?", [new_cid, ct[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_text where ctid=?", [ct[0]])
-            av_sql = "select avid from code_av where cid=?"
-            cur.execute(av_sql, [old_cid])
-            av_res = cur.fetchall()
-            for av in av_res:
-                try:
-                    cur.execute("update code_av set cid=? where avid=?", [new_cid, av[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_av where avid=?", [av[0]])
-            img_sql = "select imid from code_image where cid=?"
-            cur.execute(img_sql, [old_cid])
-            img_res = cur.fetchall()
-            for img in img_res:
-                try:
-                    cur.execute("update code_image set cid=? where imid=?", [new_cid, img[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_image where imid=?", [img[0]])
-
-            # Re-parent the merged code's sub-codes onto the target code (no orphans). <- L
-            cur.execute("update code_name set supercid=?, catid=null where supercid=?", [new_cid, old_cid])
-            cur.execute("delete from code_name where cid=?", [old_cid, ])
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            logger.debug(e_)
-            self.app.conn.rollback()  # Revert all changes
-            raise
-        self.app.delete_backup = False
-        msg = msg.replace("\n", " ")
-        self.parent_textEdit.append(msg)
-        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
-        self.get_coded_text_update_eventfilter_tooltips()
+        self.update_dialog_codes_and_categories(tables)
         self.display_page_text_objects()
-
-    def add_code(self, catid: int | None = None, code_name: str = "", supercid: int | None = None):
-        """ Use add_item dialog to get new code text. Add_code_name dialog checks for
-        duplicate code name. A random color is selected for the code.
-        New code is added to data and database.
-        Args:
-            catid : None to add to without category, catid to add to category.
-            code_name : String : Used for 'in vivo' coding where name is preset by in vivo text selection.
-            supercid : None, or Integer to add the code as a sub-code of another code. <- L
-        return:
-            True  - new code added, False - code exists or could not be added
-        """
-
-        # Mutual exclusivity: a sub-code never belongs to a category as well. <- L
-        if supercid is not None:
-            catid = None
-        if code_name == "":
-            ui = DialogAddItemName(self.app, self.codes, _("Add new code"), _("Code name"))
-            ui.exec()
-            code_name = ui.get_new_name()
-            if code_name is None:
-                return False
-        code_color = colors[randint(0, len(colors) - 1)]
-        if self.default_new_code_color:
-            code_color = self.default_new_code_color
-        item = {'name': code_name, 'memo': "", 'owner': self.app.settings['codername'],
-                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S"), 'catid': catid,
-                'color': code_color, 'supercid': supercid}
-        cur = self.app.conn.cursor()
-        try:
-            cur.execute("insert into code_name (name,memo,owner,date,catid,color,supercid) values(?,?,?,?,?,?,?)",
-                        (item['name'], item['memo'], item['owner'], item['date'], item['catid'], item['color'],
-                         item['supercid']))
-            self.app.conn.commit()
-            self.app.delete_backup = False
-            cur.execute("select last_insert_rowid()")
-            cid = cur.fetchone()[0]
-            item['cid'] = cid
-            self.parent_textEdit.append(_("New code: ") + item['name'])
-        except sqlite3.IntegrityError:
-            # Can occur with in vivo coding
-            return False
-        self.update_dialog_codes_and_categories(["code_name"])
-        self.get_coded_text_update_eventfilter_tooltips()
-        return True
 
     def update_dialog_codes_and_categories(self, tables: list[str]|None = None):
         """Refresh the local dialog after code/category changes and optionally notify other dialogs.
@@ -2832,7 +2004,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         """
 
         self.get_codes_and_categories()
-        self.fill_tree()
+        self.code_tree.fill_tree()
         self.get_coded_text_update_eventfilter_tooltips()
 
         if self.app.project_events is not None:
@@ -2857,7 +2029,7 @@ class DialogCodePdf(QtWidgets.QWidget):
 
         if code_tree_changed:
             self.get_codes_and_categories()
-            self.fill_tree()
+            self.code_tree.fill_tree()
             if refresh_current_text:
                 self.get_coded_text_update_eventfilter_tooltips()
             return
@@ -2867,278 +2039,18 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
 
-    def add_category(self, supercatid=None):
-        """ When button pressed, add a new category.
-        Note: the addItem dialog does the checking for duplicate category names
-        Args:
-            supercatid : None to add without category, supercatid to add to category. """
-
-        ui = DialogAddItemName(self.app, self.categories, _("Category"), _("Category name"))
-        ui.exec()
-        new_category_name = ui.get_new_name()
-        if new_category_name is None:
-            return
-        item = {'name': new_category_name, 'cid': None, 'memo': "",
-                'owner': self.app.settings['codername'],
-                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")}
-        cur = self.app.conn.cursor()
-        cur.execute("insert into code_cat (name, memo, owner, date, supercatid) values(?,?,?,?,?)",
-                    (item['name'], item['memo'], item['owner'], item['date'], supercatid))
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_cat"])
-        self.app.delete_backup = False
-        self.parent_textEdit.append(_("New category: ") + item['name'])
-
     def delete_category_or_code(self, selected):
         """ Determine if selected item is a code or category before deletion.
+        Category deletion now cascades down the whole branch, matching the
+        Delete category branch option propagated from the text coding page.
         Args:
-            selected : QTreeWidgetItem
+            selected: QTreeWidgetItem
         """
-
         if selected.text(1)[0:3] == 'cat':
-            self.delete_category(selected)
+            self.code_tree.delete_category_branch(selected)
             return  # Avoid error as selected is now None
-        changed_tables = []
-
         if selected.text(1)[0:3] == 'cid':
-            self.delete_code(selected)
-
-    def delete_code(self, selected):
-        """ Find code, remove from database, refresh and code data and fill treeWidget.
-        Args:
-            selected : QTreeWidgetItem
-        """
-
-        # Find the code in the list, check to delete
-        found = -1
-        for i in range(0, len(self.codes)):
-            if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                found = i
-        if found == -1:
-            return
-        code_ = self.codes[found]
-        ui = DialogConfirmDelete(self.app, _("Code: ") + selected.text(0))
-        ok = ui.exec()
-        if not ok:
-            return
-        cur = self.app.conn.cursor()
-        # Re-parent this code's sub-codes so they are not orphaned by the deletion. <- L
-        if code_.get('supercid') is not None:
-            # Was itself a sub-code: lift its children to the grandparent code.
-            cur.execute("update code_name set supercid=? where supercid=?", [code_['supercid'], code_['cid']])
-        else:
-            # Was top level (possibly under a category): move children into that category (or top level).
-            cur.execute("update code_name set supercid=null, catid=? where supercid=?",
-                        [code_['catid'], code_['cid']])
-        cur.execute("delete from code_name where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_text where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_av where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_image where cid=?", [code_['cid'], ])
-        self.app.conn.commit()
-        self.app.delete_backup = False
-        self.parent_textEdit.append(_("Code deleted: ") + code_['name'] + "\n")
-        # Remove from recent codes
-        for item in self.recent_codes:
-            if item['name'] == code_['name']:
-                self.recent_codes.remove(item)
-                break
-        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
-        self.display_page_text_objects()
-
-    def delete_category(self, selected):
-        """ Find category, remove from database, refresh categories and code data
-        and fill treeWidget.
-        Args:
-            selected : QTreeWidgetItem
-        """
-
-        found = -1
-        for i in range(0, len(self.categories)):
-            if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                found = i
-        if found == -1:
-            return
-        category = self.categories[found]
-        ui = DialogConfirmDelete(self.app, _("Category: ") + selected.text(0))
-        ok = ui.exec()
-        if not ok:
-            return
-        cur = self.app.conn.cursor()
-        cur.execute("update code_name set catid=null where catid=?", [category['catid'], ])
-        cur.execute("update code_cat set supercatid=null where catid = ?", [category['catid'], ])
-        cur.execute("delete from code_cat where catid = ?", [category['catid'], ])
-        self.app.conn.commit()
-        # An extra check. Fix 'lost' categories if present.
-        sql = "update code_cat set supercatid=null where supercatid is not null and supercatid not in " \
-              "(select catid from code_cat)"
-        cur.execute(sql)
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
-        self.app.delete_backup = False
-        self.parent_textEdit.append(_("Category deleted: ") + category['name'])
-
-    def add_edit_cat_or_code_memo(self, selected):
-        """ View and edit a memo for a category or code.
-        Args:
-            selected : QTreeWidgetItem
-        """
-
-        changed_tables = None
-        if selected.text(1)[0:3] == 'cid':
-            # Find the code in the list
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            ui = DialogMemo(self.app, _("Memo for Code: ") + self.codes[found]['name'], self.codes[found]['memo'])
-            ui.exec()
-            memo = ui.memo
-            if memo != self.codes[found]['memo']:
-                self.codes[found]['memo'] = memo
-                cur = self.app.conn.cursor()
-                cur.execute("update code_name set memo=? where cid=?", (memo, self.codes[found]['cid']))
-                self.app.conn.commit()
-                self.app.delete_backup = False
-                changed_tables = ["code_name"]
-            if memo == "":
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
-            else:
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
-                self.parent_textEdit.append(_("Memo for code: ") + self.codes[found]['name'])
-
-        if selected.text(1)[0:3] == 'cat':
-            # Find the category in the list
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            ui = DialogMemo(self.app, _("Memo for Category: ") + self.categories[found]['name'],
-                            self.categories[found]['memo'])
-            ui.exec()
-            memo = ui.memo
-            if memo != self.categories[found]['memo']:
-                self.categories[found]['memo'] = memo
-                cur = self.app.conn.cursor()
-                cur.execute("update code_cat set memo=? where catid=?", (memo, self.categories[found]['catid']))
-                self.app.conn.commit()
-                self.app.delete_backup = False
-                changed_tables = ["code_cat"]
-            if memo == "":
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
-            else:
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
-                self.parent_textEdit.append(_("Memo for category: ") + self.categories[found]['name'])
-        self.update_dialog_codes_and_categories(changed_tables)
-
-    def rename_category_or_code(self, selected):
-        """ Rename a code or category.
-        Check that the code or category name is not currently in use.
-        Args:
-            selected : QTreeWidgetItem """
-
-        if selected.text(1)[0:3] == 'cid':
-            found_code = None
-            check_codes = []
-            for code_ in self.codes:
-                if code_['cid'] == int(selected.text(1)[4:]):
-                    found_code = code_
-                else:
-                    check_codes.append(code_)
-            ui = DialogAddItemName(self.app, check_codes, _("Rename code"), _("Code name"))
-            ui.ui.lineEdit.setText(found_code['name'])
-            ui.exec()
-            new_name = ui.get_new_name()
-            if new_name is None or new_name == found_code['name']:
-                return
-
-            # Find the code in the list
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            # Rename in recent codes
-            for item in self.recent_codes:
-                if item['name'] == self.codes[found]['name']:
-                    item['name'] = new_name
-                    break
-            # Update codes list and database
-            cur = self.app.conn.cursor()
-            cur.execute("update code_name set name=? where cid=?", (new_name, self.codes[found]['cid']))
-            self.app.conn.commit()
-            self.app.delete_backup = False
-            old_name = self.codes[found]['name']
-            self.parent_textEdit.append(f'{_("Code renamed:")} {old_name} -> {new_name}')
-            self.update_dialog_codes_and_categories(["code_name"])
-            self.display_page_text_objects()
-            return
-
-        if selected.text(1)[0:3] == 'cat':
-            found_cat = None
-            check_categories = []
-            for category in self.categories:
-                if category['catid'] == int(selected.text(1)[6:]):
-                    found_cat = category
-                else:
-                    check_categories.append(category)
-            ui = DialogAddItemName(self.app, check_categories, _("Rename category"), _("Category name"))
-            ui.ui.lineEdit.setText(found_cat['name'])
-            ui.exec()
-            new_name = ui.get_new_name()
-            if new_name is None or new_name == found_cat['name']:
-                return
-
-            # Find the category in the list
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            # Update category list and database
-            cur = self.app.conn.cursor()
-            cur.execute("update code_cat set name=? where catid=?",
-                        (new_name, self.categories[found]['catid']))
-            self.app.conn.commit()
-            self.app.delete_backup = False
-            old_name = self.categories[found]['name']
-            self.update_dialog_codes_and_categories(["code_cat"])
-            self.parent_textEdit.append(f'{_("Category renamed:")} {old_name} -> {new_name}')
-
-    def change_code_color(self, selected):
-        """ Change the colour of the currently selected code.
-        Args:
-            selected : QTreeWidgetItem """
-
-        cid = int(selected.text(1)[4:])
-        found = -1
-        for i in range(0, len(self.codes)):
-            if self.codes[i]['cid'] == cid:
-                found = i
-        if found == -1:
-            return
-        ui = DialogColorSelect(self.app, self.codes[found])
-        ok = ui.exec()
-        if not ok:
-            return
-        new_color = ui.get_color()
-        if new_color is None:
-            return
-        selected.setBackground(0, QBrush(QColor(new_color), Qt.BrushStyle.SolidPattern))
-        # Update codes list, database and color markings
-        self.codes[found]['color'] = new_color
-        cur = self.app.conn.cursor()
-        cur.execute("update code_name set color=? where cid=?",
-                    (self.codes[found]['color'], self.codes[found]['cid']))
-        self.app.conn.commit()
-        self.app.delete_backup = False
-        self.update_dialog_codes_and_categories(["code_name"])
-        self.display_page_text_objects()
+            self.code_tree.delete_code(selected)
 
     def file_menu(self, position):
         """ Context menu for listWidget files to get to the next file and
@@ -3255,14 +2167,14 @@ class DialogCodePdf(QtWidgets.QWidget):
         res = cur.fetchall()
         file_ids = [r[0] for r in res]
         self.get_files(file_ids)
-        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter file <- L
+        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter file
         self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
 
     def show_files_like(self):
         """ Show files that contain specified filename text.
         If blank, show all files. """
 
-        dialog = QtWidgets.QInputDialog(None)  # use None to make it a standalone floating window <- L
+        dialog = QtWidgets.QInputDialog(None)  # use None to make it a standalone floating window
         dialog.setStyleSheet(f"* {{font-size:{self.app.settings['fontsize']}pt}} ")
         dialog.setWindowTitle(_("Show files like"))
         dialog.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowType.WindowContextHelpButtonHint)
@@ -3275,17 +2187,17 @@ class DialogCodePdf(QtWidgets.QWidget):
         text_ = str(dialog.textValue())
         if text_ == "":
             self.get_files()
-            self.ui.pushButton_clear_filter_file.setVisible(False)  # hide filter button when showing all <- L
+            self.ui.pushButton_clear_filter_file.setVisible(False)  # hide filter button when showing all
             self.ui.pushButton_clear_filter_file.setStyleSheet("")
             return
         cur = self.app.conn.cursor()
-        cur.execute("select id from source where name like ? and "  # restrict to PDF files only <- L
+        cur.execute("select id from source where name like ? and "  # restrict to PDF files only
                     "(lower(substr(mediapath, -4)) = '.pdf')",
                     [f'%{text_}%'])
         res = cur.fetchall()
         file_ids = [r[0] for r in res]
         self.get_files(file_ids)
-        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter file <- L
+        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter file
         self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
 
     def go_to_next_file(self):
@@ -3619,10 +2531,10 @@ class DialogCodePdf(QtWidgets.QWidget):
             # Canonical values of comboBox_fontsize, in the same order as the .ui items.
             # Read by index: the label goes through the translation function and may be
             # localized or corrupt (eo: '0' -> '0 0 0 0' crashed int(); fa: '-2' -> '2'
-            # silently inverted the adjustment).  # <- L
-            adjustment_values = (0, -1, -2, -3, -4)  # <- L
-            adj_index = self.ui.comboBox_fontsize.currentIndex()  # <- L
-            adjustment = adjustment_values[adj_index] if 0 <= adj_index < len(adjustment_values) else 0  # <- L
+            # silently inverted the adjustment).
+            adjustment_values = (0, -1, -2, -3, -4)
+            adj_index = self.ui.comboBox_fontsize.currentIndex()
+            adjustment = adjustment_values[adj_index] if 0 <= adj_index < len(adjustment_values) else 0
             font_size = text_box['fontsize'] + adjustment  # e.g. minus 2 helps stop text overlaps
             if font_size < 4:
                 font_size = 4
@@ -4357,7 +3269,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         cursor_start.setPosition(max(0, code_to_handle['pos0'] - self.file_['start']))
         rect_start = self.ui.plainTextEdit.cursorRect(cursor_start)
         h_start = CodeResizeHandle(self.ui.plainTextEdit, True, code_to_handle, self)
-        # start teardrop tip is at its top-right corner -> shift left by full width <- L
+        # start teardrop tip is at its top-right corner -> shift left by full width
         h_start.move(rect_start.x() - h_start.width(), rect_start.y())
         self.active_handles.append(h_start)
 
@@ -4367,7 +3279,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             min(len(self.ui.plainTextEdit.toPlainText()), code_to_handle['pos1'] - self.file_['start']))
         rect_end = self.ui.plainTextEdit.cursorRect(cursor_end)
         h_end = CodeResizeHandle(self.ui.plainTextEdit, False, code_to_handle, self)
-        # end teardrop tip is at its top-left corner -> align directly to the cursor x <- L
+        # end teardrop tip is at its top-left corner -> align directly to the cursor x
         h_end.move(rect_end.x(), rect_end.y())
         self.active_handles.append(h_end)
 
@@ -4379,7 +3291,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.active_handles = []
 
     # Reposition active handles to their code's current pos0/pos1 without recreating them.
-    # Keeps the handles on screen so start and end can be adjusted repeatedly <- L
+    # Keeps the handles on screen so start and end can be adjusted repeatedly
     def reposition_resize_handles(self):
         """ Re-anchor active handles after a resize so they stay usable. """
         if not getattr(self, 'active_handles', []) or self.file_ is None:
@@ -4448,7 +3360,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             Message(self.app, _("Duplicate Error"),
                     _("This code already exists at this exact location."), "warning").exec()
         # keep handles active after a successful resize so the user can
-        # adjust the other end without re-triggering the action <- L
+        # adjust the other end without re-triggering the action
         self.get_coded_text_update_eventfilter_tooltips()
         self.reposition_resize_handles()
 

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -699,7 +699,9 @@ class DialogCodePdf(QtWidgets.QWidget):
         # until only top categories are left
         sub_categories = copy(categories)
         counter = 0
-        while len(sub_categories) > 0 or counter < 10000:
+        # 'and', not 'or': with 'or' the 10,000 guard never fires (cycle in code_cat =
+        # infinite loop) and healthy data still spins 10,000 empty passes.
+        while len(sub_categories) > 0 and counter < 10000:
             leaf_list = []
             branch_list = []
             for cat in sub_categories:

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -2090,7 +2090,9 @@ class DialogCodeText(QtWidgets.QWidget):
         # until only top categories are left
         sub_categories = copy(categories)
         counter = 0
-        while len(sub_categories) > 0 or counter < 10000:
+        # 'and', not 'or': with 'or' the 10,000 guard never fires (cycle in code_cat =
+        # infinite loop) and healthy data still spins 10,000 empty passes.
+        while len(sub_categories) > 0 and counter < 10000:
             leaf_list = []
             branch_list = []
             for cat in sub_categories:

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -580,7 +580,6 @@ class DialogCodeText(QtWidgets.QWidget):
         self.code_text = []  # List of coded segments for the curent file
         self.undo_deleted_codes = []  # To restore recently deleted codes
         self.attributes = []  # Show selected files using these attributes in list widget
-        self.tree_sort_option = "all asc"  # all asc, all desc, cat then code asc
         self.show_codes_like_filter = ""  # gets filled when text strings are used to show specific code names
         self.show_codes_colour_filter = ""  # gets filled when a code colur is selected
 
@@ -6853,7 +6852,8 @@ class DialogCodeText(QtWidgets.QWidget):
             selected_id = int(code_item.text(1).split(':')[1])
             selected_is_code = True
 
-        ui = DialogAiSearch(self.app, 'search', selected_id, selected_is_code, self.tree_sort_option)
+        # Sort option lives in the shared code tree controller
+        ui = DialogAiSearch(self.app, 'search', selected_id, selected_is_code, self.code_tree.tree_sort_option)
         ret = ui.exec()
         if ret == QtWidgets.QDialog.DialogCode.Accepted:
             self.ai_search_code_name = ui.selected_code_name

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -16,6 +16,8 @@ If not, see <https://www.gnu.org/licenses/>.
 
 Author: Colin Curtain (ccbogel)
 https://github.com/ccbogel/QualCoder
+https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -30,7 +32,6 @@ import logging
 from operator import itemgetter
 import os
 import qtawesome as qta  # see: https://pictogrammers.com/library/mdi/
-from random import randint
 import re
 import sqlite3
 import unicodedata
@@ -44,16 +45,16 @@ from odf.opendocument import OpenDocumentText  # Required for _export_odt_clean 
 from odf import text as odf_text, office as odf_office, dc as odf_dc, style as odf_style  # Need for _export_odt_clean
 from odf.namespaces import OFFICENS, DRAWNS  # Required for _export_odt_clean method
 
-from .add_item_name import DialogAddItemName
 from .ai_agent_prompts import AiAgentPromptsCatalog, prompt_name_and_scope
 from .ai_prompt_library import DialogAiEditPrompts
 from .ai_search_dialog import DialogAiSearch
 from .ai_chat import ai_chat_signal_emitter
 from .code_in_all_files import DialogCodeInAllFiles
-from .color_selector import DialogColorSelect, colour_ranges, colors, TextColor, show_codes_of_colour_range
+from .code_tree import CodeTreeController
+from .color_selector import DialogColorSelect, colour_ranges, TextColor, show_codes_of_colour_range
 from .confirm_delete import DialogConfirmDelete
 from .helpers import Message, DialogGetStartAndEndMarks, ExportDirectoryPathDialog, NumberBar, CodeResizeHandle, \
-    ToolTipEventFilter, init_persistent_tree_header, restore_persistent_tree_widths
+    ToolTipEventFilter, init_persistent_tree_header
 from .GUI.ui_dialog_code_text import Ui_Dialog_code_text
 from .memo import DialogMemo
 from .report_attributes import DialogSelectAttributeParameters
@@ -834,7 +835,20 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.treeWidget.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.InternalMove)
         self.ui.treeWidget.viewport().installEventFilter(self)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
+        # Shared code tree controller: tree loading, common context menu, drag and drop
+        # reparenting, F2-F6 shortcuts and category branch deletion live in code_tree.py,
+        # so the four coding pages no longer duplicate this logic by hand. <- L
+        self.code_tree = CodeTreeController(self.app, self.ui.treeWidget, self)
+        self.ui.treeWidget.customContextMenuRequested.connect(self.code_tree.tree_menu)
+        self.code_tree.fill_counts_callback = self.fill_code_counts_in_tree
+        self.code_tree.coded_files_callback = self.coded_media_dialog
+        self.code_tree.on_codes_deleted = self.remove_deleted_codes_from_recent
+        self.code_tree.on_code_renamed = self.rename_code_in_recent
+        self.code_tree.find_code_callback = self.find_code_in_tree
+        self.code_tree.show_codes_like_callback = self.show_codes_like
+        self.code_tree.show_codes_of_colour_callback = self.show_codes_of_color
+        self.code_tree.codes_changed.connect(self.update_dialog_codes_and_categories)
+
         self.ui.treeWidget.itemPressed.connect(self.fill_code_label_with_selected_code)
         init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodetext_tree_widths')
 
@@ -943,7 +957,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.plainTextEdit.verticalScrollBar().valueChanged.connect(self.coding_margin.update)
 
         self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
-        self.fill_tree()
+        self.code_tree.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
         self.ui.treeWidget.itemExpanded.connect(self.get_collapsed)
@@ -1988,171 +2002,6 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.pushButton_show_codings_prev.setIcon(qta.icon('mdi6.arrow-left', options=[{'scale_factor': 1.3}]))
         self.ui.pushButton_show_codings_next.setIcon(qta.icon('mdi6.arrow-right', options=[{'scale_factor': 1.3}]))
 
-    def fill_tree(self):
-        """ Fill tree widget, top level items are main categories and unlinked codes.
-        The Count column counts the number of times that code has been used by selected coder in selected file.
-        Keep record of non-expanded items, then re-enact these items when treee fill is called again. """
-
-        cats = deepcopy(self.categories)
-        codes = deepcopy(self.codes)
-        self.ui.treeWidget.clear()
-        self.ui.treeWidget.setColumnCount(4)
-        self.ui.treeWidget.setHeaderLabels([_("Name"), _("Id"), _("Memo"), _("Count")])
-        if not self.app.settings['showids']:
-            self.ui.treeWidget.setColumnHidden(1, True)
-        else:
-            self.ui.treeWidget.setColumnHidden(1, False)
-
-        # Add top level categories
-        remove_list = []
-        for c in cats:
-            if c['supercatid'] is None:
-                memo = ""
-                if c['memo'] != "":
-                    memo = _("Memo")
-                top_item = QtWidgets.QTreeWidgetItem([c['name'], 'catid:' + str(c['catid']), memo])
-                top_item.setToolTip(2, c['memo'])
-                top_item.setToolTip(0, '')
-                if len(c['name']) > 52:
-                    top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                    top_item.setToolTip(0, c['name'])
-                self.ui.treeWidget.addTopLevelItem(top_item)
-                if f"catid:{c['catid']}" in self.app.collapsed_categories:
-                    top_item.setExpanded(False)
-                else:
-                    top_item.setExpanded(True)
-                remove_list.append(c)
-        for item in remove_list:
-            cats.remove(item)
-        ''' Add child categories: place each category under its parent. Break when no progress
-         is made (a cycle or a dangling supercatid), then place any leftovers at top level so a
-         category branch is never lost or hidden because of corruption. <- L '''
-        count = 0
-        while cats and count < 10000:
-            remove_list = []
-            for c in cats:
-                it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-                item = it.value()
-                count2 = 0
-                while item and count2 < 10000:  # while there is an item in the list
-                    if item.text(1) == f"catid:{c['supercatid']}":
-                        memo = ""
-                        if c['memo'] != "":
-                            memo = _("Memo")
-                        child = QtWidgets.QTreeWidgetItem([c['name'], f"catid:{c['catid']}", memo])
-                        child.setToolTip(2, c['memo'])
-                        child.setToolTip(0, '')
-                        if len(c['name']) > 52:
-                            child.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                            child.setToolTip(0, c['name'])
-                        item.addChild(child)
-                        if f"catid:{c['catid']}" in self.app.collapsed_categories:
-                            child.setExpanded(False)
-                        else:
-                            child.setExpanded(True)
-                        remove_list.append(c)
-                        break
-                    it += 1
-                    item = it.value()
-                    count2 += 1
-            if not remove_list:
-                break  # cycle or dangling parent: remaining categories placed at top level below
-            for item in remove_list:
-                cats.remove(item)
-            count += 1
-        # Fallback: never lose a category. Any with a missing/cyclic parent goes to top level. <- L
-        for c in cats:
-            memo = _("Memo") if c['memo'] != "" else ""
-            top_item = QtWidgets.QTreeWidgetItem([c['name'], 'catid:' + str(c['catid']), memo])
-            top_item.setToolTip(2, c['memo'])
-            top_item.setToolTip(0, '')
-            if len(c['name']) > 52:
-                top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                top_item.setToolTip(0, c['name'])
-            self.ui.treeWidget.addTopLevelItem(top_item)
-        # Add codes, with sub-code nesting. A code is top level only when it has neither a
-        # parent category (catid) nor a parent code (supercid). The rest are nested under
-        # their category (catid:) or under their parent code (cid:). <- L
-
-        def _make_code_item(code_dict):
-            """ Build a styled tree item for a code. Sub-codes share this styling. <- L """
-            memo_ = _("Memo") if code_dict['memo'] != "" else ""
-            code_item = QtWidgets.QTreeWidgetItem([code_dict['name'], f"cid:{code_dict['cid']}", memo_])
-            code_item.setToolTip(2, code_dict['memo'])
-            code_item.setToolTip(0, '')
-            if len(code_dict['name']) > 52:
-                code_item.setText(0, f"{code_dict['name'][:25]}..{code_dict['name'][-25:]}")
-                code_item.setToolTip(0, code_dict['name'])
-            code_item.setBackground(0, QBrush(QColor(code_dict['color']), Qt.BrushStyle.SolidPattern))
-            code_item.setForeground(0, QBrush(QColor(TextColor(code_dict['color']).recommendation)))
-            code_item.setFlags(
-                Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable |
-                Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsDragEnabled)
-            return code_item
-
-        # Index every node already in the tree (categories) by its id text for O(1) lookup. <- L
-        node_index = {}
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node_index[it.value().text(1)] = it.value()
-            it += 1
-        # Top level codes: no category and no parent code.
-        remove_items = []
-        for c in codes:
-            if c['catid'] is None and c.get('supercid') is None:
-                node = _make_code_item(c)
-                self.ui.treeWidget.addTopLevelItem(node)
-                node_index[f"cid:{c['cid']}"] = node
-                remove_items.append(c)
-        for c in remove_items:
-            codes.remove(c)
-        # Remaining codes: nest under category or parent code. Iterate because a parent code
-        # may itself be a not-yet-placed sub-code. Each pass places every code whose parent
-        # already exists; the loop ends when all are placed or no further progress is possible.
-        count = 0
-        while codes and count < 10000:
-            remove_items = []
-            for c in codes:
-                if c.get('supercid') is not None:
-                    parent_key = f"cid:{c['supercid']}"
-                else:
-                    parent_key = f"catid:{c['catid']}"
-                parent_node = node_index.get(parent_key)
-                if parent_node is not None:
-                    node = _make_code_item(c)
-                    parent_node.addChild(node)
-                    node_index[f"cid:{c['cid']}"] = node
-                    remove_items.append(c)
-            if not remove_items:
-                break  # remaining codes have a missing/cyclic parent: placed at top level below
-            for c in remove_items:
-                codes.remove(c)
-            count += 1
-        # Fallback: never lose a code. Any code with a dangling parent goes to top level. <- L
-        for c in codes:
-            node = _make_code_item(c)
-            self.ui.treeWidget.addTopLevelItem(node)
-            node_index[f"cid:{c['cid']}"] = node
-
-        if self.tree_sort_option == "all asc":
-            self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
-        if self.tree_sort_option == "all desc":
-            self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
-        # Show the code tree expanded from the start: sub-code branches are visible by default;
-        # categories the user had collapsed are restored to their collapsed state. <- L
-        self.ui.treeWidget.expandAll()
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node = it.value()
-            if node.text(1) in self.app.collapsed_categories:
-                node.setExpanded(False)
-            it += 1
-        self.fill_code_counts_in_tree()
-        restore_persistent_tree_widths(
-            self.ui.treeWidget,
-            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
-        )
-
     def fill_code_counts_in_tree(self):
         """ Calculate the frequency of each code and category for this coder and the selected file.
         Add a list item to each code that can be used to display in treeWidget.
@@ -2283,7 +2132,7 @@ class DialogCodeText(QtWidgets.QWidget):
         """ Use to quicky open memo. """
 
         if column == 2:
-            self.add_edit_cat_or_code_memo(item)
+            self.code_tree.add_edit_cat_or_code_memo(item)
 
     def get_codes_and_categories(self):
         """ Called from init, delete category/code.
@@ -2814,9 +2663,9 @@ class DialogCodeText(QtWidgets.QWidget):
             catid = int(tree_item.text(1)[6:])
         codes_copy = deepcopy(self.codes)
         if not in_vivo:
-            self.add_code(catid)
+            self.code_tree.add_code(catid)
         else:
-            self.add_code(catid, code_name=self.ui.plainTextEdit.textCursor().selectedText())
+            self.code_tree.add_code(catid, code_name=self.ui.plainTextEdit.textCursor().selectedText())
         new_code = None
         for c in self.codes:
             if c not in codes_copy:
@@ -3133,393 +2982,6 @@ class DialogCodeText(QtWidgets.QWidget):
         cb = QtWidgets.QApplication.clipboard()
         cb.setText(text)
 
-    def tree_menu(self, position):
-        """ Context menu for treewidget code/category items.
-        Add, rename, memo, move or delete code or category. Change code color.
-        Assign selected text to current hovered code. """
-
-        menu = QtWidgets.QMenu()
-        menu.setStyleSheet(f"QMenu {{font-size:{self.app.settings['fontsize']}pt}} ")
-        selected = self.ui.treeWidget.currentItem()
-        action_add_code_to_category = None
-        action_add_category_to_category = None
-        action_expand_collapse = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_add_code_to_category = menu.addAction(_("Add new code to category"))
-            action_add_category_to_category = menu.addAction(_("Add a new category to category"))
-        action_add_code = menu.addAction(_("Add a new code"))
-        action_add_category = menu.addAction(_("Add a new category"))
-        action_add_subcode = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_add_subcode = menu.addAction(_("Add a new sub-code to code"))
-        action_cat_show_coded_files = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
-            action_cat_show_coded_files = menu.addAction(_("Show coded files"))
-        if selected is not None and selected.text(1)[0:3] == 'cid' and selected.childCount() > 0:
-            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
-        modify_menu = menu.addMenu(_("Modify"))
-        action_rename = modify_menu.addAction(_("Rename F2"))
-        action_edit_memo = modify_menu.addAction(_("View or edit memo F3"))
-        action_merge_category = None
-        action_move_category = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_merge_category = modify_menu.addAction(_("Merge category into category"))
-            action_move_category = modify_menu.addAction(_("Move category under category F6"))
-        action_delete = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_delete = modify_menu.addAction(_("Delete F4"))
-        action_delete_branch = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            # Cascade deletion of the whole branch, only offered for categories.
-            action_delete_branch = modify_menu.addAction(_("Delete category branch F4"))
-        action_color = None
-        action_show_coded_media = None
-        action_move_code = None
-        action_move_multi_codes = None
-        action_merge_code_into_code = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_color = modify_menu.addAction(_("Change code color F5"))
-            action_show_coded_media = menu.addAction(_("Show coded files"))
-            action_move_code = modify_menu.addAction(_("Move code to F6"))
-            action_move_multi_codes = modify_menu.addAction(_("Move multiple codes"))
-            action_merge_code_into_code = modify_menu.addAction(_("Merge code into code"))  # <- L
-        filter_menu = menu.addMenu(_("Filter"))
-        action_show_codes_like = filter_menu.addAction(_("Show codes like") + ": " + self.show_codes_like_filter)
-        action_show_codes_colour = filter_menu.addAction(_("Show codes of colour") + f": {self.show_codes_colour_filter}")
-        sort_menu = menu.addMenu(_("Sort"))
-        action_all_asc = sort_menu.addAction(_("Sort ascending"))
-        action_all_desc = sort_menu.addAction(_("Sort descending"))
-        action_cat_then_code_asc = sort_menu.addAction(_("Sort category then code ascending"))
-
-        action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
-        if action is not None:
-            if action == action_all_asc:
-                self.tree_sort_option = "all asc"
-                self.fill_tree()
-                return
-            if action == action_all_desc:
-                self.tree_sort_option = "all desc"
-                self.fill_tree()
-                return
-            if action == action_cat_then_code_asc:
-                self.tree_sort_option = "cat and code asc"
-                self.fill_tree()
-                return
-            if action == action_show_codes_like:
-                self.show_codes_like()
-                return
-            if action == action_show_codes_colour:
-                self.show_codes_of_color()
-                return
-            if selected is not None and action == action_color:
-                self.change_code_color(selected)
-            if action == action_add_category:
-                self.add_category()
-                return
-            if action == action_add_code:
-                self.add_code()
-                return
-            if action == action_merge_category:
-                catid = int(selected.text(1).split(":")[1])
-                self.merge_category(catid)
-                return
-            if action == action_move_category:
-                catid = int(selected.text(1).split(":")[1])
-                self.move_category(catid)
-                return
-            if action == action_add_code_to_category:
-                catid = int(selected.text(1).split(":")[1])
-                self.add_code(catid)
-                return
-            if action == action_add_subcode and selected is not None:
-                supercid = int(selected.text(1).split(":")[1])  # <- L
-                self.add_code(supercid=supercid)
-                return
-            if action == action_add_category_to_category:
-                catid = int(selected.text(1).split(":")[1])
-                self.add_category(catid)
-                return
-            if selected is not None and action == action_move_code:
-                self.move_code(selected)
-                return
-            if action == action_move_multi_codes:
-                self.move_multiple_codes()
-                return
-            if action == action_merge_code_into_code and selected is not None:
-                self.merge_code_into_code(selected)  # <- L
-                return
-            if action == action_expand_collapse:
-                expand_toggle = not selected.isExpanded()
-                self.recursive_expand_collapse_branch(selected, expand_toggle)
-                return
-            if selected is not None and action == action_rename:
-                self.rename_category_or_code(selected)
-            if selected is not None and action == action_edit_memo:
-                self.add_edit_cat_or_code_memo(selected)
-            if selected is not None and action == action_delete:
-                #self.delete_category_or_code(selected)
-                self.delete_code(selected)
-            if selected is not None and action == action_delete_branch:
-                self.delete_category_branch(selected)
-                return  # Avoid error as selected is now None
-            if action == action_cat_show_coded_files:
-                branch_codes = self.recursive_get_branch_codes(selected, [])
-                DialogCodeInAllFiles(self.app, branch_codes, "File", selected.text(0))
-                self.get_coded_text_update_eventfilter_tooltips()
-                return
-            if selected is not None and action == action_show_coded_media:
-                to_find = int(selected.text(1)[4:])
-                found = next((code for code in self.codes if code['cid'] == to_find), None)
-                if found:
-                    DialogCodeInAllFiles(self.app, found)
-                    self.get_coded_text_update_eventfilter_tooltips()
-
-    def recursive_get_branch_codes(self, item, branch_codes):
-        """ Set all children of this item to be expanded or collapsed.
-        Recurse through all child categories.
-        Args:
-            item: QTreeWidgetItem
-            branch_codes: List of code dictionaries
-        """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            if item.child(i).text(1)[0:3] == "cid":
-                cid = int(item.child(i).text(1)[4:])
-                for code_ in self.codes:
-                    if cid == code_['cid']:
-                        branch_codes.append(code_)
-                        break
-                self.recursive_get_branch_codes(item.child(i), branch_codes)  # also gather sub-codes nested under this code (supercid) <- L
-            if item.child(i).text(1)[0:3] == "cat":
-                self.recursive_get_branch_codes(item.child(i), branch_codes)
-        return branch_codes
-
-    def recursive_expand_collapse_branch(self, item, expand_toggle: bool):
-        """ Set all children of this item to be expanded or collapsed.
-        Recurse through all child categories.
-        Args:
-            item: QTreeWidgetItem
-            expand_toggle: boolean
-        """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            item.setExpanded(expand_toggle)
-            self.recursive_expand_collapse_branch(item.child(i), expand_toggle)
-
-    def recursive_non_merge_item(self, item, no_merge_list):
-        """ Find matching item to be the current selected item.
-        Recurse through any child categories.
-        Tried to use QTreeWidget.finditems - but this did not find matching item text
-        Called by: textEdit recent codes menu option
-        Required for: merge_category()
-        Args:
-            item : QTreeWidgetItem
-            no_merge_list : List of child Category ids (as Strings)
-        """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            if item.child(i).text(1)[0:3] == "cat":
-                no_merge_list.append(item.child(i).text(1)[6:])
-            self.recursive_non_merge_item(item.child(i), no_merge_list)
-        return no_merge_list
-
-    def move_category(self, catid: int):
-        """ Select another category to move this category underneath.
-        Args:
-            catid : Integer category identifier
-        """
-
-        do_not_merge_list = []
-        do_not_merge_list = self.recursive_non_merge_item(self.ui.treeWidget.currentItem(), do_not_merge_list)
-        do_not_merge_list.append(str(catid))
-        do_not_merge_ids_string = f"({','.join(do_not_merge_list)})"
-        sql = "select name, catid, supercatid from code_cat where catid not in "
-        sql += do_not_merge_ids_string + " order by name"
-        cur = self.app.conn.cursor()
-        cur.execute(sql)
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
-        ui = DialogSelectItems(self.app, category_list, _("Move category: Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        current_cat_name = self.ui.treeWidget.currentItem().text(0)
-        if category['name'] == '':
-            cur.execute("update code_cat set supercatid=Null where catid=?", [catid])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → Top level")
-        else:
-            cur.execute("update code_cat set supercatid=? where catid=?", [category['catid'], catid])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → " + category['name'])
-        self.update_dialog_codes_and_categories()
-
-    def merge_category(self, catid: int):
-        """ Select another category to merge this category into.
-        Args:
-            catid : Integer category identifier
-        """
-
-        do_not_merge_list = []
-        do_not_merge_list = self.recursive_non_merge_item(self.ui.treeWidget.currentItem(), do_not_merge_list)
-        do_not_merge_list.append(str(catid))
-        do_not_merge_ids_string = "(" + ",".join(do_not_merge_list) + ")"
-        sql = "select name, catid, supercatid from code_cat where catid not in "
-        sql += do_not_merge_ids_string + " order by name"
-        cur = self.app.conn.cursor()
-        cur.execute(sql)
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        try:
-            # Always record merge info in target category memo  <- L
-            source_cat = None
-            for c in self.categories:
-                if c['catid'] == catid:
-                    source_cat = c
-                    break
-            if source_cat is not None and category['catid'] is not None:
-                target_cat = None
-                for c in self.categories:
-                    if c['catid'] == category['catid']:
-                        target_cat = c
-                        break
-                if target_cat is not None:
-                    merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
-                    source_memo = (source_cat.get('memo', '') or '').strip()
-                    source_owner = source_cat.get('owner', self.app.settings['codername'])
-                    merged_block = f"\n\n[{_('Merged from category:')} {source_cat['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"  
-                    if source_memo:
-                        merged_block += f"\n{source_memo}"
-                    target_memo = target_cat.get('memo', '') or ''
-                    new_memo = (target_memo + merged_block).strip()
-                    cur.execute("update code_cat set memo=? where catid=?", [new_memo, category['catid']])
-                    target_cat['memo'] = new_memo 
-            for code in self.codes:
-                if code['catid'] == catid:
-                    cur.execute("update code_name set catid=? where catid=?", [category['catid'], catid])
-            cur.execute("delete from code_cat where catid=?", [catid])
-            for cat in self.categories:
-                if cat['supercatid'] == catid:
-                    cur.execute("update code_cat set supercatid=? where supercatid=?", [category['catid'], catid])
-            # Clear any orphan supercatids
-            sql = "select supercatid from code_cat where supercatid not in (select catid from code_cat)"
-            cur.execute(sql)
-            orphans = cur.fetchall()
-            sql = "update code_cat set supercatid=Null where supercatid=?"
-            for orphan in orphans:
-                cur.execute(sql, [orphan[0]])
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            self.app.conn.rollback()  # Revert all changes
-            self.update_dialog_codes_and_categories()
-            raise
-        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
-
-    def move_multiple_codes(self):
-        """ Move multiple codes to another category. """
-
-        cur = self.app.conn.cursor()
-        cur.execute("select code_name.name, code_cat.name, cid from code_name left join code_cat on "
-                    "code_cat.catid=code_name.catid order by upper(code_cat.name) asc, upper(code_name.name) asc")
-        res = cur.fetchall()
-        code_list = []
-        for r in res:
-            name = r[0]
-            if r[1] is not None:
-                name = r[1] + " ← " + r[0]
-            code_list.append({'name': name, 'cid': r[2]})
-        ui = DialogSelectItems(self.app, code_list, _("Select codes"), "multi")
-        ok = ui.exec()
-        if not ok:
-            return
-        selected_codes = ui.get_selected()
-        cur.execute("select name, catid from code_cat order by upper(name)")
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        for s in selected_codes:
-            # Moving to a category (or to blank) removes any sub-code nesting.
-            cur.execute("update code_name set catid=?, supercid=null where cid=?", [category['catid'], s['cid']])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Code moved.") + s['name'].replace(" ← ", "/") + " → " + category['name'])
-        self.update_dialog_codes_and_categories(["code_name"])
-
-    def move_code(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Move code to another category, or code or to none (top level).
-        Uses a list selection which represents the codes tree.
-        Args:
-            selected : QTreeWidgetItem
-         """
-
-        items_list = [{'name': " ", 'catid': -1, 'cid': -1}]  # Default blank item
-        iterator = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while iterator.value():
-            can_append = True
-            item = iterator.value()
-            depth = 0
-            current = item
-            # Get depth and if circular reference present
-            while current.parent() is not None:
-                if current.text(1) == selected.text(1):
-                    can_append = False
-                current = current.parent()
-                depth += 1
-            prefix = ""
-            if depth > 0:
-                prefix = "  " * (depth - 1) * 2 + "└─"  # U2514 U2500
-            name = prefix + item.text(0)
-            cid = -1
-            catid = -1
-            if "cid" in item.text(1):
-                cid = int(item.text(1)[4:])
-            else:
-                catid = int(item.text(1)[6:])
-                name += " " + _("[CATEGORY]")
-            # Check the same item is not the same selected item
-            if item.text(1) == selected.text(1) and item.text(2) == selected.text(2):
-                can_append = False
-            memo = item.toolTip(2)
-            if can_append:
-                items_list.append({'name': name, 'catid': catid, 'cid': cid, 'memo': memo})
-            iterator +=1
-        ui = DialogSelectItems(self.app, items_list, _("Move code: Select blank or category or code"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        destination = ui.get_selected()
-        #print(destination)
-        selected_cid = int(selected.text(1)[4:])
-        cur = self.app.conn.cursor()
-        if destination['catid'] == -1 and destination['cid'] == -1:  # move to top level
-            cur.execute("update code_name set catid=null, supercid=null where cid=?", [selected_cid])
-        elif destination['cid'] > 0:  # Move under another code
-            cur.execute("update code_name set catid=null, supercid=? where cid=?", [destination['cid'], selected_cid])
-        else:  # Move under a category
-            cur.execute("update code_name set catid=?, supercid=null where cid=?", [destination['catid'], selected_cid])
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_name"])
-
     def show_memos(self):
         """ Show all memos for coded text in dialog. """
 
@@ -3818,31 +3280,9 @@ class DialogCodeText(QtWidgets.QWidget):
             if key == QtCore.Qt.Key.Key_0:
                 self.help()
                 return
-        # Tree widget menu items keys F2 - F6
+        # Tree widget menu item keys F2 - F6, handled by the shared controller. <- L
         if self.ui.treeWidget.hasFocus():
-            selected = self.ui.treeWidget.currentItem()
-            if selected is None:
-                return
-            if key == QtCore.Qt.Key.Key_F2:
-                self.rename_category_or_code(selected)
-                return
-            if key == QtCore.Qt.Key.Key_F3:
-                self.add_edit_cat_or_code_memo(selected)
-                return
-            if key == QtCore.Qt.Key.Key_F4:
-                if selected.text(1)[0:3] == 'cat':
-                    self.delete_category_branch(selected)
-                else:
-                    self.delete_code(selected)
-                return
-            if key == QtCore.Qt.Key.Key_F5 and selected.text(1)[0:3] == 'cid':
-                self.change_code_color(selected)
-                return
-            if key == QtCore.Qt.Key.Key_F6:
-                if selected.text(1)[0:3] == 'cat':
-                    self.move_category(selected)
-                else:
-                    self.move_code(selected)
+            if self.code_tree.handle_key_press(event):
                 return
 
         if not self.ui.plainTextEdit.hasFocus():
@@ -3889,7 +3329,7 @@ class DialogCodeText(QtWidgets.QWidget):
             selected = self.ui.treeWidget.currentItem()
             if selected is not None and selected.text(1)[0:3] == 'cat':
                 supercatid = int(selected.text(1)[6:])
-            self.add_category(supercatid)
+            self.code_tree.add_category(supercatid)
             return
         # Hide unHide top groupbox
         if key == QtCore.Qt.Key.Key_H:
@@ -4750,7 +4190,7 @@ class DialogCodeText(QtWidgets.QWidget):
                 item = self.ui.treeWidget.currentItem()
                 # event position is QPointF, itemAt requires toPoint
                 parent = self.ui.treeWidget.itemAt(event.position().toPoint())
-                self.item_moved_update_data(item, parent)
+                self.code_tree.item_moved_update_data(item, parent)
                 return True
             # Scroll the tree when dragged item it as top or bottom edges
             if event.type() == QtCore.QEvent.Type.DragMove:
@@ -5069,312 +4509,38 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.pushButton_show_codings_next.setToolTip(tt)
         self.get_coded_text_update_eventfilter_tooltips()
 
-    def item_moved_update_data(self, item:QtWidgets.QTreeWidgetItem, parent:QtWidgets.QTreeWidgetItem):
-        """ Called from drop event in treeWidget view port.
-        identify code or category to move.
-        Also merge codes if one code is dropped on another code.
+    def coded_media_dialog(self, code_or_codes, title=""):
+        """ Show all coded files for a code, or for a list of branch codes.
+        Called from the shared code tree controller. <- L
         Args:
-            item : QTreeWidgetItem
-            parent : QTreeWidgetItem
+            code_or_codes: Dictionary of one code, or List of code dictionaries for a category branch
+            title: String, category name when showing a branch
         """
-
-        # Find the category in the list
-        if item.text(1)[0:3] == 'cat':
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(item.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            if parent is None:
-                self.categories[found]['supercatid'] = None
-            else:
-                if parent.text(1).split(':')[0] == 'cid':
-                    # Parent is a code, a category cannot nest under a code.
-                    return
-                supercatid = int(parent.text(1).split(':')[1])
-                if supercatid == self.categories[found]['catid']:
-                    # Cannot be its own parent.
-                    return
-                # Guard against cycles: moving a category under one of its own sub-categories
-                # would make the branch disappear and corrupt the tree. <- L
-                if self._category_is_descendant(supercatid, self.categories[found]['catid']):
-                    Message(self.app, _("Cannot move category"),
-                            _("Cannot move a category under one of its own sub-categories.")).exec()
-                    return
-                self.categories[found]['supercatid'] = supercatid
-            cur = self.app.conn.cursor()
-            cur.execute("update code_cat set supercatid=? where catid=?",
-                        [self.categories[found]['supercatid'], self.categories[found]['catid']])
-            self.app.conn.commit()
-            self.update_dialog_codes_and_categories(["code_cat"])
-            self.app.delete_backup = False
-            return
-
-        # find the code in the list
-        if item.text(1)[0:3] == 'cid':
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(item.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            if parent is None:
-                # Move code to top level: clear both parents. <- L
-                self.codes[found]['catid'] = None
-                self.codes[found]['supercid'] = None
-            else:
-                if parent.text(1).split(':')[0] == 'cid':
-                    parent_cid = int(parent.text(1).split(':')[1])
-                    # Ctrl held while dropping a code on a code merges (previous behaviour);
-                    # otherwise the code is nested as a sub-code. <- L
-                    ctrl = bool(QtWidgets.QApplication.keyboardModifiers() &
-                                QtCore.Qt.KeyboardModifier.ControlModifier)
-                    if ctrl:
-                        self.merge_codes(self.codes[found], parent)
-                        return
-                    if parent_cid == self.codes[found]['cid']:
-                        return  # cannot nest under itself
-                    if self._code_is_descendant(parent_cid, self.codes[found]['cid']):
-                        Message(self.app, _("Cannot nest code"),
-                                _("Cannot move a code under one of its own sub-codes.")).exec()
-                        return
-                    # Nest as a sub-code (mutually exclusive with category). <- L
-                    self.codes[found]['supercid'] = parent_cid
-                    self.codes[found]['catid'] = None
-                else:
-                    # Dropped onto a category. <- L
-                    catid = int(parent.text(1).split(':')[1])
-                    self.codes[found]['catid'] = catid
-                    self.codes[found]['supercid'] = None
-
-            cur = self.app.conn.cursor()
-            cur.execute("update code_name set catid=?, supercid=? where cid=?",
-                        [self.codes[found]['catid'], self.codes[found].get('supercid'),
-                         self.codes[found]['cid']])
-            self.app.conn.commit()
-            self.app.delete_backup = False
-            self.update_dialog_codes_and_categories(["code_name"])
-
-    def _code_is_descendant(self, candidate_cid, ancestor_cid):
-        """ Return True if candidate_cid is ancestor_cid or one of its descendant sub-codes.
-        Used to prevent cycles when nesting a code under another code. <- L """
-        if candidate_cid == ancestor_cid:
-            return True
-        children = {}
-        for c in self.codes:
-            sup = c.get('supercid')
-            if sup is not None:
-                children.setdefault(sup, []).append(c['cid'])
-        stack = list(children.get(ancestor_cid, []))
-        seen = set()
-        while stack:
-            cid = stack.pop()
-            if cid == candidate_cid:
-                return True
-            if cid in seen:
-                continue
-            seen.add(cid)
-            stack.extend(children.get(cid, []))
-        return False
-
-    def _category_is_descendant(self, candidate_catid, ancestor_catid):
-        """ Return True if candidate_catid is ancestor_catid or one of its descendant
-        sub-categories. Used to prevent cycles when moving a category under another. <- L """
-        if candidate_catid == ancestor_catid:
-            return True
-        children = {}
-        for c in self.categories:
-            sup = c.get('supercatid')
-            if sup is not None:
-                children.setdefault(sup, []).append(c['catid'])
-        stack = list(children.get(ancestor_catid, []))
-        seen = set()
-        while stack:
-            catid = stack.pop()
-            if catid == candidate_catid:
-                return True
-            if catid in seen:
-                continue
-            seen.add(catid)
-            stack.extend(children.get(catid, []))
-        return False
-
-    def merge_code_into_code(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Merge the selected code into another code chosen from a list.
-        Reuses merge_codes (the same logic used by drag-and-drop with Ctrl). The source code
-        and all of its descendant sub-codes are excluded from the candidate targets to avoid
-        creating a supercid cycle when merging a code into one of its own sub-codes. <- L
-        Args:
-            selected: QTreeWidgetItem
-        """
-
-        if selected is None or selected.text(1)[0:3] != 'cid':
-            return
-        src_cid = int(selected.text(1)[4:])
-        source_code = next((c for c in self.codes if c['cid'] == src_cid), None)
-        if source_code is None:
-            return
-        # Candidate targets: every code that is not the source nor a descendant of the source.
-        target_list = []
-        for c in self.codes:
-            if not self._code_is_descendant(c['cid'], src_cid):
-                target_list.append({'name': c['name'], 'cid': c['cid']})
-        if not target_list:
-            Message(self.app, _("Merge code into code"),
-                    _("There is no other code to merge into.")).exec()
-            return
-        target_list = sorted(target_list, key=lambda x: x['name'].lower())
-        ui = DialogSelectItems(self.app, target_list, _("Select code to merge into"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        target = ui.get_selected()
-        if not target:
-            return
-        # merge_codes expects the target as a QTreeWidgetItem, so find it in the tree.
-        target_item = None
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node = it.value()
-            if node.text(1) == f"cid:{target['cid']}":
-                target_item = node
-                break
-            it += 1
-        if target_item is None:
-            return
-        self.merge_codes(source_code, target_item)
-
-    def merge_codes(self, item, parent:QtWidgets.QTreeWidgetItem):
-        """ Merge code with another code.
-        Called by item_moved_update_data when a code is moved onto another code.
-        code text unique(cid,fid,pos0,pos1, owner)
-        Args:
-            item : Dictionary code item
-            parent : QTreeWidgetItem
-        """
-
-        # Check item dropped on itself
-        if item['name'] == parent.text(0):
-            return
-        # Prevent a supercid cycle <- L
-        target_cid = int(parent.text(1).split(':')[1])
-        if self._code_is_descendant(target_cid, item['cid']):
-            Message(self.app, _("Cannot merge code"),
-                    _("Cannot merge a code into itself or one of its own sub-codes.")).exec()
-            return            
-        msg = '<p style="font-size:' + str(self.app.settings['fontsize']) + 'px">'
-        msg += _("Merge code: ") + item['name'] + _(" into code: ") + parent.text(0) + '</p>'
-        reply = QtWidgets.QMessageBox.question(self, _('Merge codes'),
-                                               msg, QtWidgets.QMessageBox.StandardButton.Yes,
-                                               QtWidgets.QMessageBox.StandardButton.No)
-        if reply == QtWidgets.QMessageBox.StandardButton.No:
-            return
-        cur = self.app.conn.cursor()
-        old_cid = item['cid']
-        new_cid = int(parent.text(1).split(':')[1])
-        # Always record merge info in target code memo  <- L
-        target_code = None
-        for c in self.codes:
-            if c['cid'] == new_cid:
-                target_code = c
-                break
-        if target_code is not None:
-            merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
-            source_memo = item.get('memo', '').strip()
-            source_owner = item.get('owner', self.app.settings['codername'])
-            merged_block = f"\n\n[{_('Merged from code:')} {item['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"  
-            if source_memo:
-                merged_block += f"\n{source_memo}"
-            target_memo = target_code.get('memo', '') or ''
-            new_memo = (target_memo + merged_block).strip()
-            cur.execute("update code_name set memo=? where cid=?", [new_memo, new_cid])
-            target_code['memo'] = new_memo
-        # Update cid for each coded segment in text, av, image. Delete where there is an Integrity error
-        ct_sql = "select ctid from code_text where cid=?"
-        cur.execute(ct_sql, [old_cid])
-        ct_res = cur.fetchall()
-        try:
-            for ct in ct_res:
-                try:
-                    cur.execute("update code_text set cid=? where ctid=?", [new_cid, ct[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_text where ctid=?", [ct[0]])
-            av_sql = "select avid from code_av where cid=?"
-            cur.execute(av_sql, [old_cid])
-            av_res = cur.fetchall()
-            for av in av_res:
-                try:
-                    cur.execute("update code_av set cid=? where avid=?", [new_cid, av[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_av where avid=?", [av[0]])
-            img_sql = "select imid from code_image where cid=?"
-            cur.execute(img_sql, [old_cid])
-            img_res = cur.fetchall()
-            for img in img_res:
-                try:
-                    cur.execute("update code_image set cid=? where imid=?", [new_cid, img[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_image where imid=?", [img[0]])
-            # Re-parent the merged code's sub-codes onto the target code (no orphans). <- L
-            cur.execute("update code_name set supercid=?, catid=null where supercid=?", [new_cid, old_cid])
-            cur.execute("delete from code_name where cid=?", [old_cid, ])
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            self.app.conn.rollback()  # Revert all changes
-            raise
-        self.app.delete_backup = False
-        msg = msg.replace("\n", " ")
-        self.parent_textEdit.append(msg)
-        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
+        if isinstance(code_or_codes, list):
+            DialogCodeInAllFiles(self.app, code_or_codes, "File", title)
+        else:
+            DialogCodeInAllFiles(self.app, code_or_codes)
         self.get_coded_text_update_eventfilter_tooltips()
 
-    def add_code(self, catid:int|None=None, code_name:str="", supercid:int|None=None):
-        """ Use add_item dialog to get new code text. Add_code_name dialog checks for
-        duplicate code name. A random color is selected for the code, or a color has been pre-set by the user.
-        New code is added to data and database.
+    def remove_deleted_codes_from_recent(self, cids):
+        """ Drop deleted codes from the recent codes list. Called from the
+        shared code tree controller after code or branch deletion. <- L
         Args:
-            catid : None to add code without category, catid Integer to add to category.
-            code_name : String : Used for 'in vivo' coding where name is preset by in vivo text selection.
-            supercid : None, or Integer to add the code as a sub-code of another code. <- L
-        Returns:
-            True  - new code added, False - code exists or could not be added
+            cids: List of Integer code ids
         """
+        self.recent_codes = [c for c in self.recent_codes if c['cid'] not in cids]
 
-        # Mutual exclusivity: a sub-code never belongs to a category as well. <- L
-        if supercid is not None:
-            catid = None
-        if code_name == "":
-            ui = DialogAddItemName(self.app, self.codes, _("Add new code"), _("Code name"))
-            ui.exec()
-            code_name = ui.get_new_name()
-            if code_name is None:
-                return False
-        code_color = colors[randint(0, len(colors) - 1)]
-        if self.default_new_code_color:
-            code_color = self.default_new_code_color
-        item = {'name': code_name, 'memo': "", 'owner': self.app.settings['codername'],
-                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S"), 'catid': catid,
-                'color': code_color, 'supercid': supercid}
-        cur = self.app.conn.cursor()
-        try:
-            cur.execute("insert into code_name (name,memo,owner,date,catid,color,supercid) values(?,?,?,?,?,?,?)",
-                        (item['name'], item['memo'], item['owner'], item['date'], item['catid'], item['color'],
-                         item['supercid']))
-            self.app.conn.commit()
-            self.app.delete_backup = False
-            cur.execute("select last_insert_rowid()")
-            cid = cur.fetchone()[0]
-            item['cid'] = cid
-            self.parent_textEdit.append(_("New code: ") + item['name'])
-        except sqlite3.IntegrityError:
-            # Can occur with in vivo coding
-            print("in vivo coding. Code already exists")
-            return False
-        self.update_dialog_codes_and_categories(["code_name"])
-        self.get_coded_text_update_eventfilter_tooltips()
-        return True
+    def rename_code_in_recent(self, old_name, new_name):
+        """ Rename a code inside the recent codes list. Called from the
+        shared code tree controller after a code rename. <- L
+        Args:
+            old_name: String
+            new_name: String
+        """
+        for item in self.recent_codes:
+            if item['name'] == old_name:
+                item['name'] = new_name
+                break
 
     def update_dialog_codes_and_categories(self, tables: list[str]|None = None):
         """Refresh the local dialog after code/category changes and optionally notify other dialogs.
@@ -5385,7 +4551,7 @@ class DialogCodeText(QtWidgets.QWidget):
         """
 
         self.get_codes_and_categories()
-        self.fill_tree()
+        self.code_tree.fill_tree()
         self.unlight()
         self.highlight()
         self.get_coded_text_update_eventfilter_tooltips()
@@ -5418,414 +4584,8 @@ class DialogCodeText(QtWidgets.QWidget):
             return
         # codes or categories have changed, so refresh all
         self.get_codes_and_categories()
-        self.fill_tree()
+        self.code_tree.fill_tree()
         self.get_coded_text_update_eventfilter_tooltips()
-
-    def add_category(self, supercatid:int|None=None):
-        """ Add a new category.
-        Note: the addItem dialog does the checking for duplicate category names
-        Args:
-            supercatid : None to add without category, supercatid to add to category. """
-
-        ui = DialogAddItemName(self.app, self.categories, _("Category"), _("Category name"))
-        ui.exec()
-        new_category_name = ui.get_new_name()
-        if new_category_name is None:
-            return
-        item = {'name': new_category_name, 'cid': None, 'memo': "",
-                'owner': self.app.settings['codername'],
-                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")}
-        cur = self.app.conn.cursor()
-        cur.execute("insert into code_cat (name, memo, owner, date, supercatid) values(?,?,?,?,?)",
-                    (item['name'], item['memo'], item['owner'], item['date'], supercatid))
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_cat"])
-        self.app.delete_backup = False
-        self.parent_textEdit.append(_("New category: ") + item['name'])
-
-    '''def delete_category_or_code(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Determine if selected item is a code or category before deletion.
-        Args:
-            selected: QTreeWidgetItem
-        """
-
-        if selected.text(1)[0:3] == 'cat':
-            self.delete_category(selected)
-            return  # Avoid error as selected is now None
-        if selected.text(1)[0:3] == 'cid':
-            self.delete_code(selected)'''
-
-    def delete_code(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Find code, remove from database, refresh and code data and fill treeWidget.
-        Args:
-            selected: QTreeWidgetItem
-        """
-
-        # Find the code in the list, check to delete
-        found = -1
-        for i in range(0, len(self.codes)):
-            if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                found = i
-        if found == -1:
-            return
-        code_ = self.codes[found]
-        ui = DialogConfirmDelete(self.app, _("Code: ") + selected.text(0))
-        ok = ui.exec()
-        if not ok:
-            return
-        cur = self.app.conn.cursor()
-        # Re-parent this code's sub-codes so they are not orphaned by the deletion. <- L
-        if code_.get('supercid') is not None:
-            # Was itself a sub-code: lift its children to the grandparent code.
-            cur.execute("update code_name set supercid=? where supercid=?", [code_['supercid'], code_['cid']])
-        else:
-            # Was top level (possibly under a category): move children into that category (or top level).
-            cur.execute("update code_name set supercid=null, catid=? where supercid=?",
-                        [code_['catid'], code_['cid']])
-        cur.execute("delete from code_name where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_text where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_av where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_image where cid=?", [code_['cid'], ])
-        self.app.conn.commit()
-        self.app.delete_backup = False
-        self.parent_textEdit.append(_("Code deleted: ") + code_['name'] + "\n")
-        # Remove from recent codes
-        for item in self.recent_codes:
-            if item['name'] == code_['name']:
-                self.recent_codes.remove(item)
-                break
-        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
-        self.app.delete_backup = False
-
-    '''def delete_category(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Find category, remove from database, refresh categories and code data
-        and fill treeWidget.
-        Args:
-            selected: QTreeWidgetItem
-        """
-
-        found = -1
-        for i in range(0, len(self.categories)):
-            if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                found = i
-        if found == -1:
-            return
-        category = self.categories[found]
-        ui = DialogConfirmDelete(self.app, _("Category: ") + selected.text(0))
-        ok = ui.exec()
-        if not ok:
-            return
-        cur = self.app.conn.cursor()
-        cur.execute("update code_name set catid=null where catid=?", [category['catid'], ])
-        cur.execute("update code_cat set supercatid=null where catid = ?", [category['catid'], ])
-        cur.execute("delete from code_cat where catid = ?", [category['catid'], ])
-        self.app.conn.commit()
-        # An extra check. Fix 'lost' categories if present.
-        sql = "update code_cat set supercatid=null where supercatid is not null and supercatid not in " \
-              "(select catid from code_cat)"
-        cur.execute(sql)
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
-        self.app.delete_backup = False
-        self.parent_textEdit.append(_("Category deleted: ") + category['name'])'''
-
-    def get_branch_catids_and_cids(self, catid:int):
-        """ Gather every category and code that hangs below a category, including the category itself.
-        Sub-codes (supercid) nested under branch codes are collected too.
-        Read straight from the database, not from the cached self.codes / self.categories, so a
-        stale dialog snapshot can never delete or miss the wrong rows.
-        Iterative walk, so cyclic or malformed data cannot cause infinite recursion. <- L
-        Args:
-            catid: Integer, category id of the branch root
-        Returns:
-            Tuple: (list of category ids, list of code ids)
-        """
-
-        cur = self.app.conn.cursor()
-        cur.execute("select catid, supercatid from code_cat")
-        db_cats = cur.fetchall()
-        cur.execute("select cid, catid, supercid from code_name")
-        db_codes = cur.fetchall()
-        catids = [catid]
-        i = 0
-        while i < len(catids):
-            for cat_ in db_cats:
-                if cat_[1] == catids[i] and cat_[0] not in catids:
-                    catids.append(cat_[0])
-            i += 1
-        cids = []
-        for code_ in db_codes:
-            if code_[1] in catids and code_[0] not in cids:
-                cids.append(code_[0])
-        i = 0
-        while i < len(cids):
-            for code_ in db_codes:
-                if code_[2] == cids[i] and code_[0] not in cids:
-                    cids.append(code_[0])
-            i += 1
-        return catids, cids
-
-    def delete_category_branch(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Delete a category and everything underneath it: nested categories, codes, sub-codes
-        and all the codings (text, audio/video, image) made with those codes.
-        Unlike Delete, which only removes the category and re-parents its contents,
-        this cascades down the whole branch. All writes run in a single transaction. <- L
-        Args:
-            selected: QTreeWidgetItem
-        """
-
-        if selected is None or selected.text(1)[0:3] != 'cat':
-            return
-        cur = self.app.conn.cursor()
-        cur.execute("select catid, name from code_cat where catid=?", [int(selected.text(1)[6:]), ])
-        res = cur.fetchone()
-        if res is None:  # Already deleted elsewhere, the tree item is stale
-            self.update_dialog_codes_and_categories([])
-            return
-        category = {'catid': res[0], 'name': res[1]}
-        catids, cids = self.get_branch_catids_and_cids(category['catid'])
-        # Count the codings that will be lost, so the user knows what is at stake.
-        # One grouped scan per table, instead of one query per code. <- L
-        cids_set = set(cids)
-        codings = 0
-        for table in ("code_text", "code_av", "code_image"):
-            cur.execute(f"select cid, count(*) from {table} group by cid")
-            for row in cur.fetchall():
-                if row[0] in cids_set:
-                    codings += row[1]
-        msg = _("Category branch") + ": " + category['name'] + "\n\n"
-        msg += _("All categories and codes under this category will also be deleted.") + "\n"
-        msg += _("All codings made with these codes across all files will be deleted.") + "\n\n"
-        msg += _("Categories to delete") + f": {len(catids)}\n"
-        msg += _("Codes to delete") + f": {len(cids)}\n"
-        msg += _("Codings to delete") + f": {codings}\n\n"
-        msg += _("Make a project backup first. This action cannot be undone.")
-        ui = DialogConfirmDelete(self.app, msg)
-        # Cancel is the default button here, so a stray Enter cannot wipe out the branch. <- L
-        button_box = ui.findChild(QtWidgets.QDialogButtonBox)
-        if button_box is not None:
-            ok_button = button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
-            cancel_button = button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
-            if ok_button is not None:
-                ok_button.setAutoDefault(False)
-                ok_button.setDefault(False)
-            if cancel_button is not None:
-                cancel_button.setAutoDefault(True)
-                cancel_button.setDefault(True)
-                cancel_button.setFocus()
-        ok = ui.exec()
-        if not ok:
-            return
-        try:
-            for cid in cids:
-                cur.execute("delete from code_text where cid=?", [cid, ])
-                cur.execute("delete from code_av where cid=?", [cid, ])
-                cur.execute("delete from code_image where cid=?", [cid, ])
-                cur.execute("delete from code_name where cid=?", [cid, ])
-                # Saved graphs: drop nodes and links pointing at this code, so that a reused
-                # cid cannot silently re-bind an old graph node to an unrelated code. <- L
-                cur.execute("delete from gr_cdct_text_item where cid=?", [cid, ])
-                cur.execute("delete from gr_cdct_line_item where fromcid=? or tocid=?", [cid, cid])
-                cur.execute("delete from gr_free_line_item where fromcid=? or tocid=?", [cid, cid])
-            for cat_id in catids:
-                cur.execute("delete from code_cat where catid=?", [cat_id, ])
-                cur.execute("delete from gr_cdct_text_item where catid=?", [cat_id, ])
-                cur.execute("delete from gr_cdct_line_item where fromcatid=? or tocatid=?", [cat_id, cat_id])
-                cur.execute("delete from gr_free_line_item where fromcatid=? or tocatid=?", [cat_id, cat_id])
-            # Drop the deleted codes from the stored recently used codes. <- L
-            cur.execute("select recently_used_codes from project")
-            recent_res = cur.fetchone()
-            if recent_res is not None and recent_res[0]:
-                keep = []
-                for token in recent_res[0].split():
-                    try:
-                        if int(token) in cids:
-                            continue
-                    except ValueError:
-                        pass
-                    keep.append(token)
-                cur.execute("update project set recently_used_codes=?", [" ".join(keep), ])
-            # Extra check. Clear any dangling references left behind by the deletion. <- L
-            cur.execute("update code_cat set supercatid=null where supercatid is not null and supercatid not in "
-                        "(select catid from code_cat)")
-            cur.execute("update code_name set catid=null where catid is not null and catid not in "
-                        "(select catid from code_cat)")
-            cur.execute("update code_name set supercid=null where supercid is not null and supercid not in "
-                        "(select cid from code_name)")
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            self.app.conn.rollback()  # Revert all changes
-            self.update_dialog_codes_and_categories([])
-            raise
-        # Remove the deleted codes from the recent codes list
-        self.recent_codes = [c for c in self.recent_codes if c['cid'] not in cids]
-        self.app.delete_backup = False
-        msg = _("Category branch deleted") + ": " + category['name'] + ". "
-        msg += _("Categories") + f": {len(catids)}, " + _("Codes") + f": {len(cids)}, "
-        msg += _("Codings") + f": {codings}"
-        self.parent_textEdit.append(msg)
-        self.update_dialog_codes_and_categories(["code_cat", "code_name", "code_text", "code_av", "code_image"])
-
-    def add_edit_cat_or_code_memo(self, selected:QtWidgets.QTreeWidgetItem):
-        """ View and edit a memo for a category or code.
-        Args:
-            selected: QTreeWidgetItem
-        """
-
-        changed_tables = []
-        if selected.text(1)[0:3] == 'cid':
-            # Find the code in the list
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            ui = DialogMemo(self.app, _("Memo for Code: ") + self.codes[found]['name'], self.codes[found]['memo'])
-            ui.exec()
-            memo = ui.memo
-            if memo != self.codes[found]['memo']:
-                self.codes[found]['memo'] = memo
-                cur = self.app.conn.cursor()
-                cur.execute("update code_name set memo=? where cid=?", (memo, self.codes[found]['cid']))
-                self.app.conn.commit()
-                self.app.delete_backup = False
-                changed_tables = ["code_name"]
-            if memo == "":
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
-            else:
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
-                self.parent_textEdit.append(_("Memo for code: ") + self.codes[found]['name'])
-
-        if selected.text(1)[0:3] == 'cat':
-            # Find the category in the list
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            ui = DialogMemo(self.app, _("Memo for Category: ") + self.categories[found]['name'],
-                            self.categories[found]['memo'])
-            ui.exec()
-            memo = ui.memo
-            if memo != self.categories[found]['memo']:
-                self.categories[found]['memo'] = memo
-                cur = self.app.conn.cursor()
-                cur.execute("update code_cat set memo=? where catid=?", (memo, self.categories[found]['catid']))
-                self.app.conn.commit()
-                self.app.delete_backup = False
-                changed_tables = ["code_cat"]
-            if memo == "":
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
-            else:
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
-                self.parent_textEdit.append(_("Memo for category: ") + self.categories[found]['name'])
-        self.update_dialog_codes_and_categories(changed_tables)
-
-    def rename_category_or_code(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Rename a code or category.
-        Check that the code or category name is not currently in use.
-        Args:
-            selected : QTreeWidgetItem """
-
-        if selected.text(1)[0:3] == 'cid':
-            found_code = None
-            check_codes = []
-            for code_ in self.codes:
-                if code_['cid'] == int(selected.text(1)[4:]):
-                    found_code = code_
-                else:
-                    check_codes.append(code_)
-            ui = DialogAddItemName(self.app, check_codes, _("Rename code"), _("Code name"))
-            ui.ui.lineEdit.setText(found_code['name'])
-            ui.exec()
-            new_name = ui.get_new_name()
-            if new_name is None or new_name == found_code['name']:
-                return
-            # Find the code in the list
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            # Rename in recent codes
-            for item in self.recent_codes:
-                if item['name'] == self.codes[found]['name']:
-                    item['name'] = new_name
-                    break
-            # Update codes list and database
-            cur = self.app.conn.cursor()
-            cur.execute("update code_name set name=? where cid=?", (new_name, self.codes[found]['cid']))
-            self.app.conn.commit()
-            self.app.delete_backup = False
-            old_name = self.codes[found]['name']
-            self.parent_textEdit.append(_("Code renamed from: ") + f"{old_name} --> {new_name}")
-            self.update_dialog_codes_and_categories(["code_name"])
-            return
-
-        if selected.text(1)[0:3] == 'cat':
-            found_cat = None
-            check_categories = []
-            for category in self.categories:
-                if category['catid'] == int(selected.text(1)[6:]):
-                    found_cat = category
-                else:
-                    check_categories.append(category)
-            ui = DialogAddItemName(self.app, check_categories, _("Rename category"), _("Category name"))
-            ui.ui.lineEdit.setText(found_cat['name'])
-            ui.exec()
-            new_name = ui.get_new_name()
-            if new_name is None or new_name == found_cat['name']:
-                return
-
-            # Find the category in the list
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            # Update category list and database
-            cur = self.app.conn.cursor()
-            cur.execute("update code_cat set name=? where catid=?",
-                        (new_name, self.categories[found]['catid']))
-            self.app.conn.commit()
-            self.app.delete_backup = False
-            old_name = self.categories[found]['name']
-            self.update_dialog_codes_and_categories(["code_cat"])
-            self.parent_textEdit.append(_("Category renamed from: ") + f"{old_name} --> {new_name}")
-
-    def change_code_color(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Change the colour of the currently selected code.
-        Args:
-            selected : QTreeWidgetItem """
-
-        cid = int(selected.text(1)[4:])
-        found = -1
-        for i in range(0, len(self.codes)):
-            if self.codes[i]['cid'] == cid:
-                found = i
-        if found == -1:
-            return
-        ui = DialogColorSelect(self.app, self.codes[found])
-        ok = ui.exec()
-        if not ok:
-            return
-        new_color = ui.get_color()
-        if new_color is None:
-            return
-        selected.setBackground(0, QBrush(QColor(new_color), Qt.BrushStyle.SolidPattern))
-        # Update codes list, database and color markings
-        self.codes[found]['color'] = new_color
-        cur = self.app.conn.cursor()
-        cur.execute("update code_name set color=? where cid=?",
-                    (self.codes[found]['color'], self.codes[found]['cid']))
-        self.app.conn.commit()
-        self.app.delete_backup = False
-        self.update_dialog_codes_and_categories(["code_name"])
 
     def file_menu(self, position):
         """ Context menu for listWidget files to get to the next file and

--- a/src/qualcoder/code_tree.py
+++ b/src/qualcoder/code_tree.py
@@ -1,0 +1,1425 @@
+# -*- coding: utf-8 -*-
+
+"""
+This file is part of QualCoder.
+
+QualCoder is free software: you can redistribute it and/or modify it under the
+terms of the GNU Lesser General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+QualCoder is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with QualCoder.
+If not, see <https://www.gnu.org/licenses/>.
+
+Author: Colin Curtain (ccbogel)
+https://github.com/ccbogel/QualCoder
+https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
+https://qualcoder.org/
+"""
+
+from copy import deepcopy
+import datetime
+import logging
+from random import randint
+import sqlite3
+
+from PyQt6 import QtCore, QtWidgets
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QBrush, QColor
+
+from .add_item_name import DialogAddItemName
+from .color_selector import DialogColorSelect, colors, TextColor
+from .confirm_delete import DialogConfirmDelete
+from .helpers import Message, restore_persistent_tree_widths
+from .memo import DialogMemo
+from .select_items import DialogSelectItems
+
+logger = logging.getLogger(__name__)
+
+
+class CodeTreeController(QtCore.QObject):
+    """ Owns the shared behaviour of a codes treeWidget for a coding dialog. """
+
+    # Built QMenu and selected QTreeWidgetItem (or None), emitted before menu.exec
+    menu_requested = QtCore.pyqtSignal(object, object)
+    # List of changed database table names, emitted after every database change
+    codes_changed = QtCore.pyqtSignal(list)
+
+    def __init__(self, app, tree_widget: QtWidgets.QTreeWidget, host,
+                 column_width_factors: dict | None = None):
+        """
+        Args:
+            app: App object
+            tree_widget: the QTreeWidget the dialog already owns (from its .ui)
+            host: the coding dialog, see the host protocol in the module docstring
+            column_width_factors: Dictionary or None, passed to restore_persistent_tree_widths
+        """
+
+        super().__init__(tree_widget)
+        self.app = app
+        self.tree = tree_widget
+        self.host = host
+        self.tree_sort_option = "all asc"  # all asc, all desc, cat and code asc
+        self.column_width_factors = column_width_factors if column_width_factors is not None \
+            else {0: 0.70, 2: 0.15, 3: 0.15}
+        # Optional host callbacks, see module docstring
+        self.fill_counts_callback = None
+        self.coded_files_callback = None
+        self.find_code_callback = None
+        self.show_codes_like_callback = None
+        self.show_codes_of_colour_callback = None
+        self.on_codes_deleted = None
+        self.on_code_renamed = None
+
+    # Live views over the host's data, never cached here.
+    @property
+    def codes(self) -> list:
+        return self.host.codes
+
+    @property
+    def categories(self) -> list:
+        return self.host.categories
+
+    @property
+    def parent_textEdit(self):
+        return self.host.parent_textEdit
+
+    # tree fill
+
+    def fill_tree(self):
+        """ Fill tree widget, top level items are main categories and unlinked codes.
+        The Count column is filled by the host through fill_counts_callback.
+        Keep record of non-expanded items, then re-enact these items when tree fill is called again. """
+
+        cats = deepcopy(self.categories)
+        codes = deepcopy(self.codes)
+        self.tree.clear()
+        self.tree.setColumnCount(4)
+        self.tree.setHeaderLabels([_("Name"), _("Id"), _("Memo"), _("Count")])
+        if not self.app.settings['showids']:
+            self.tree.setColumnHidden(1, True)
+        else:
+            self.tree.setColumnHidden(1, False)
+
+        # Add top level categories
+        remove_list = []
+        for c in cats:
+            if c['supercatid'] is None:
+                memo = ""
+                if c['memo'] != "":
+                    memo = _("Memo")
+                top_item = QtWidgets.QTreeWidgetItem([c['name'], 'catid:' + str(c['catid']), memo])
+                top_item.setToolTip(2, c['memo'])
+                top_item.setToolTip(0, '')
+                if len(c['name']) > 52:
+                    top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
+                    top_item.setToolTip(0, c['name'])
+                self.tree.addTopLevelItem(top_item)
+                if f"catid:{c['catid']}" in self.app.collapsed_categories:
+                    top_item.setExpanded(False)
+                else:
+                    top_item.setExpanded(True)
+                remove_list.append(c)
+        for item in remove_list:
+            cats.remove(item)
+        ''' Add child categories: place each category under its parent. Break when no progress
+         is made (a cycle or a dangling supercatid), then place any leftovers at top level so a
+         category branch is never lost or hidden because of corruption. '''
+        count = 0
+        while cats and count < 10000:
+            remove_list = []
+            for c in cats:
+                it = QtWidgets.QTreeWidgetItemIterator(self.tree)
+                item = it.value()
+                count2 = 0
+                while item and count2 < 10000:  # while there is an item in the list
+                    if item.text(1) == f"catid:{c['supercatid']}":
+                        memo = ""
+                        if c['memo'] != "":
+                            memo = _("Memo")
+                        child = QtWidgets.QTreeWidgetItem([c['name'], f"catid:{c['catid']}", memo])
+                        child.setToolTip(2, c['memo'])
+                        child.setToolTip(0, '')
+                        if len(c['name']) > 52:
+                            child.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
+                            child.setToolTip(0, c['name'])
+                        item.addChild(child)
+                        if f"catid:{c['catid']}" in self.app.collapsed_categories:
+                            child.setExpanded(False)
+                        else:
+                            child.setExpanded(True)
+                        remove_list.append(c)
+                        break
+                    it += 1
+                    item = it.value()
+                    count2 += 1
+            if not remove_list:
+                break  # cycle or dangling parent: remaining categories placed at top level below
+            for item in remove_list:
+                cats.remove(item)
+            count += 1
+        # Fallback: never lose a category. Any with a missing/cyclic parent goes to top level.
+        for c in cats:
+            memo = _("Memo") if c['memo'] != "" else ""
+            top_item = QtWidgets.QTreeWidgetItem([c['name'], 'catid:' + str(c['catid']), memo])
+            top_item.setToolTip(2, c['memo'])
+            top_item.setToolTip(0, '')
+            if len(c['name']) > 52:
+                top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
+                top_item.setToolTip(0, c['name'])
+            self.tree.addTopLevelItem(top_item)
+        # Add codes, with sub-code nesting. A code is top level only when it has neither a
+        # parent category (catid) nor a parent code (supercid). The rest are nested under
+        # their category (catid:) or under their parent code (cid:).
+
+        def _make_code_item(code_dict):
+            """ Build a styled tree item for a code. Sub-codes share this styling. """
+            memo_ = _("Memo") if code_dict['memo'] != "" else ""
+            code_item = QtWidgets.QTreeWidgetItem([code_dict['name'], f"cid:{code_dict['cid']}", memo_])
+            code_item.setToolTip(2, code_dict['memo'])
+            code_item.setToolTip(0, '')
+            if len(code_dict['name']) > 52:
+                code_item.setText(0, f"{code_dict['name'][:25]}..{code_dict['name'][-25:]}")
+                code_item.setToolTip(0, code_dict['name'])
+            code_item.setBackground(0, QBrush(QColor(code_dict['color']), Qt.BrushStyle.SolidPattern))
+            code_item.setForeground(0, QBrush(QColor(TextColor(code_dict['color']).recommendation)))
+            code_item.setFlags(
+                Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable |
+                Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsDragEnabled)
+            return code_item
+
+        # Index every node already in the tree (categories) by its id text for O(1) lookup.
+        node_index = {}
+        it = QtWidgets.QTreeWidgetItemIterator(self.tree)
+        while it.value():
+            node_index[it.value().text(1)] = it.value()
+            it += 1
+        # Top level codes: no category and no parent code.
+        remove_items = []
+        for c in codes:
+            if c['catid'] is None and c.get('supercid') is None:
+                node = _make_code_item(c)
+                self.tree.addTopLevelItem(node)
+                node_index[f"cid:{c['cid']}"] = node
+                remove_items.append(c)
+        for c in remove_items:
+            codes.remove(c)
+        # Remaining codes: nest under category or parent code. Iterate because a parent code
+        # may itself be a not-yet-placed sub-code. Each pass places every code whose parent
+        # already exists; the loop ends when all are placed or no further progress is possible.
+        count = 0
+        while codes and count < 10000:
+            remove_items = []
+            for c in codes:
+                if c.get('supercid') is not None:
+                    parent_key = f"cid:{c['supercid']}"
+                else:
+                    parent_key = f"catid:{c['catid']}"
+                parent_node = node_index.get(parent_key)
+                if parent_node is not None:
+                    node = _make_code_item(c)
+                    parent_node.addChild(node)
+                    node_index[f"cid:{c['cid']}"] = node
+                    remove_items.append(c)
+            if not remove_items:
+                break  # remaining codes have a missing/cyclic parent: placed at top level below
+            for c in remove_items:
+                codes.remove(c)
+            count += 1
+        # Fallback: never lose a code. Any code with a dangling parent goes to top level.
+        for c in codes:
+            node = _make_code_item(c)
+            self.tree.addTopLevelItem(node)
+            node_index[f"cid:{c['cid']}"] = node
+
+        if self.tree_sort_option == "all asc":
+            self.tree.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
+        if self.tree_sort_option == "all desc":
+            self.tree.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
+        # Show the code tree expanded from the start: sub-code branches are visible by default;
+        # categories the user had collapsed are restored to their collapsed state.
+        self.tree.expandAll()
+        it = QtWidgets.QTreeWidgetItemIterator(self.tree)
+        while it.value():
+            node = it.value()
+            if node.text(1) in self.app.collapsed_categories:
+                node.setExpanded(False)
+            it += 1
+        if self.fill_counts_callback is not None:
+            self.fill_counts_callback()
+        restore_persistent_tree_widths(
+            self.tree,
+            default_width_factors=self.column_width_factors
+        )
+
+    # context menu
+
+    def tree_menu(self, position):
+        """
+        Context menu for treewidget code/category items.
+        Add, rename, memo, move or delete code or category. Change code color.
+        Emits menu_requested(menu, selected) before showing, so the host dialog
+        can append its own page-specific entries.
+        """
+
+        menu = QtWidgets.QMenu()
+        menu.setStyleSheet(f"QMenu {{font-size:{self.app.settings['fontsize']}pt}} ")
+        selected = self.tree.currentItem()
+        action_add_code_to_category = None
+        action_add_category_to_category = None
+        action_expand_collapse = None
+        if selected is not None and selected.text(1)[0:3] == 'cat':
+            action_add_code_to_category = menu.addAction(_("Add new code to category"))
+            action_add_category_to_category = menu.addAction(_("Add a new category to category"))
+        action_add_code = menu.addAction(_("Add a new code"))
+        action_add_category = menu.addAction(_("Add a new category"))
+        action_add_subcode = None
+        if selected is not None and selected.text(1)[0:3] == 'cid':
+            action_add_subcode = menu.addAction(_("Add a new sub-code to code"))
+        action_cat_show_coded_files = None
+        if selected is not None and selected.text(1)[0:3] == 'cat':
+            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
+            if self.coded_files_callback is not None:
+                action_cat_show_coded_files = menu.addAction(_("Show coded files"))
+        if selected is not None and selected.text(1)[0:3] == 'cid' and selected.childCount() > 0:
+            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
+        modify_menu = menu.addMenu(_("Modify"))
+        action_rename = modify_menu.addAction(_("Rename F2"))
+        action_edit_memo = modify_menu.addAction(_("View or edit memo F3"))
+        action_merge_category = None
+        action_move_category = None
+        if selected is not None and selected.text(1)[0:3] == 'cat':
+            action_merge_category = modify_menu.addAction(_("Merge category into category"))
+            action_move_category = modify_menu.addAction(_("Move category under category F6"))
+        action_delete = None
+        if selected is not None and selected.text(1)[0:3] == 'cid':
+            action_delete = modify_menu.addAction(_("Delete F4"))
+        action_delete_branch = None
+        if selected is not None and selected.text(1)[0:3] == 'cat':
+            # Cascade deletion of the whole branch, only offered for categories.
+            action_delete_branch = modify_menu.addAction(_("Delete category branch F4"))
+        action_color = None
+        action_show_coded_media = None
+        action_move_code = None
+        action_move_multi_codes = None
+        action_merge_code_into_code = None
+        if selected is not None and selected.text(1)[0:3] == 'cid':
+            action_color = modify_menu.addAction(_("Change code color F5"))
+            if self.coded_files_callback is not None:
+                action_show_coded_media = menu.addAction(_("Show coded files"))
+            action_move_code = modify_menu.addAction(_("Move code to F6"))
+            action_move_multi_codes = modify_menu.addAction(_("Move multiple codes"))
+            action_merge_code_into_code = modify_menu.addAction(_("Merge code into code"))
+        action_find_code = None
+        if self.find_code_callback is not None:
+            action_find_code = menu.addAction(_("Find code"))
+        action_show_codes_like = None
+        action_show_codes_colour = None
+        if self.show_codes_like_callback is not None or self.show_codes_of_colour_callback is not None:
+            filter_menu = menu.addMenu(_("Filter"))
+            if self.show_codes_like_callback is not None:
+                like_filter = getattr(self.host, 'show_codes_like_filter', "")
+                action_show_codes_like = filter_menu.addAction(_("Show codes like") + ": " + like_filter)
+            if self.show_codes_of_colour_callback is not None:
+                colour_filter = getattr(self.host, 'show_codes_colour_filter', "")
+                action_show_codes_colour = filter_menu.addAction(_("Show codes of colour") + f": {colour_filter}")
+        sort_menu = menu.addMenu(_("Sort"))
+        action_all_asc = sort_menu.addAction(_("Sort ascending"))
+        action_all_desc = sort_menu.addAction(_("Sort descending"))
+        action_cat_then_code_asc = sort_menu.addAction(_("Sort category then code ascending"))
+
+        # Let the host dialog add its own entries before the menu is shown.
+        self.menu_requested.emit(menu, selected)
+
+        action = menu.exec(self.tree.mapToGlobal(position))
+        if action is None:
+            return
+        if action == action_all_asc:
+            self.tree_sort_option = "all asc"
+            self.fill_tree()
+            return
+        if action == action_all_desc:
+            self.tree_sort_option = "all desc"
+            self.fill_tree()
+            return
+        if action == action_cat_then_code_asc:
+            self.tree_sort_option = "cat and code asc"
+            self.fill_tree()
+            return
+        if action == action_show_codes_like:
+            self.show_codes_like_callback()
+            return
+        if action == action_show_codes_colour:
+            self.show_codes_of_colour_callback()
+            return
+        if action == action_find_code:
+            self.find_code_callback()
+            return
+        if selected is not None and action == action_color:
+            self.change_code_color(selected)
+        if action == action_add_category:
+            self.add_category()
+            return
+        if action == action_add_code:
+            self.add_code()
+            return
+        if action == action_merge_category:
+            catid = int(selected.text(1).split(":")[1])
+            self.merge_category(catid)
+            return
+        if action == action_move_category:
+            catid = int(selected.text(1).split(":")[1])
+            self.move_category(catid)
+            return
+        if action == action_add_code_to_category:
+            catid = int(selected.text(1).split(":")[1])
+            self.add_code(catid)
+            return
+        if action == action_add_subcode and selected is not None:
+            supercid = int(selected.text(1).split(":")[1])
+            self.add_code(supercid=supercid)
+            return
+        if action == action_add_category_to_category:
+            catid = int(selected.text(1).split(":")[1])
+            self.add_category(catid)
+            return
+        if selected is not None and action == action_move_code:
+            self.move_code(selected)
+            return
+        if action == action_move_multi_codes:
+            self.move_multiple_codes()
+            return
+        if action == action_merge_code_into_code and selected is not None:
+            self.merge_code_into_code(selected)
+            return
+        if action == action_expand_collapse:
+            expand_toggle = not selected.isExpanded()
+            self.recursive_expand_collapse_branch(selected, expand_toggle)
+            return
+        if selected is not None and action == action_rename:
+            self.rename_category_or_code(selected)
+        if selected is not None and action == action_edit_memo:
+            self.add_edit_cat_or_code_memo(selected)
+        if selected is not None and action == action_delete:
+            self.delete_code(selected)
+        if selected is not None and action == action_delete_branch:
+            self.delete_category_branch(selected)
+            return  # Avoid error as selected is now None
+        if action == action_cat_show_coded_files:
+            branch_codes = self.recursive_get_branch_codes(selected, [])
+            self.coded_files_callback(branch_codes, selected.text(0))
+            return
+        if selected is not None and action == action_show_coded_media:
+            to_find = int(selected.text(1)[4:])
+            found = next((code for code in self.codes if code['cid'] == to_find), None)
+            if found:
+                self.coded_files_callback(found, "")
+
+    # keyboard and drag/drop
+
+    def handle_key_press(self, event) -> bool:
+        """
+        Tree widget menu item keys F2 - F6. Called from the host keyPressEvent
+        when the treeWidget has focus. Returns True when the key was handled.
+        Args:
+            event: QKeyEvent
+        """
+
+        selected = self.tree.currentItem()
+        if selected is None:
+            return False
+        key = event.key()
+        if key == QtCore.Qt.Key.Key_F2:
+            self.rename_category_or_code(selected)
+            return True
+        if key == QtCore.Qt.Key.Key_F3:
+            self.add_edit_cat_or_code_memo(selected)
+            return True
+        if key == QtCore.Qt.Key.Key_F4:
+            if selected.text(1)[0:3] == 'cat':
+                self.delete_category_branch(selected)
+            else:
+                self.delete_code(selected)
+            return True
+        if key == QtCore.Qt.Key.Key_F5 and selected.text(1)[0:3] == 'cid':
+            self.change_code_color(selected)
+            return True
+        if key == QtCore.Qt.Key.Key_F6:
+            if selected.text(1)[0:3] == 'cat':
+                self.move_category(int(selected.text(1).split(":")[1]))
+            else:
+                self.move_code(selected)
+            return True
+        return False
+
+    def handle_tree_viewport_event(self, event) -> bool:
+        """
+        Drop and DragMove handling for the treeWidget viewport. Available for hosts
+        that prefer delegating the whole viewport branch of their eventFilter.
+        Args:
+            event: QEvent
+        Returns:
+            True when the event was consumed
+        """
+
+        if event.type() == QtCore.QEvent.Type.Drop:
+            item = self.tree.currentItem()
+            # event position is QPointF, itemAt requires toPoint
+            parent = self.tree.itemAt(event.position().toPoint())
+            self.item_moved_update_data(item, parent)
+            return True
+        # Scroll the tree when the dragged item is at the top or bottom edges
+        if event.type() == QtCore.QEvent.Type.DragMove:
+            vsb = self.tree.verticalScrollBar()
+            top = self.tree.visualRect(self.tree.indexAt(self.tree.rect().topLeft())).bottom()
+            bottom = self.tree.viewport().height()
+            y = event.position().toPoint().y()
+            if y < top + 8:  # Margin of 8
+                vsb.setValue(vsb.value() - 1)
+            if y > bottom - 8:  # Margin of 8
+                vsb.setValue(vsb.value() + 1)
+            return True
+        return False
+
+    def item_moved_update_data(self, item: QtWidgets.QTreeWidgetItem, parent: QtWidgets.QTreeWidgetItem):
+        """
+        Called from drop event in treeWidget view port.
+        Identify code or category to move.
+        Also merge codes if one code is dropped on another code with Ctrl held.
+        Args:
+            item : QTreeWidgetItem
+            parent : QTreeWidgetItem
+        """
+
+        if item is None:
+            return
+        # Find the category in the list
+        if item.text(1)[0:3] == 'cat':
+            found = -1
+            for i in range(0, len(self.categories)):
+                if self.categories[i]['catid'] == int(item.text(1)[6:]):
+                    found = i
+            if found == -1:
+                return
+            if parent is None:
+                self.categories[found]['supercatid'] = None
+            else:
+                if parent.text(1).split(':')[0] == 'cid':
+                    # Parent is a code, a category cannot nest under a code.
+                    return
+                supercatid = int(parent.text(1).split(':')[1])
+                if supercatid == self.categories[found]['catid']:
+                    # Cannot be its own parent.
+                    return
+                # Guard against cycles: moving a category under one of its own sub-categories
+                # would make the branch disappear and corrupt the tree.
+                if self.category_is_descendant(supercatid, self.categories[found]['catid']):
+                    Message(self.app, _("Cannot move category"),
+                            _("Cannot move a category under one of its own sub-categories.")).exec()
+                    return
+                self.categories[found]['supercatid'] = supercatid
+            cur = self.app.conn.cursor()
+            cur.execute("update code_cat set supercatid=? where catid=?",
+                        [self.categories[found]['supercatid'], self.categories[found]['catid']])
+            self.app.conn.commit()
+            self.app.delete_backup = False
+            self.codes_changed.emit(["code_cat"])
+            return
+
+        # Find the code in the list
+        if item.text(1)[0:3] == 'cid':
+            found = -1
+            for i in range(0, len(self.codes)):
+                if self.codes[i]['cid'] == int(item.text(1)[4:]):
+                    found = i
+            if found == -1:
+                return
+            if parent is None:
+                # Move code to top level: clear both parents.
+                self.codes[found]['catid'] = None
+                self.codes[found]['supercid'] = None
+            else:
+                if parent.text(1).split(':')[0] == 'cid':
+                    parent_cid = int(parent.text(1).split(':')[1])
+                    # Ctrl held while dropping a code on a code merges (previous behaviour);
+                    # otherwise the code is nested as a sub-code.
+                    ctrl = bool(QtWidgets.QApplication.keyboardModifiers() &
+                                QtCore.Qt.KeyboardModifier.ControlModifier)
+                    if ctrl:
+                        self.merge_codes(self.codes[found], parent)
+                        return
+                    if parent_cid == self.codes[found]['cid']:
+                        return  # cannot nest under itself
+                    if self.code_is_descendant(parent_cid, self.codes[found]['cid']):
+                        Message(self.app, _("Cannot nest code"),
+                                _("Cannot move a code under one of its own sub-codes.")).exec()
+                        return
+                    # Nest as a sub-code (mutually exclusive with category).
+                    self.codes[found]['supercid'] = parent_cid
+                    self.codes[found]['catid'] = None
+                else:
+                    # Dropped onto a category.
+                    catid = int(parent.text(1).split(':')[1])
+                    self.codes[found]['catid'] = catid
+                    self.codes[found]['supercid'] = None
+
+            cur = self.app.conn.cursor()
+            cur.execute("update code_name set catid=?, supercid=? where cid=?",
+                        [self.codes[found]['catid'], self.codes[found].get('supercid'),
+                         self.codes[found]['cid']])
+            self.app.conn.commit()
+            self.app.delete_backup = False
+            self.codes_changed.emit(["code_name"])
+
+    def code_is_descendant(self, candidate_cid, ancestor_cid) -> bool:
+        """
+        Return True if candidate_cid is ancestor_cid or one of its descendant sub-codes.
+        Used to prevent cycles when nesting a code under another code.
+        """
+        if candidate_cid == ancestor_cid:
+            return True
+        children = {}
+        for c in self.codes:
+            sup = c.get('supercid')
+            if sup is not None:
+                children.setdefault(sup, []).append(c['cid'])
+        stack = list(children.get(ancestor_cid, []))
+        seen = set()
+        while stack:
+            cid = stack.pop()
+            if cid == candidate_cid:
+                return True
+            if cid in seen:
+                continue
+            seen.add(cid)
+            stack.extend(children.get(cid, []))
+        return False
+
+    def category_is_descendant(self, candidate_catid, ancestor_catid) -> bool:
+        """
+        Return True if candidate_catid is ancestor_catid or one of its descendant
+        sub-categories. Used to prevent cycles when moving a category under another.
+        """
+        if candidate_catid == ancestor_catid:
+            return True
+        children = {}
+        for c in self.categories:
+            sup = c.get('supercatid')
+            if sup is not None:
+                children.setdefault(sup, []).append(c['catid'])
+        stack = list(children.get(ancestor_catid, []))
+        seen = set()
+        while stack:
+            catid = stack.pop()
+            if catid == candidate_catid:
+                return True
+            if catid in seen:
+                continue
+            seen.add(catid)
+            stack.extend(children.get(catid, []))
+        return False
+
+    # recursive tree helpers
+
+    def recursive_get_branch_codes(self, item, branch_codes) -> list:
+        """
+        Gather all code dictionaries below this item, including sub-codes.
+        Recurse through all child categories.
+        Args:
+            item: QTreeWidgetItem
+            branch_codes: List of code dictionaries
+        """
+
+        child_count = item.childCount()
+        for i in range(child_count):
+            if item.child(i).text(1)[0:3] == "cid":
+                cid = int(item.child(i).text(1)[4:])
+                for code_ in self.codes:
+                    if cid == code_['cid']:
+                        branch_codes.append(code_)
+                        break
+                self.recursive_get_branch_codes(item.child(i), branch_codes)  # also gather sub-codes nested under this code (supercid)
+            if item.child(i).text(1)[0:3] == "cat":
+                self.recursive_get_branch_codes(item.child(i), branch_codes)
+        return branch_codes
+
+    def recursive_expand_collapse_branch(self, item, expand_toggle: bool):
+        """
+        Set all children of this item to be expanded or collapsed.
+        Recurse through all child categories.
+        Args:
+            item: QTreeWidgetItem
+            expand_toggle: boolean
+        """
+
+        child_count = item.childCount()
+        for i in range(child_count):
+            item.setExpanded(expand_toggle)
+            self.recursive_expand_collapse_branch(item.child(i), expand_toggle)
+
+    def recursive_non_merge_item(self, item, no_merge_list) -> list:
+        """
+        Find child category ids below the item, as strings.
+        Required for merge_category() and move_category().
+        Args:
+            item : QTreeWidgetItem
+            no_merge_list : List of child Category ids (as Strings)
+        """
+
+        child_count = item.childCount()
+        for i in range(child_count):
+            if item.child(i).text(1)[0:3] == "cat":
+                no_merge_list.append(item.child(i).text(1)[6:])
+            self.recursive_non_merge_item(item.child(i), no_merge_list)
+        return no_merge_list
+
+    # add
+
+    def add_code(self, catid: int | None = None, code_name: str = "", supercid: int | None = None) -> bool:
+        """
+        Use add_item dialog to get new code text. Add_code_name dialog checks for
+        duplicate code name. A random color is selected for the code, or a color has been pre-set by the user.
+        New code is added to data and database.
+        Args:
+            catid : None to add code without category, catid Integer to add to category.
+            code_name : String : Used for 'in vivo' coding where name is preset by in vivo text selection.
+            supercid : None, or Integer to add the code as a sub-code of another code.
+        Returns:
+            True  - new code added, False - code exists or could not be added
+        """
+
+        # Mutual exclusivity: a sub-code never belongs to a category as well.
+        if supercid is not None:
+            catid = None
+        if code_name == "":
+            ui = DialogAddItemName(self.app, self.codes, _("Add new code"), _("Code name"))
+            ui.exec()
+            code_name = ui.get_new_name()
+            if code_name is None:
+                return False
+        code_color = colors[randint(0, len(colors) - 1)]
+        default_color = getattr(self.host, 'default_new_code_color', None)
+        if default_color:
+            code_color = default_color
+        item = {'name': code_name, 'memo': "", 'owner': self.app.settings['codername'],
+                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S"), 'catid': catid,
+                'color': code_color, 'supercid': supercid}
+        cur = self.app.conn.cursor()
+        try:
+            cur.execute("insert into code_name (name,memo,owner,date,catid,color,supercid) values(?,?,?,?,?,?,?)",
+                        (item['name'], item['memo'], item['owner'], item['date'], item['catid'], item['color'],
+                         item['supercid']))
+            self.app.conn.commit()
+            self.app.delete_backup = False
+            cur.execute("select last_insert_rowid()")
+            cid = cur.fetchone()[0]
+            item['cid'] = cid
+            self.parent_textEdit.append(_("New code: ") + item['name'])
+        except sqlite3.IntegrityError:
+            # Can occur with in vivo coding
+            logger.debug("in vivo coding. Code already exists")
+            return False
+        self.codes_changed.emit(["code_name"])
+        return True
+
+    def add_category(self, supercatid: int | None = None):
+        """
+        Add a new category.
+        Note: the addItem dialog does the checking for duplicate category names
+        Args:
+            supercatid : None to add without category, supercatid to add to category.
+        """
+
+        ui = DialogAddItemName(self.app, self.categories, _("Category"), _("Category name"))
+        ui.exec()
+        new_category_name = ui.get_new_name()
+        if new_category_name is None:
+            return
+        item = {'name': new_category_name, 'cid': None, 'memo': "",
+                'owner': self.app.settings['codername'],
+                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")}
+        cur = self.app.conn.cursor()
+        cur.execute("insert into code_cat (name, memo, owner, date, supercatid) values(?,?,?,?,?)",
+                    (item['name'], item['memo'], item['owner'], item['date'], supercatid))
+        self.app.conn.commit()
+        self.app.delete_backup = False
+        self.parent_textEdit.append(_("New category: ") + item['name'])
+        self.codes_changed.emit(["code_cat"])
+
+    # delete
+
+    def delete_code(self, selected: QtWidgets.QTreeWidgetItem):
+        """
+        Find code, remove from database, refresh code data and fill treeWidget.
+        Args:
+            selected: QTreeWidgetItem
+        """
+
+        # Find the code in the list, check to delete
+        found = -1
+        for i in range(0, len(self.codes)):
+            if self.codes[i]['cid'] == int(selected.text(1)[4:]):
+                found = i
+        if found == -1:
+            return
+        code_ = self.codes[found]
+        ui = DialogConfirmDelete(self.app, _("Code: ") + selected.text(0))
+        ok = ui.exec()
+        if not ok:
+            return
+        cur = self.app.conn.cursor()
+        # Re-parent this code's sub-codes so they are not orphaned by the deletion.
+        if code_.get('supercid') is not None:
+            # Was itself a sub-code: lift its children to the grandparent code.
+            cur.execute("update code_name set supercid=? where supercid=?", [code_['supercid'], code_['cid']])
+        else:
+            # Was top level (possibly under a category): move children into that category (or top level).
+            cur.execute("update code_name set supercid=null, catid=? where supercid=?",
+                        [code_['catid'], code_['cid']])
+        cur.execute("delete from code_name where cid=?", [code_['cid'], ])
+        cur.execute("delete from code_text where cid=?", [code_['cid'], ])
+        cur.execute("delete from code_av where cid=?", [code_['cid'], ])
+        cur.execute("delete from code_image where cid=?", [code_['cid'], ])
+        self.app.conn.commit()
+        self.app.delete_backup = False
+        self.parent_textEdit.append(_("Code deleted: ") + code_['name'] + "\n")
+        # Let the host clean its own caches, such as the recent codes list.
+        if self.on_codes_deleted is not None:
+            self.on_codes_deleted([code_['cid']])
+        self.codes_changed.emit(["code_name", "code_text", "code_av", "code_image"])
+
+    def get_branch_catids_and_cids(self, catid: int) -> tuple:
+        """
+        Gather every category and code that hangs below a category, including the category itself.
+        Sub-codes (supercid) nested under branch codes are collected too.
+        Read straight from the database, not from the cached host codes / categories, so a
+        stale dialog snapshot can never delete or miss the wrong rows.
+        Iterative walk, so cyclic or malformed data cannot cause infinite recursion.
+        Args:
+            catid: Integer, category id of the branch root
+        Returns:
+            Tuple: (list of category ids, list of code ids)
+        """
+
+        cur = self.app.conn.cursor()
+        cur.execute("select catid, supercatid from code_cat")
+        db_cats = cur.fetchall()
+        cur.execute("select cid, catid, supercid from code_name")
+        db_codes = cur.fetchall()
+        catids = [catid]
+        i = 0
+        while i < len(catids):
+            for cat_ in db_cats:
+                if cat_[1] == catids[i] and cat_[0] not in catids:
+                    catids.append(cat_[0])
+            i += 1
+        cids = []
+        for code_ in db_codes:
+            if code_[1] in catids and code_[0] not in cids:
+                cids.append(code_[0])
+        i = 0
+        while i < len(cids):
+            for code_ in db_codes:
+                if code_[2] == cids[i] and code_[0] not in cids:
+                    cids.append(code_[0])
+            i += 1
+        return catids, cids
+
+    def delete_category_branch(self, selected: QtWidgets.QTreeWidgetItem):
+        """
+        Delete a category and everything underneath it: nested categories, codes, sub-codes
+        and all the codings (text, audio/video, image) made with those codes.
+        Unlike Delete, which only removes the category and re-parents its contents,
+        this cascades down the whole branch. All writes run in a single transaction.
+        Args:
+            selected: QTreeWidgetItem
+        """
+
+        if selected is None or selected.text(1)[0:3] != 'cat':
+            return
+        cur = self.app.conn.cursor()
+        cur.execute("select catid, name from code_cat where catid=?", [int(selected.text(1)[6:]), ])
+        res = cur.fetchone()
+        if res is None:  # Already deleted elsewhere, the tree item is stale
+            self.codes_changed.emit([])
+            return
+        category = {'catid': res[0], 'name': res[1]}
+        catids, cids = self.get_branch_catids_and_cids(category['catid'])
+        # Count the codings that will be lost, so the user knows what is at stake.
+        # One grouped scan per table, instead of one query per code.
+        cids_set = set(cids)
+        codings = 0
+        for table in ("code_text", "code_av", "code_image"):
+            cur.execute(f"select cid, count(*) from {table} group by cid")
+            for row in cur.fetchall():
+                if row[0] in cids_set:
+                    codings += row[1]
+        msg = _("Category branch") + ": " + category['name'] + "\n\n"
+        msg += _("All categories and codes under this category will also be deleted.") + "\n"
+        msg += _("All codings made with these codes across all files will be deleted.") + "\n\n"
+        msg += _("Categories to delete") + f": {len(catids)}\n"
+        msg += _("Codes to delete") + f": {len(cids)}\n"
+        msg += _("Codings to delete") + f": {codings}\n\n"
+        msg += _("Make a project backup first. This action cannot be undone.")
+        ui = DialogConfirmDelete(self.app, msg)
+        # Cancel is the default button here, so a stray Enter cannot wipe out the branch.
+        button_box = ui.findChild(QtWidgets.QDialogButtonBox)
+        if button_box is not None:
+            ok_button = button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+            cancel_button = button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
+            if ok_button is not None:
+                ok_button.setAutoDefault(False)
+                ok_button.setDefault(False)
+            if cancel_button is not None:
+                cancel_button.setAutoDefault(True)
+                cancel_button.setDefault(True)
+                cancel_button.setFocus()
+        ok = ui.exec()
+        if not ok:
+            return
+        try:
+            for cid in cids:
+                cur.execute("delete from code_text where cid=?", [cid, ])
+                cur.execute("delete from code_av where cid=?", [cid, ])
+                cur.execute("delete from code_image where cid=?", [cid, ])
+                cur.execute("delete from code_name where cid=?", [cid, ])
+                # Saved graphs: drop nodes and links pointing at this code, so that a reused
+                # cid cannot silently re-bind an old graph node to an unrelated code.
+                cur.execute("delete from gr_cdct_text_item where cid=?", [cid, ])
+                cur.execute("delete from gr_cdct_line_item where fromcid=? or tocid=?", [cid, cid])
+                cur.execute("delete from gr_free_line_item where fromcid=? or tocid=?", [cid, cid])
+            for cat_id in catids:
+                cur.execute("delete from code_cat where catid=?", [cat_id, ])
+                cur.execute("delete from gr_cdct_text_item where catid=?", [cat_id, ])
+                cur.execute("delete from gr_cdct_line_item where fromcatid=? or tocatid=?", [cat_id, cat_id])
+                cur.execute("delete from gr_free_line_item where fromcatid=? or tocatid=?", [cat_id, cat_id])
+            # Drop the deleted codes from the stored recently used codes.
+            cur.execute("select recently_used_codes from project")
+            recent_res = cur.fetchone()
+            if recent_res is not None and recent_res[0]:
+                keep = []
+                for token in recent_res[0].split():
+                    try:
+                        if int(token) in cids:
+                            continue
+                    except ValueError:
+                        pass
+                    keep.append(token)
+                cur.execute("update project set recently_used_codes=?", [" ".join(keep), ])
+            # Extra check. Clear any dangling references left behind by the deletion.
+            cur.execute("update code_cat set supercatid=null where supercatid is not null and supercatid not in "
+                        "(select catid from code_cat)")
+            cur.execute("update code_name set catid=null where catid is not null and catid not in "
+                        "(select catid from code_cat)")
+            cur.execute("update code_name set supercid=null where supercid is not null and supercid not in "
+                        "(select cid from code_name)")
+            self.app.conn.commit()
+        except Exception as e_:
+            logger.warning(e_)
+            self.app.conn.rollback()  # Revert all changes
+            self.codes_changed.emit([])
+            raise
+        # Let the host clean its own caches, such as the recent codes list.
+        if self.on_codes_deleted is not None:
+            self.on_codes_deleted(cids)
+        self.app.delete_backup = False
+        msg = _("Category branch deleted") + ": " + category['name'] + ". "
+        msg += _("Categories") + f": {len(catids)}, " + _("Codes") + f": {len(cids)}, "
+        msg += _("Codings") + f": {codings}"
+        self.parent_textEdit.append(msg)
+        self.codes_changed.emit(["code_cat", "code_name", "code_text", "code_av", "code_image"])
+
+    # memo, rename, colour
+
+    def add_edit_cat_or_code_memo(self, selected: QtWidgets.QTreeWidgetItem):
+        """
+        View and edit a memo for a category or code.
+        Args:
+            selected: QTreeWidgetItem
+        """
+
+        changed_tables = []
+        if selected.text(1)[0:3] == 'cid':
+            # Find the code in the list
+            found = -1
+            for i in range(0, len(self.codes)):
+                if self.codes[i]['cid'] == int(selected.text(1)[4:]):
+                    found = i
+            if found == -1:
+                return
+            ui = DialogMemo(self.app, _("Memo for Code: ") + self.codes[found]['name'], self.codes[found]['memo'])
+            ui.exec()
+            memo = ui.memo
+            if memo != self.codes[found]['memo']:
+                self.codes[found]['memo'] = memo
+                cur = self.app.conn.cursor()
+                cur.execute("update code_name set memo=? where cid=?", (memo, self.codes[found]['cid']))
+                self.app.conn.commit()
+                self.app.delete_backup = False
+                changed_tables = ["code_name"]
+            if memo == "":
+                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
+            else:
+                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
+                self.parent_textEdit.append(_("Memo for code: ") + self.codes[found]['name'])
+
+        if selected.text(1)[0:3] == 'cat':
+            # Find the category in the list
+            found = -1
+            for i in range(0, len(self.categories)):
+                if self.categories[i]['catid'] == int(selected.text(1)[6:]):
+                    found = i
+            if found == -1:
+                return
+            ui = DialogMemo(self.app, _("Memo for Category: ") + self.categories[found]['name'],
+                            self.categories[found]['memo'])
+            ui.exec()
+            memo = ui.memo
+            if memo != self.categories[found]['memo']:
+                self.categories[found]['memo'] = memo
+                cur = self.app.conn.cursor()
+                cur.execute("update code_cat set memo=? where catid=?", (memo, self.categories[found]['catid']))
+                self.app.conn.commit()
+                self.app.delete_backup = False
+                changed_tables = ["code_cat"]
+            if memo == "":
+                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
+            else:
+                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
+                self.parent_textEdit.append(_("Memo for category: ") + self.categories[found]['name'])
+        self.codes_changed.emit(changed_tables)
+
+    def rename_category_or_code(self, selected: QtWidgets.QTreeWidgetItem):
+        """
+        Rename a code or category.
+        Check that the code or category name is not currently in use.
+        Args:
+            selected : QTreeWidgetItem
+        """
+
+        if selected.text(1)[0:3] == 'cid':
+            found_code = None
+            check_codes = []
+            for code_ in self.codes:
+                if code_['cid'] == int(selected.text(1)[4:]):
+                    found_code = code_
+                else:
+                    check_codes.append(code_)
+            if found_code is None:
+                return
+            ui = DialogAddItemName(self.app, check_codes, _("Rename code"), _("Code name"))
+            ui.ui.lineEdit.setText(found_code['name'])
+            ui.exec()
+            new_name = ui.get_new_name()
+            if new_name is None or new_name == found_code['name']:
+                return
+            old_name = found_code['name']
+            # Let the host update its own caches, such as the recent codes list.
+            if self.on_code_renamed is not None:
+                self.on_code_renamed(old_name, new_name)
+            # Update codes list and database
+            cur = self.app.conn.cursor()
+            cur.execute("update code_name set name=? where cid=?", (new_name, found_code['cid']))
+            self.app.conn.commit()
+            self.app.delete_backup = False
+            self.parent_textEdit.append(_("Code renamed from: ") + f"{old_name} --> {new_name}")
+            self.codes_changed.emit(["code_name"])
+            return
+
+        if selected.text(1)[0:3] == 'cat':
+            found_cat = None
+            check_categories = []
+            for category in self.categories:
+                if category['catid'] == int(selected.text(1)[6:]):
+                    found_cat = category
+                else:
+                    check_categories.append(category)
+            if found_cat is None:
+                return
+            ui = DialogAddItemName(self.app, check_categories, _("Rename category"), _("Category name"))
+            ui.ui.lineEdit.setText(found_cat['name'])
+            ui.exec()
+            new_name = ui.get_new_name()
+            if new_name is None or new_name == found_cat['name']:
+                return
+            old_name = found_cat['name']
+            # Update category list and database
+            cur = self.app.conn.cursor()
+            cur.execute("update code_cat set name=? where catid=?", (new_name, found_cat['catid']))
+            self.app.conn.commit()
+            self.app.delete_backup = False
+            self.parent_textEdit.append(_("Category renamed from: ") + f"{old_name} --> {new_name}")
+            self.codes_changed.emit(["code_cat"])
+
+    def change_code_color(self, selected: QtWidgets.QTreeWidgetItem):
+        """
+        Change the colour of the currently selected code.
+        Args:
+            selected : QTreeWidgetItem
+        """
+
+        cid = int(selected.text(1)[4:])
+        found = -1
+        for i in range(0, len(self.codes)):
+            if self.codes[i]['cid'] == cid:
+                found = i
+        if found == -1:
+            return
+        ui = DialogColorSelect(self.app, self.codes[found])
+        ok = ui.exec()
+        if not ok:
+            return
+        new_color = ui.get_color()
+        if new_color is None:
+            return
+        selected.setBackground(0, QBrush(QColor(new_color), Qt.BrushStyle.SolidPattern))
+        # Update codes list, database and color markings
+        self.codes[found]['color'] = new_color
+        cur = self.app.conn.cursor()
+        cur.execute("update code_name set color=? where cid=?",
+                    (self.codes[found]['color'], self.codes[found]['cid']))
+        self.app.conn.commit()
+        self.app.delete_backup = False
+        self.codes_changed.emit(["code_name"])
+
+    # move
+
+    def move_code(self, selected: QtWidgets.QTreeWidgetItem):
+        """
+        Move code to another category, or code or to none (top level).
+        Uses a list selection which represents the codes tree.
+        Args:
+            selected : QTreeWidgetItem
+         """
+
+        items_list = [{'name': " ", 'catid': -1, 'cid': -1}]  # Default blank item
+        iterator = QtWidgets.QTreeWidgetItemIterator(self.tree)
+        while iterator.value():
+            can_append = True
+            item = iterator.value()
+            depth = 0
+            current = item
+            # Get depth and if circular reference present
+            while current.parent() is not None:
+                if current.text(1) == selected.text(1):
+                    can_append = False
+                current = current.parent()
+                depth += 1
+            prefix = ""
+            if depth > 0:
+                prefix = "  " * (depth - 1) * 2 + "└─"  # U2514 U2500
+            name = prefix + item.text(0)
+            cid = -1
+            catid = -1
+            if "cid" in item.text(1):
+                cid = int(item.text(1)[4:])
+            else:
+                catid = int(item.text(1)[6:])
+                name += " " + _("[CATEGORY]")
+            # Check the same item is not the same selected item
+            if item.text(1) == selected.text(1) and item.text(2) == selected.text(2):
+                can_append = False
+            memo = item.toolTip(2)
+            if can_append:
+                items_list.append({'name': name, 'catid': catid, 'cid': cid, 'memo': memo})
+            iterator += 1
+        ui = DialogSelectItems(self.app, items_list, _("Move code: Select blank or category or code"), "single")
+        ok = ui.exec()
+        if not ok:
+            return
+        destination = ui.get_selected()
+        selected_cid = int(selected.text(1)[4:])
+        cur = self.app.conn.cursor()
+        if destination['catid'] == -1 and destination['cid'] == -1:  # move to top level
+            cur.execute("update code_name set catid=null, supercid=null where cid=?", [selected_cid])
+        elif destination['cid'] > 0:  # Move under another code
+            cur.execute("update code_name set catid=null, supercid=? where cid=?", [destination['cid'], selected_cid])
+        else:  # Move under a category
+            cur.execute("update code_name set catid=?, supercid=null where cid=?", [destination['catid'], selected_cid])
+        self.app.conn.commit()
+        self.app.delete_backup = False
+        self.codes_changed.emit(["code_name"])
+
+    def move_multiple_codes(self):
+        """
+        Move multiple codes to another category.
+        """
+
+        cur = self.app.conn.cursor()
+        cur.execute("select code_name.name, code_cat.name, cid from code_name left join code_cat on "
+                    "code_cat.catid=code_name.catid order by upper(code_cat.name) asc, upper(code_name.name) asc")
+        res = cur.fetchall()
+        code_list = []
+        for r in res:
+            name = r[0]
+            if r[1] is not None:
+                name = r[1] + " ← " + r[0]
+            code_list.append({'name': name, 'cid': r[2]})
+        ui = DialogSelectItems(self.app, code_list, _("Select codes"), "multi")
+        ok = ui.exec()
+        if not ok:
+            return
+        selected_codes = ui.get_selected()
+        cur.execute("select name, catid from code_cat order by upper(name)")
+        res = cur.fetchall()
+        category_list = [{'name': "", 'catid': None}]
+        for r in res:
+            category_list.append({'name': r[0], 'catid': r[1]})
+        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
+        ok = ui.exec()
+        if not ok:
+            return
+        category = ui.get_selected()
+        for s in selected_codes:
+            # Moving to a category (or to blank) removes any sub-code nesting.
+            cur.execute("update code_name set catid=?, supercid=null where cid=?", [category['catid'], s['cid']])
+            self.app.conn.commit()
+            self.parent_textEdit.append(_("Code moved.") + s['name'].replace(" ← ", "/") + " → " + category['name'])
+        self.app.delete_backup = False
+        self.codes_changed.emit(["code_name"])
+
+    def move_category(self, catid: int):
+        """
+        Select another category to move this category underneath.
+        Args:
+            catid : Integer category identifier
+        """
+
+        do_not_merge_list = []
+        do_not_merge_list = self.recursive_non_merge_item(self.tree.currentItem(), do_not_merge_list)
+        do_not_merge_list.append(str(catid))
+        do_not_merge_ids_string = f"({','.join(do_not_merge_list)})"
+        sql = "select name, catid, supercatid from code_cat where catid not in "
+        sql += do_not_merge_ids_string + " order by name"
+        cur = self.app.conn.cursor()
+        cur.execute(sql)
+        res = cur.fetchall()
+        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
+        for r in res:
+            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
+        ui = DialogSelectItems(self.app, category_list, _("Move category: Select blank or category"), "single")
+        ok = ui.exec()
+        if not ok:
+            return
+        category = ui.get_selected()
+        current_cat_name = self.tree.currentItem().text(0)
+        if category['name'] == '':
+            cur.execute("update code_cat set supercatid=Null where catid=?", [catid])
+            self.app.conn.commit()
+            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → Top level")
+        else:
+            cur.execute("update code_cat set supercatid=? where catid=?", [category['catid'], catid])
+            self.app.conn.commit()
+            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → " + category['name'])
+        self.app.delete_backup = False
+        self.codes_changed.emit(["code_cat"])
+
+    # merge
+
+    def merge_category(self, catid: int):
+        """ Select another category to merge this category into.
+        Args:
+            catid : Integer category identifier
+        """
+
+        do_not_merge_list = []
+        do_not_merge_list = self.recursive_non_merge_item(self.tree.currentItem(), do_not_merge_list)
+        do_not_merge_list.append(str(catid))
+        do_not_merge_ids_string = "(" + ",".join(do_not_merge_list) + ")"
+        sql = "select name, catid, supercatid from code_cat where catid not in "
+        sql += do_not_merge_ids_string + " order by name"
+        cur = self.app.conn.cursor()
+        cur.execute(sql)
+        res = cur.fetchall()
+        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
+        for r in res:
+            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
+        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
+        ok = ui.exec()
+        if not ok:
+            return
+        category = ui.get_selected()
+        try:
+            # Always record merge info in target category memo
+            source_cat = None
+            for c in self.categories:
+                if c['catid'] == catid:
+                    source_cat = c
+                    break
+            if source_cat is not None and category['catid'] is not None:
+                target_cat = None
+                for c in self.categories:
+                    if c['catid'] == category['catid']:
+                        target_cat = c
+                        break
+                if target_cat is not None:
+                    merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
+                    source_memo = (source_cat.get('memo', '') or '').strip()
+                    source_owner = source_cat.get('owner', self.app.settings['codername'])
+                    merged_block = f"\n\n[{_('Merged from category:')} {source_cat['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"
+                    if source_memo:
+                        merged_block += f"\n{source_memo}"
+                    target_memo = target_cat.get('memo', '') or ''
+                    new_memo = (target_memo + merged_block).strip()
+                    cur.execute("update code_cat set memo=? where catid=?", [new_memo, category['catid']])
+                    target_cat['memo'] = new_memo
+            for code in self.codes:
+                if code['catid'] == catid:
+                    cur.execute("update code_name set catid=? where catid=?", [category['catid'], catid])
+            cur.execute("delete from code_cat where catid=?", [catid])
+            for cat in self.categories:
+                if cat['supercatid'] == catid:
+                    cur.execute("update code_cat set supercatid=? where supercatid=?", [category['catid'], catid])
+            # Clear any orphan supercatids
+            sql = "select supercatid from code_cat where supercatid not in (select catid from code_cat)"
+            cur.execute(sql)
+            orphans = cur.fetchall()
+            sql = "update code_cat set supercatid=Null where supercatid=?"
+            for orphan in orphans:
+                cur.execute(sql, [orphan[0]])
+            self.app.conn.commit()
+        except Exception as e_:
+            logger.warning(e_)
+            self.app.conn.rollback()  # Revert all changes
+            self.codes_changed.emit([])
+            raise
+        self.app.delete_backup = False
+        self.codes_changed.emit(["code_cat", "code_name"])
+
+    def merge_code_into_code(self, selected: QtWidgets.QTreeWidgetItem):
+        """
+        Merge the selected code into another code chosen from a list.
+        Reuses merge_codes (the same logic used by drag-and-drop with Ctrl). The source code
+        and all of its descendant sub-codes are excluded from the candidate targets to avoid
+        creating a supercid cycle when merging a code into one of its own sub-codes.
+        Args:
+            selected: QTreeWidgetItem
+        """
+
+        if selected is None or selected.text(1)[0:3] != 'cid':
+            return
+        src_cid = int(selected.text(1)[4:])
+        source_code = next((c for c in self.codes if c['cid'] == src_cid), None)
+        if source_code is None:
+            return
+        # Candidate targets: every code that is not the source nor a descendant of the source.
+        target_list = []
+        for c in self.codes:
+            if not self.code_is_descendant(c['cid'], src_cid):
+                target_list.append({'name': c['name'], 'cid': c['cid']})
+        if not target_list:
+            Message(self.app, _("Merge code into code"),
+                    _("There is no other code to merge into.")).exec()
+            return
+        target_list = sorted(target_list, key=lambda x: x['name'].lower())
+        ui = DialogSelectItems(self.app, target_list, _("Select code to merge into"), "single")
+        ok = ui.exec()
+        if not ok:
+            return
+        target = ui.get_selected()
+        if not target:
+            return
+        # merge_codes expects the target as a QTreeWidgetItem, so find it in the tree.
+        target_item = None
+        it = QtWidgets.QTreeWidgetItemIterator(self.tree)
+        while it.value():
+            node = it.value()
+            if node.text(1) == f"cid:{target['cid']}":
+                target_item = node
+                break
+            it += 1
+        if target_item is None:
+            return
+        self.merge_codes(source_code, target_item)
+
+    def merge_codes(self, item: dict, parent: QtWidgets.QTreeWidgetItem):
+        """
+        Merge code with another code.
+        Called by item_moved_update_data when a code is moved onto another code with Ctrl held.
+        code text unique(cid,fid,pos0,pos1, owner)
+        Args:
+            item : Dictionary code item
+            parent : QTreeWidgetItem
+        """
+
+        # Check item dropped on itself
+        if item['name'] == parent.text(0):
+            return
+        # Prevent a supercid cycle
+        target_cid = int(parent.text(1).split(':')[1])
+        if self.code_is_descendant(target_cid, item['cid']):
+            Message(self.app, _("Cannot merge code"),
+                    _("Cannot merge a code into itself or one of its own sub-codes.")).exec()
+            return
+        msg = '<p style="font-size:' + str(self.app.settings['fontsize']) + 'px">'
+        msg += _("Merge code: ") + item['name'] + _(" into code: ") + parent.text(0) + '</p>'
+        reply = QtWidgets.QMessageBox.question(self.tree, _('Merge codes'),
+                                               msg, QtWidgets.QMessageBox.StandardButton.Yes,
+                                               QtWidgets.QMessageBox.StandardButton.No)
+        if reply == QtWidgets.QMessageBox.StandardButton.No:
+            return
+        cur = self.app.conn.cursor()
+        old_cid = item['cid']
+        new_cid = int(parent.text(1).split(':')[1])
+        # Always record merge info in target code memo
+        target_code = None
+        for c in self.codes:
+            if c['cid'] == new_cid:
+                target_code = c
+                break
+        if target_code is not None:
+            merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
+            source_memo = item.get('memo', '').strip()
+            source_owner = item.get('owner', self.app.settings['codername'])
+            merged_block = f"\n\n[{_('Merged from code:')} {item['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"
+            if source_memo:
+                merged_block += f"\n{source_memo}"
+            target_memo = target_code.get('memo', '') or ''
+            new_memo = (target_memo + merged_block).strip()
+            cur.execute("update code_name set memo=? where cid=?", [new_memo, new_cid])
+            target_code['memo'] = new_memo
+        # Update cid for each coded segment in text, av, image. Delete where there is an Integrity error
+        ct_sql = "select ctid from code_text where cid=?"
+        cur.execute(ct_sql, [old_cid])
+        ct_res = cur.fetchall()
+        try:
+            for ct in ct_res:
+                try:
+                    cur.execute("update code_text set cid=? where ctid=?", [new_cid, ct[0]])
+                except sqlite3.IntegrityError:
+                    cur.execute("delete from code_text where ctid=?", [ct[0]])
+            av_sql = "select avid from code_av where cid=?"
+            cur.execute(av_sql, [old_cid])
+            av_res = cur.fetchall()
+            for av in av_res:
+                try:
+                    cur.execute("update code_av set cid=? where avid=?", [new_cid, av[0]])
+                except sqlite3.IntegrityError:
+                    cur.execute("delete from code_av where avid=?", [av[0]])
+            img_sql = "select imid from code_image where cid=?"
+            cur.execute(img_sql, [old_cid])
+            img_res = cur.fetchall()
+            for img in img_res:
+                try:
+                    cur.execute("update code_image set cid=? where imid=?", [new_cid, img[0]])
+                except sqlite3.IntegrityError:
+                    cur.execute("delete from code_image where imid=?", [img[0]])
+            # Re-parent the merged code's sub-codes onto the target code (no orphans).
+            cur.execute("update code_name set supercid=?, catid=null where supercid=?", [new_cid, old_cid])
+            cur.execute("delete from code_name where cid=?", [old_cid, ])
+            self.app.conn.commit()
+        except Exception as e_:
+            logger.warning(e_)
+            self.app.conn.rollback()  # Revert all changes
+            raise
+        self.app.delete_backup = False
+        # Let the host clean its own caches, such as the recent codes list.
+        if self.on_codes_deleted is not None:
+            self.on_codes_deleted([old_cid])
+        msg = msg.replace("\n", " ")
+        self.parent_textEdit.append(msg)
+        self.codes_changed.emit(["code_name", "code_text", "code_av", "code_image"])

--- a/src/qualcoder/code_tree.py
+++ b/src/qualcoder/code_tree.py
@@ -1115,12 +1115,11 @@ class CodeTreeController(QtCore.QObject):
             item = iterator.value()
             depth = 0
             current = item
-            # Get depth and if circular reference present
             while current.parent() is not None:
-                if current.text(1) == selected.text(1):
-                    can_append = False
                 current = current.parent()
                 depth += 1
+                if current.text(1) == selected.text(1):
+                    can_append = False
             prefix = ""
             if depth > 0:
                 prefix = "  " * (depth - 1) * 2 + "└─"  # U2514 U2500
@@ -1149,6 +1148,12 @@ class CodeTreeController(QtCore.QObject):
         if destination['catid'] == -1 and destination['cid'] == -1:  # move to top level
             cur.execute("update code_name set catid=null, supercid=null where cid=?", [selected_cid])
         elif destination['cid'] > 0:  # Move under another code
+            # Belt and braces: never write a supercid cycle, even if the selection list
+            # was built from a stale or corrupted tree.
+            if self.code_is_descendant(destination['cid'], selected_cid):
+                Message(self.app, _("Cannot move code"),
+                        _("Cannot move a code under itself or one of its own sub-codes.")).exec()
+                return
             cur.execute("update code_name set catid=null, supercid=? where cid=?", [destination['cid'], selected_cid])
         else:  # Move under a category
             cur.execute("update code_name set catid=?, supercid=null where cid=?", [destination['catid'], selected_cid])

--- a/src/qualcoder/code_tree.py
+++ b/src/qualcoder/code_tree.py
@@ -42,7 +42,19 @@ logger = logging.getLogger(__name__)
 
 
 class CodeTreeController(QtCore.QObject):
-    """ Owns the shared behaviour of a codes treeWidget for a coding dialog. """
+    """ Owns the shared behaviour of a codes treeWidget for a coding dialog.
+    Host protocol:
+    The host dialog must provide: codes (list of dict), categories (list of dict)
+    and parent_textEdit. Both lists are read live, never cached here.
+    Optional callbacks, set after construction:
+        fill_counts_callback() - fill the Count column after fill_tree
+        coded_files_callback(code_or_codes, title) - one code dict, or a list for a category branch
+        find_code_callback(), show_codes_like_callback(), show_codes_of_colour_callback()
+        on_codes_deleted(cids), on_code_renamed(old_name, new_name) - host cache cleanup
+    Signals:
+        menu_requested(menu, selected_item) - emitted before the context menu is shown
+        codes_changed(list_of_table_names) - emitted after every database change
+    """
 
     # Built QMenu and selected QTreeWidgetItem (or None), emitted before menu.exec
     menu_requested = QtCore.pyqtSignal(object, object)
@@ -55,7 +67,7 @@ class CodeTreeController(QtCore.QObject):
         Args:
             app: App object
             tree_widget: the QTreeWidget the dialog already owns (from its .ui)
-            host: the coding dialog, see the host protocol in the module docstring
+            host: the coding dialog, see the host protocol in the class docstring
             column_width_factors: Dictionary or None, passed to restore_persistent_tree_widths
         """
 
@@ -66,7 +78,7 @@ class CodeTreeController(QtCore.QObject):
         self.tree_sort_option = "all asc"  # all asc, all desc, cat and code asc
         self.column_width_factors = column_width_factors if column_width_factors is not None \
             else {0: 0.70, 2: 0.15, 3: 0.15}
-        # Optional host callbacks, see module docstring
+        # Optional host callbacks, see class docstring
         self.fill_counts_callback = None
         self.coded_files_callback = None
         self.find_code_callback = None

--- a/src/qualcoder/view_image.py
+++ b/src/qualcoder/view_image.py
@@ -589,7 +589,9 @@ class DialogCodeImage(QtWidgets.QDialog):
         # until only top categories are left
         sub_categories = copy(categories)
         counter = 0
-        while len(sub_categories) > 0 or counter < 10000:
+        # 'and', not 'or': with 'or' the 10,000 guard never fires (cycle in code_cat =
+        # infinite loop) and healthy data still spins 10,000 empty passes.
+        while len(sub_categories) > 0 and counter < 10000:
             leaf_list = []
             branch_list = []
             for cat in sub_categories:
@@ -845,7 +847,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.file_ = None
         self.selection = None
         self.scale = 1.0
-        # Clear handle states on image change/close to prevent ghost handles or memory errors <- L
+        # Clear handle states on image change/close to prevent ghost handles or memory errors
         self.item_to_resize = None
         self.is_dragging_handle = False
         self.active_handle = None
@@ -1030,7 +1032,7 @@ class DialogCodeImage(QtWidgets.QDialog):
 
         if self.pixmap is None:
             return
-        # If the user uses keyboard shortcuts to zoom/rotate WHILE dragging, safely cancel the drag <- L
+        # If the user uses keyboard shortcuts to zoom/rotate WHILE dragging, safely cancel the drag
         if hasattr(self, 'is_dragging_handle') and self.is_dragging_handle:
             self.is_dragging_handle = False
             self.interactive_rect_item = None
@@ -1132,24 +1134,24 @@ class DialogCodeImage(QtWidgets.QDialog):
                     self.scene.addItem(rect_item)
                 if not self.important:
                     self.scene.addItem(rect_item)
-                # Draw 4 handles (red squares) on the corners of the active segment <- L
+                # Draw 4 handles (red squares) on the corners of the active segment
                 if hasattr(self, 'item_to_resize') and self.item_to_resize and self.item_to_resize['imid'] == coded['imid']:
                     handle_size = 12
                     # Dictionary with relative X, Y coordinates for the 4 corners:
-                    # Top-Left (TL), Top-Right (TR), Bottom-Left (BL), Bottom-Right (BR) <- L
+                    # Top-Left (TL), Top-Right (TR), Bottom-Left (BL), Bottom-Right (BR)
                     handles = {
                         "TL": (x, y),
                         "TR": (x + width - handle_size, y),
                         "BL": (x, y + height - handle_size),
                         "BR": (x + width - handle_size, y + height - handle_size)
                     }
-                    # Iterate through corners to create interactive square items in the scene <- L
+                    # Iterate through corners to create interactive square items in the scene
                     for h_type, (hx, hy) in handles.items():
                         handle_item = QtWidgets.QGraphicsRectItem(hx, hy, handle_size, handle_size)
-                        handle_item.setBrush(QBrush(QtGui.QColor("#ff0000")))  # Red color for visibility <- L
-                        handle_item.setData(0, "resize_handle")  # Main tag to detect clicks <- L
-                        handle_item.setData(1, h_type)          # Identifies the specific corner <- L
-                        handle_item.setZValue(1000)  # keep handles above all coded rectangles so they are always clickable <- L
+                        handle_item.setBrush(QBrush(QtGui.QColor("#ff0000")))  # Red color for visibility
+                        handle_item.setData(0, "resize_handle")  # Main tag to detect clicks
+                        handle_item.setData(1, h_type)          # Identifies the specific corner
+                        handle_item.setZValue(1000)  # keep handles above all coded rectangles so they are always clickable
                         self.scene.addItem(handle_item)
                 if self.show_code_captions == 1:
                     self.caption(x, y, code_name)
@@ -1360,7 +1362,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         """ Find all children codes of this item that match or not and hide or unhide based on 'text'.
         Recurse through all child categories and sub-codes. A code stays visible if it matches or
         if any of its descendant sub-codes matches, so a match is never hidden under a
-        non-matching parent code. Returns True if this item or any descendant matches. <- L
+        non-matching parent code. Returns True if this item or any descendant matches.
         Called by: show_codes_like
         Args:
             item: a QTreeWidgetItem
@@ -1373,7 +1375,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         for i in range(child_count):
             child = item.child(i)
             is_code = "cid:" in child.text(1)
-            # Recurse first so we know whether any descendant matches. <- L
+            # Recurse first so we know whether any descendant matches.
             descendant_match = self.recursive_traverse(child, text_, case_sensitive)
             if text_ == "":
                 if is_code:
@@ -1444,7 +1446,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.zoom_in()
             return
 
-        # Tree widget menu item keys F2 - F6, handled by the shared controller. <- L
+        # Tree widget menu item keys F2 - F6, handled by the shared controller.
         if self.ui.treeWidget.hasFocus():
             if self.code_tree.handle_key_press(event):
                 return
@@ -1611,30 +1613,30 @@ class DialogCodeImage(QtWidgets.QDialog):
                     vsb.setValue(vsb.value() + 1)
                 return True
         if object_ is self.scene:
-            # Detect mouse movement on the scene to update the dashed rectangle in real-time <- L
+            # Detect mouse movement on the scene to update the dashed rectangle in real-time
             if type(event) == QtWidgets.QGraphicsSceneMouseEvent and event.type() == QtCore.QEvent.Type.GraphicsSceneMouseMove:
                 if hasattr(self, 'is_dragging_handle') and self.is_dragging_handle:
-                    # Call function to recalculate boundaries based on cursor movement <- L
+                    # Call function to recalculate boundaries based on cursor movement
                     self.update_interactive_resize(event.scenePos())
                     return True
             if type(event) == QtWidgets.QGraphicsSceneMouseEvent and event.button() == Qt.MouseButton.LeftButton:
                 pos = event.buttonDownScenePos(Qt.MouseButton.LeftButton)
-                # Intercept left click to initiate handle dragging or cancel it <- L
+                # Intercept left click to initiate handle dragging or cancel it
                 if event.type() == QtCore.QEvent.Type.GraphicsSceneMousePress:
                     item_at = self.scene.itemAt(pos, QtGui.QTransform())
-                    # Check if the click is exactly on one of the 4 handles... <- L
+                    # Check if the click is exactly on one of the 4 handles...
                     if hasattr(self, 'item_to_resize') and self.item_to_resize and item_at and item_at.data(0) == "resize_handle":
                         self.is_dragging_handle = True
-                        self.active_handle = item_at.data(1)  # Store which corner was clicked <- L
+                        self.active_handle = item_at.data(1)  # Store which corner was clicked
                         
-                        # Extract absolute data from the active segment, scaled to screen <- L
+                        # Extract absolute data from the active segment, scaled to screen
                         it = self.item_to_resize
                         vx = it['x1'] * self.scale
                         vy = it['y1'] * self.scale
                         vw = it['width'] * self.scale
                         vh = it['height'] * self.scale
                         
-                        # Calculate exact visual position applying rotations manually (90, 180, 270 degrees) <- L
+                        # Calculate exact visual position applying rotations manually (90, 180, 270 degrees)
                         if self.degrees == 90:
                             vy = it['x1'] * self.scale
                             vx = (self.pixmap.height() - it['y1'] - it['height']) * self.scale
@@ -1651,9 +1653,9 @@ class DialogCodeImage(QtWidgets.QDialog):
                             vh = it['width'] * self.scale
                             vw = it['height'] * self.scale
 
-                        # Store this starting geometric position <- L
+                        # Store this starting geometric position
                         self.original_resize_geom = (vx, vy, vw, vh)
-                        # Create the temporary rectangle that guides the user visually (live feedback) <- L
+                        # Create the temporary rectangle that guides the user visually (live feedback)
                         self.interactive_rect_item = QtWidgets.QGraphicsRectItem(vx, vy, vw, vh)
                         pen = QtGui.QPen(QtGui.QColor("#ff0000"), 2, QtCore.Qt.PenStyle.DashLine)
                         self.interactive_rect_item.setPen(pen)
@@ -1662,10 +1664,10 @@ class DialogCodeImage(QtWidgets.QDialog):
                         # Temporarily disable standard selection rubber band
                         self.ui.graphicsView.setDragMode(QtWidgets.QGraphicsView.DragMode.NoDrag)
                         return True
-                    # If we didn't click a handle, but a segment was active, cancel the process <- L
+                    # If we didn't click a handle, but a segment was active, cancel the process
                     elif hasattr(self, 'item_to_resize') and self.item_to_resize:
                         self.item_to_resize = None
-                        self.redraw_scene()  # Redraw clears the handles from the screen <- L
+                        self.redraw_scene()  # Redraw clears the handles from the screen
                 self.fill_coded_area_label(self.find_coded_areas_for_pos(pos))
                 if event.type() == QtCore.QEvent.Type.GraphicsSceneMousePress:
                     p0 = event.buttonDownScenePos(Qt.MouseButton.LeftButton)
@@ -1673,7 +1675,7 @@ class DialogCodeImage(QtWidgets.QDialog):
                     return True
                 if event.type() == QtCore.QEvent.Type.GraphicsSceneMouseRelease:
                     p1 = event.lastScenePos()
-                    # On button release, process and save the final change if dragging a handle <- L
+                    # On button release, process and save the final change if dragging a handle
                     if hasattr(self, 'is_dragging_handle') and self.is_dragging_handle:
                         self.execute_interactive_resize(p1)
                         return True
@@ -1732,27 +1734,27 @@ class DialogCodeImage(QtWidgets.QDialog):
             return
         # build and show the context menu FIRST, before resolving which
         # segment to act on. The segment is only disambiguated after an action that
-        # needs a specific segment is chosen (see below). <- L
-        item = items[0]  # used only for important-mark menu options when a single segment <- L
+        # needs a specific segment is chosen (see below).
+        item = items[0]  # used only for important-mark menu options when a single segment
 
         # Determine importance state for menu construction when there is only one segment.
-        # With multiple segments we show both important options, since the target is not yet known. <- L
+        # With multiple segments we show both important options, since the target is not yet known.
         single_segment = len(items) == 1
         menu = QtWidgets.QMenu()
         menu.setStyleSheet("QMenu {font-size:" + str(self.app.settings['fontsize']) + "pt} ")
         action_memo = menu.addAction(_('Memo'))
         action_unmark = menu.addAction(_('Unmark'))
         action_move_resize = menu.addAction(_("Move or resize"))
-        # Add the option Interactive resize <- L
+        # Add the option Interactive resize
         action_interactive_resize = menu.addAction(_("Interactive resize"))
         action_important = None
         action_not_important = None
-        if single_segment:  # only filter important options when the target segment is unambiguous <- L
+        if single_segment:  # only filter important options when the target segment is unambiguous
             if item['important'] is None or item['important'] != 1:
                 action_important = menu.addAction(_("Add important mark"))
             if item['important'] == 1:
                 action_not_important = menu.addAction(_("Remove important mark"))
-        else:  # multiple segments: offer both, decide after segment is selected <- L
+        else:  # multiple segments: offer both, decide after segment is selected
             action_important = menu.addAction(_("Add important mark"))
             action_not_important = menu.addAction(_("Remove important mark"))
         action_highlight_gray = menu.addAction(_("Highlight this area - gray"))
@@ -1767,9 +1769,9 @@ class DialogCodeImage(QtWidgets.QDialog):
             return
 
         # after an action is chosen, if it acts on a specific segment and there is
-        # more than one segment under the cursor, ask which segment now. <- L
+        # more than one segment under the cursor, ask which segment now.
         # include "Highlight this code" actions so the user picks which code's
-        # cid is used when several segments overlap <- L
+        # cid is used when several segments overlap
         segment_actions = (action_memo, action_unmark, action_move_resize, action_interactive_resize,
                            action_important, action_not_important, action_highlight_gray,
                            action_highlight_solarize, action_highlight_blur,
@@ -1816,10 +1818,10 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.set_coded_importance(item, False)
         if action == action_move_resize:
             self.move_or_resize_coding(item)
-        # If the user selects the new option, store the segment to be resized <- L
+        # If the user selects the new option, store the segment to be resized
         if action == action_interactive_resize:
             self.item_to_resize = item
-            self.redraw_scene()  # Redrawing triggers draw_coded_areas, showing the handles <- L
+            self.redraw_scene()  # Redrawing triggers draw_coded_areas, showing the handles
         items = self.find_coded_areas_for_pos(pos)
         self.fill_coded_area_label(items)
 

--- a/src/qualcoder/view_image.py
+++ b/src/qualcoder/view_image.py
@@ -31,24 +31,21 @@ import os
 import PIL.Image
 from PIL import Image, ImageDraw, ImageFilter, ImageFont, ImageOps
 import qtawesome as qta  # see: https://pictogrammers.com/library/mdi/
-from random import randint
 import sqlite3
-from typing import Any
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtCore import Qt, QBuffer
 from PyQt6.QtGui import QBrush
 
-from .add_item_name import DialogAddItemName
 from .code_in_all_files import DialogCodeInAllFiles
 from .coder_names import DialogCoderNames
+from .code_tree import CodeTreeController
 from .color_selector import DialogColorSelect
-from .color_selector import colors, TextColor, colour_ranges, show_codes_of_colour_range
-from .confirm_delete import DialogConfirmDelete
+from .color_selector import colour_ranges, show_codes_of_colour_range
 from .GUI.ui_dialog_code_image import Ui_Dialog_code_image
 from .GUI.ui_dialog_view_image import Ui_Dialog_view_image
 from .move_resize_rectangle import DialogMoveResizeRectangle
-from .helpers import ExportDirectoryPathDialog, Message, init_persistent_tree_header, restore_persistent_tree_widths
+from .helpers import ExportDirectoryPathDialog, Message, init_persistent_tree_header
 from .memo import DialogMemo
 from .report_attributes import DialogSelectAttributeParameters
 from .ris import Ris
@@ -139,7 +136,18 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.ui.treeWidget.viewport().installEventFilter(self)
         self.ui.listWidget.installEventFilter(self)
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        self.ui.treeWidget.customContextMenuRequested.connect(self.tree_menu)
+        # Shared code tree controller: tree loading, common context menu, drag and drop
+        # reparenting, F2-F6 shortcuts and category branch deletion live in code_tree.py,
+        # so the four coding pages no longer duplicate this logic by hand. <- L
+        self.code_tree = CodeTreeController(self.app, self.ui.treeWidget, self)
+        self.ui.treeWidget.customContextMenuRequested.connect(self.code_tree.tree_menu)
+        self.code_tree.fill_counts_callback = self.fill_code_counts_in_tree
+        self.code_tree.coded_files_callback = self.coded_media_dialog
+        self.code_tree.find_code_callback = self.find_code_in_tree
+        self.code_tree.show_codes_like_callback = self.show_codes_like
+        self.code_tree.show_codes_of_colour_callback = self.show_codes_of_color
+        self.code_tree.codes_changed.connect(self.update_dialog_codes_and_categories)
+
         self.ui.treeWidget.itemClicked.connect(self.tree_item_clicked)
         init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodeimage_tree_widths')
         # Header widgets
@@ -208,7 +216,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.ui.splitter.splitterMoved.connect(self.update_sizes)
         self.ui.splitter_2.splitterMoved.connect(self.update_sizes)
         self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
-        self.fill_tree()
+        self.code_tree.fill_tree()
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
         self.ui.treeWidget.itemExpanded.connect(self.get_collapsed)
@@ -508,168 +516,6 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter <- L
         self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
 
-    def fill_tree(self):
-        """ Fill tree widget, top level items are main categories and unlinked codes. """
-
-        cats = deepcopy(self.categories)
-        codes = deepcopy(self.codes)
-        self.ui.treeWidget.clear()
-        self.ui.treeWidget.setColumnCount(4)
-        self.ui.treeWidget.setHeaderLabels([_("Name"), _("Id"), _("Memo"), _("Count")])
-        if not self.app.settings['showids']:
-            self.ui.treeWidget.setColumnHidden(1, True)
-        else:
-            self.ui.treeWidget.setColumnHidden(1, False)
-        # Add top level categories
-        remove_list = []
-        for c in cats:
-            if c['supercatid'] is None:
-                memo = ""
-                if c['memo'] != "":
-                    memo = "Memo"
-                top_item = QtWidgets.QTreeWidgetItem([c['name'], f"catid:{c['catid']}", memo])
-                top_item.setToolTip(0, '')
-                if len(c['name']) > 52:
-                    top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                    top_item.setToolTip(0, c['name'])
-                top_item.setToolTip(2, c['memo'])
-                self.ui.treeWidget.addTopLevelItem(top_item)
-                if f"catid:{c['catid']}" in self.app.collapsed_categories:
-                    top_item.setExpanded(False)
-                else:
-                    top_item.setExpanded(True)
-                remove_list.append(c)
-        for item in remove_list:
-            cats.remove(item)
-
-        ''' Add child categories. Look at each unmatched category, iterate through tree
-        to add as child, then remove matched categories from the list. '''
-        count = 0
-        while len(cats) > 0 and count < 10000:
-            remove_list = []
-            for c in cats:
-                it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-                item = it.value()
-                count2 = 0
-                while item and count2 < 10000:  # while there is an item in the list
-                    if item.text(1) == f"catid:{c['supercatid']}":
-                        memo = ""
-                        if c['memo'] != "":
-                            memo = "Memo"
-                        child = QtWidgets.QTreeWidgetItem([c['name'], f"catid:{c['catid']}", memo])
-                        child.setToolTip(0, '')
-                        if len(c['name']) > 52:
-                            child.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                            child.setToolTip(0, c['name'])
-                        child.setToolTip(2, c['memo'])
-                        item.addChild(child)
-                        if f"catid:{c['catid']}" in self.app.collapsed_categories:
-                            child.setExpanded(False)
-                        else:
-                            child.setExpanded(True)
-                        remove_list.append(c)
-                    it += 1
-                    item = it.value()
-                    count2 += 1
-            if not remove_list:
-                break  # cycle or dangling parent: leftovers placed at top level below
-            for item in remove_list:
-                cats.remove(item)
-            count += 1
-        # Fallback: never lose a category. Any with a missing/cyclic parent goes to top level. <- L
-        for c in cats:
-            memo = _("Memo") if c['memo'] != "" else ""
-            top_item = QtWidgets.QTreeWidgetItem([c['name'], 'catid:' + str(c['catid']), memo])
-            top_item.setToolTip(2, c['memo'])
-            top_item.setToolTip(0, '')
-            if len(c['name']) > 52:
-                top_item.setText(0, f"{c['name'][:25]}..{c['name'][-25:]}")
-                top_item.setToolTip(0, c['name'])
-            self.ui.treeWidget.addTopLevelItem(top_item)
-
-        # Add codes, with sub-code nesting. A code is top level only when it has neither a
-        # parent category (catid) nor a parent code (supercid). The rest are nested under
-        # their category (catid:) or under their parent code (cid:). <- L
-
-        def _make_code_item(code_dict):
-            """ Build a styled tree item for a code. Sub-codes share this styling. <- L """
-            memo_ = _("Memo") if code_dict['memo'] != "" else ""
-            code_item = QtWidgets.QTreeWidgetItem([code_dict['name'], f"cid:{code_dict['cid']}", memo_])
-            code_item.setToolTip(2, code_dict['memo'])
-            code_item.setToolTip(0, '')
-            if len(code_dict['name']) > 52:
-                code_item.setText(0, f"{code_dict['name'][:25]}..{code_dict['name'][-25:]}")
-                code_item.setToolTip(0, code_dict['name'])
-            code_item.setBackground(0, QBrush(QtGui.QColor(code_dict['color']), Qt.BrushStyle.SolidPattern))
-            code_item.setForeground(0, QBrush(QtGui.QColor(TextColor(code_dict['color']).recommendation)))
-            code_item.setFlags(
-                Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable |
-                Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsDragEnabled)
-            return code_item
-
-        # Index every node already in the tree (categories) by its id text for O(1) lookup. <- L
-        node_index = {}
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node_index[it.value().text(1)] = it.value()
-            it += 1
-        # Top level codes: no category and no parent code.
-        remove_items = []
-        for c in codes:
-            if c['catid'] is None and c.get('supercid') is None:
-                node = _make_code_item(c)
-                self.ui.treeWidget.addTopLevelItem(node)
-                node_index[f"cid:{c['cid']}"] = node
-                remove_items.append(c)
-        for c in remove_items:
-            codes.remove(c)
-        # Remaining codes: nest under category or parent code. Iterate because a parent code
-        # may itself be a not-yet-placed sub-code. Each pass places every code whose parent
-        # already exists; the loop ends when all are placed or no further progress is possible.
-        count = 0
-        while codes and count < 10000:
-            remove_items = []
-            for c in codes:
-                if c.get('supercid') is not None:
-                    parent_key = f"cid:{c['supercid']}"
-                else:
-                    parent_key = f"catid:{c['catid']}"
-                parent_node = node_index.get(parent_key)
-                if parent_node is not None:
-                    node = _make_code_item(c)
-                    parent_node.addChild(node)
-                    node_index[f"cid:{c['cid']}"] = node
-                    remove_items.append(c)
-            if not remove_items:
-                break  # remaining codes have a missing/cyclic parent: placed at top level below
-            for c in remove_items:
-                codes.remove(c)
-            count += 1
-        # Fallback: never lose a code. Any code with a dangling parent goes to top level. <- L
-        for c in codes:
-            node = _make_code_item(c)
-            self.ui.treeWidget.addTopLevelItem(node)
-            node_index[f"cid:{c['cid']}"] = node
-
-        if self.tree_sort_option == "all asc":
-            self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
-        if self.tree_sort_option == "all desc":
-            self.ui.treeWidget.sortByColumn(0, QtCore.Qt.SortOrder.DescendingOrder)
-        # Show the code tree expanded from the start: sub-code branches are visible by default;
-        # categories the user had collapsed are restored to their collapsed state. <- L
-        self.ui.treeWidget.expandAll()
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node = it.value()
-            if node.text(1) in self.app.collapsed_categories:
-                node.setExpanded(False)
-            it += 1
-        self.fill_code_counts_in_tree()
-        restore_persistent_tree_widths(
-            self.ui.treeWidget,
-            default_width_factors={0: 0.70, 2: 0.15, 3: 0.15}
-        )
-
     def fill_code_counts_in_tree(self):
         """ Calculate the frequency of each code and category for all visible coders and the selected file.
         Add a list item to each code that can be used to display in treeWidget.
@@ -785,7 +631,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         """ Use to quicky open memo. """
 
         if column == 2:
-            self.add_edit_cat_or_code_memo(item)
+            self.code_tree.add_edit_cat_or_code_memo(item)
 
     def get_collapsed(self, item):
         """ On category collapse or expansion signal, find the collapsed parent category items.
@@ -1140,7 +986,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         """
 
         self.get_codes_and_categories()
-        self.fill_tree()
+        self.code_tree.fill_tree()
         self.get_coded_areas()
         self.draw_coded_areas()
 
@@ -1168,7 +1014,7 @@ class DialogCodeImage(QtWidgets.QDialog):
 
         if code_tree_changed:
             self.get_codes_and_categories()
-            self.fill_tree()
+            self.code_tree.fill_tree()
         elif not refresh_areas and not refresh_counts:
             return
 
@@ -1402,179 +1248,6 @@ class DialogCodeImage(QtWidgets.QDialog):
             f.write(h)
         Message(self.app, _("Image exported"), filepath).exec()
 
-    def tree_menu(self, position):
-        """ Context menu for treewidget items.
-        Add, rename, memo, move or delete code or category. Change code color. Find code. """
-
-        menu = QtWidgets.QMenu()
-        menu.setStyleSheet(f"QMenu {{font-size:{self.app.settings['fontsize']}pt}} ")
-        selected = self.ui.treeWidget.currentItem()
-        action_add_code_to_category = None
-        action_add_category_to_category = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_add_code_to_category = menu.addAction(_("Add new code to category"))
-            action_add_category_to_category = menu.addAction(_("Add a new category to category"))
-        action_add_code = menu.addAction(_("Add a new code"))
-        action_add_category = menu.addAction(_("Add a new category"))
-        action_add_subcode = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_add_subcode = menu.addAction(_("Add a new sub-code to code"))
-        action_expand_collapse = None
-        action_cat_show_coded_files = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
-            action_cat_show_coded_files = menu.addAction(_("Show coded files"))
-        if selected is not None and selected.text(1)[0:3] == 'cid' and selected.childCount() > 0:
-            action_expand_collapse = menu.addAction(_("Expand or collapse branch"))
-        modify_menu = menu.addMenu(_("Modify"))
-        action_rename = modify_menu.addAction(_("Rename F2"))
-        action_edit_memo = modify_menu.addAction(_("View or edit memo F3"))
-        action_merge_category = None
-        action_move_category = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            action_merge_category = modify_menu.addAction(_("Merge category into category"))
-            action_move_category = modify_menu.addAction(_("Move category under category F6"))
-        action_delete = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_delete = modify_menu.addAction(_("Delete F4"))
-        action_delete_branch = None
-        if selected is not None and selected.text(1)[0:3] == 'cat':
-            # Cascade deletion of the whole branch, only offered for categories.
-            action_delete_branch = modify_menu.addAction(_("Delete category branch F4"))
-        action_color = None
-        action_show_coded_media = None
-        action_move_code = None
-        action_move_multi_codes = None
-        action_merge_code_into_code = None
-        if selected is not None and selected.text(1)[0:3] == 'cid':
-            action_color = modify_menu.addAction(_("Change code color F5"))
-            action_move_code = modify_menu.addAction(_("Move code to F6"))
-            action_move_multi_codes = modify_menu.addAction(_("Move multiple codes"))
-            action_merge_code_into_code = modify_menu.addAction(_("Merge code into code"))
-            action_show_coded_media = menu.addAction(_("Show coded files"))
-        action_find_code = menu.addAction(_("Find code"))
-        filter_menu = menu.addMenu(_("Filter"))
-        action_show_codes_like = filter_menu.addAction(_("Show codes like") + ": " + self.show_codes_like_filter)
-        action_show_codes_of_colour = filter_menu.addAction(_("Show codes of colour") + ": " + self.show_codes_colour_filter)
-        sort_menu = menu.addMenu(_("Sort"))
-        action_all_asc = sort_menu.addAction(_("Sort ascending"))
-        action_all_desc = sort_menu.addAction(_("Sort descending"))
-        action_cat_then_code_asc = sort_menu.addAction(_("Sort category then code ascending"))
-        action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
-        if action is None:
-            return
-        if action == action_show_codes_of_colour:
-            self.show_codes_of_color()
-            return
-        if action == action_all_asc:
-            self.tree_sort_option = "all asc"
-            self.fill_tree()
-            return
-        if action == action_all_desc:
-            self.tree_sort_option = "all desc"
-            self.fill_tree()
-            return
-        if action == action_cat_then_code_asc:
-            self.tree_sort_option = "cat and code asc"
-            self.fill_tree()
-            return
-        if action == action_find_code:
-            self.find_code_in_tree()
-            return
-        if selected is not None and selected.text(1)[0:3] == 'cid' and action == action_color:
-            self.change_code_color(selected)
-            return
-        if selected is not None and action == action_move_code:
-            self.move_code(selected)
-            return
-        if action == action_move_multi_codes:
-            self.move_multiple_codes()
-            return
-        if action == action_merge_code_into_code and selected is not None:
-            self.merge_code_into_code(selected)  # <- L
-            return
-        if action == action_add_category:
-            self.add_category()
-            return
-        if action == action_add_category_to_category:
-            catid = int(selected.text(1).split(":")[1])
-            self.add_category(catid)
-            return
-        if action == action_move_category:
-            catid = int(selected.text(1).split(":")[1])
-            self.move_category(catid)
-            return
-        if action == action_add_code:
-            self.add_code()
-            return
-        if action == action_expand_collapse:
-            expand_toggle = not selected.isExpanded()
-            self.recursive_expand_collapse_branch(selected, expand_toggle)
-            return
-        if action == action_merge_category:
-            catid = int(selected.text(1).split(":")[1])
-            self.merge_category(catid)
-        if action == action_add_code_to_category:
-            catid = int(selected.text(1).split(":")[1])
-            self.add_code(catid)
-        if action == action_add_subcode and selected is not None:
-            supercid = int(selected.text(1).split(":")[1])  # <- L
-            self.add_code(supercid=supercid)
-            return
-        if action == action_show_codes_like:
-            self.show_codes_like()
-            return
-        if selected is not None and action == action_rename:
-            self.rename_category_or_code(selected)
-        if selected is not None and action == action_edit_memo:
-            self.add_edit_cat_or_code_memo(selected)
-        if selected is not None and action == action_delete:
-            #self.delete_category_or_code(selected)
-            self.delete_code(selected)
-            return
-        if selected is not None and action == action_delete_branch:
-            self.delete_category_branch(selected)
-            return
-        if selected is not None and action == action_delete:
-            self.delete_category_branch(selected)
-        if action == action_cat_show_coded_files:
-            branch_codes = self.recursive_get_branch_codes(selected, [])
-            self.coded_media_dialog(branch_codes, selected.text(0))
-            return
-        if selected is not None and action == action_show_coded_media:
-            to_find = int(selected.text(1)[4:])
-            found = next((code for code in self.codes if code['cid'] == to_find), None)
-            if found:
-                self.coded_media_dialog(found)
-            if found:
-                self.coded_media_dialog(found)
-
-    def recursive_get_branch_codes(self, item, branch_codes):
-        """ Set all children of this item to be expanded or collapsed.
-        Recurse through all child categories. """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            if item.child(i).text(1)[0:3] == "cid":
-                cid = int(item.child(i).text(1)[4:])
-                for code_ in self.codes:
-                    if cid == code_['cid']:
-                        branch_codes.append(code_)
-                        break
-                self.recursive_get_branch_codes(item.child(i), branch_codes)  # also gather sub-codes nested under this code (supercid) <- L
-            if item.child(i).text(1)[0:3] == "cat":
-                self.recursive_get_branch_codes(item.child(i), branch_codes)
-        return branch_codes
-
-    def recursive_expand_collapse_branch(self, item, expand_toggle):
-        """ Set all children of this item to be expanded or collapsed.
-        Recurse through all child categories. """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            item.setExpanded(expand_toggle)
-            self.recursive_expand_collapse_branch(item.child(i), expand_toggle)
-
     def coded_media_dialog(self, code_dict, category_name:str = ""):
         """ Display all coded media for this code, in a separate modal dialog.
         Coded media comes from ALL files for this coder.
@@ -1590,131 +1263,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.get_coded_areas()
         self.redraw_scene()
 
-    def move_category(self, catid: int):
-        """ Select another category to move this category underneath.
-        Args:
-            catid : Integer category identifier
-        """
-
-        do_not_merge_list = []
-        do_not_merge_list = self.recursive_non_merge_item(self.ui.treeWidget.currentItem(), do_not_merge_list)
-        do_not_merge_list.append(str(catid))
-        do_not_merge_ids_string = f"({','.join(do_not_merge_list)})"
-        sql = "select name, catid, supercatid from code_cat where catid not in "
-        sql += do_not_merge_ids_string + " order by name"
-        cur = self.app.conn.cursor()
-        cur.execute(sql)
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
-        ui = DialogSelectItems(self.app, category_list, _("Move Category: Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        current_cat_name = self.ui.treeWidget.currentItem().text(0)
-        if category['name'] == '':
-            cur.execute("update code_cat set supercatid=Null where catid=?", [catid])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → Top level")
-        else:
-            cur.execute("update code_cat set supercatid=? where catid=?", [category['catid'], catid])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Moved category: ") + current_cat_name + " → " + category['name'])
-        self.update_dialog_codes_and_categories()
-
-    def move_multiple_codes(self):
-        """ Move multiple codes to another category. """
-
-        cur = self.app.conn.cursor()
-        cur.execute("select code_name.name, code_cat.name, cid from code_name left join code_cat on "
-                    "code_cat.catid=code_name.catid order by upper(code_cat.name) asc, upper(code_name.name) asc")
-        res = cur.fetchall()
-        code_list = []
-        for r in res:
-            name = r[0]
-            if r[1] is not None:
-                name = r[1] + " ← " + r[0]
-            code_list.append({'name': name, 'cid': r[2]})
-        ui = DialogSelectItems(self.app, code_list, _("Select codes"), "multi")
-        ok = ui.exec()
-        if not ok:
-            return
-        selected_codes = ui.get_selected()
-        cur.execute("select name, catid from code_cat order by upper(name)")
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        for s in selected_codes:
-            # Moving to a category (or to blank) removes any sub-code nesting. <- L
-            cur.execute("update code_name set catid=?, supercid=null where cid=?", [category['catid'], s['cid']])
-            self.app.conn.commit()
-            self.parent_textEdit.append(_("Code moved.") + s['name'].replace(" ← ", "/") + " → " + category['name'])
-        self.update_dialog_codes_and_categories(["code_name"])
-
-    def move_code(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Move code to another category or to no category in the tree.
-        Uses a list selection.
-        param:
-            selected : QTreeWidgetItem
-         """
-
-        items_list = [{'name': " ", 'catid': -1, 'cid': -1}]  # Default blank item
-        iterator = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while iterator.value():
-            can_append = True
-            item = iterator.value()
-            depth = 0
-            current = item
-            # Get depth and if circular reference present
-            while current.parent() is not None:
-                if current.text(1) == selected.text(1):
-                    can_append = False
-                current = current.parent()
-                depth += 1
-            prefix = ""
-            if depth > 0:
-                prefix = "  " * (depth - 1) * 2 + "└─"  # U2514 U2500
-            name = prefix + item.text(0)
-            cid = -1
-            catid = -1
-            if "cid" in item.text(1):
-                cid = int(item.text(1)[4:])
-            else:
-                catid = int(item.text(1)[6:])
-                name += " " + _("[CATEGORY]")
-            # Check the same item is not the same selected item
-            if item.text(1) == selected.text(1) and item.text(2) == selected.text(2):
-                can_append = False
-            memo = item.toolTip(2)
-            if can_append:
-                items_list.append({'name': name, 'catid': catid, 'cid': cid, 'memo': memo})
-            iterator += 1
-        ui = DialogSelectItems(self.app, items_list, _("Move code: Select blank or category or code"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        destination = ui.get_selected()
-        # print(destination)
-        selected_cid = int(selected.text(1)[4:])
-        cur = self.app.conn.cursor()
-        if destination['catid'] == -1 and destination['cid'] == -1:  # move to top level
-            cur.execute("update code_name set catid=null, supercid=null where cid=?", [selected_cid])
-        elif destination['cid'] > 0:  # Move under another code
-            cur.execute("update code_name set catid=null, supercid=? where cid=?", [destination['cid'], selected_cid])
-        else:  # Move under a category
-            cur.execute("update code_name set catid=?, supercid=null where cid=?", [destination['catid'], selected_cid])
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_name"])
-
-    def show_codes_like(self, preset:str|None=None):
+    def show_codes_like(self, preset=None):
         """ Show all codes if text is empty.
          Show selected codes that contain entered text.
          The input dialog is too narrow, so it is re-created.
@@ -1779,7 +1328,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.show_codes_colour_filter = ""
         show_codes_of_colour_range(self.app, self.ui.treeWidget, self.codes, selected)
         self.show_codes_like_filter = ""
-        if self.show_codes_colour_filter == "":  # for clear filter code
+        if self.show_codes_colour_filter == "":  # for clear filter code<- L
             self.ui.pushButton_clear_filter_code.setVisible(False)
             self.ui.pushButton_clear_filter_code.setStyleSheet("")
         else:
@@ -1799,7 +1348,7 @@ class DialogCodeImage(QtWidgets.QDialog):
 
     def clear_file_filter(self):
         """ Clear any active file filter (show files like, case files, attributes)
-        and reload all files. """ 
+        and reload all files. """ # <- L
         self.attributes = []
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable', options=[{'scale_factor': 1.3}]))
         self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
@@ -1808,7 +1357,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.ui.pushButton_clear_filter_file.setVisible(False)
         self.ui.pushButton_clear_filter_file.setStyleSheet("")  # reset blue style
 
-    def recursive_traverse(self, item, text_:str="", case_sensitive=False):
+    def recursive_traverse(self, item, text_="", case_sensitive=False):
         """ Find all children codes of this item that match or not and hide or unhide based on 'text'.
         Recurse through all child categories and sub-codes. A code stays visible if it matches or
         if any of its descendant sub-codes matches, so a match is never hidden under a
@@ -1877,7 +1426,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             selected = self.ui.treeWidget.currentItem()
             if selected is not None and selected.text(1)[0:3] == 'cat':
                 supercatid = int(selected.text(1)[6:])
-            self.add_category(supercatid)
+            self.code_tree.add_category(supercatid)
             return
         if key == QtCore.Qt.Key.Key_H:
             self.ui.groupBox_2.setHidden(not (self.ui.groupBox_2.isHidden()))
@@ -1897,32 +1446,10 @@ class DialogCodeImage(QtWidgets.QDialog):
             return
 
         # Tree widget menu items keys F2 - F6
+        # Tree widget menu item keys F2 - F6, handled by the shared controller. <- L
         if self.ui.treeWidget.hasFocus():
-            selected = self.ui.treeWidget.currentItem()
-            if selected is None:
+            if self.code_tree.handle_key_press(event):
                 return
-            if key == QtCore.Qt.Key.Key_F2:
-                self.rename_category_or_code(selected)
-                return
-            if key == QtCore.Qt.Key.Key_F3:
-                self.add_edit_cat_or_code_memo(selected)
-                return
-            if key == QtCore.Qt.Key.Key_F4:
-                if selected.text(1)[0:3] == 'cat':
-                    self.delete_category_branch(selected)
-                else:
-                    self.delete_code(selected)
-                return
-            if key == QtCore.Qt.Key.Key_F5 and selected.text(1)[0:3] == 'cid':
-                self.change_code_color(selected)
-                return
-            if key == QtCore.Qt.Key.Key_F6:
-                if selected.text(1)[0:3] == 'cat':
-                    self.move_category(selected)
-                else:
-                    self.move_code(selected)
-                return
-
         # Ctrl 0 to 9, G
         if mods & QtCore.Qt.KeyboardModifier.ControlModifier:
             if key == QtCore.Qt.Key.Key_G:
@@ -1961,14 +1488,12 @@ class DialogCodeImage(QtWidgets.QDialog):
             return
         self.ui.horizontalSlider.setValue(v)
 
-    def image_highlight(self, image_operation:str="gray", coded_area=None, code_id:int|None=None):
+    def image_highlight(self, image_operation="gray", coded_area=None, code_id=None):
         """ Gray, blurred or solarised image with coloured coded highlight(s).
         Highlight all coded area, or selected coded area, or all areas coded by one specific code.
         Takes a few seconds to build and show image.
-        Args:
-            image_operation: gray, blurred, solarised
-            coded_area: Dictionary of coded area
-            coded_id: Integer code id
+        :param: coded_area Dictionary of coded area
+        :param: coded_id Integer code id
         """
 
         img = self.pixmap.toImage()
@@ -2035,7 +1560,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         Message(self.app, _('Image saved'), msg, "information").exec()
         self.parent_textEdit.append(msg)
 
-    def text_box(self, draw, background_width, position, text:str, memo:str):
+    def text_box(self, draw, background_width, position, text, memo):
         """ Draw codename caption if show_code_captions=1, or codename plus memo if show_code_captions=2. """
 
         if self.show_code_captions == 0:
@@ -2069,7 +1594,7 @@ class DialogCodeImage(QtWidgets.QDialog):
                 item = self.ui.treeWidget.currentItem()
                 # event position is QPointF, itemAt requires toPoint
                 parent = self.ui.treeWidget.itemAt(event.position().toPoint())
-                self.item_moved_update_data(item, parent)
+                self.code_tree.item_moved_update_data(item, parent)
                 return True
             # Scroll the tree when dragged item it as top or bottom edges
             if event.type() == QtCore.QEvent.Type.DragMove:
@@ -2309,10 +1834,11 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.degrees = 270
         self.redraw_scene()
 
-    def move_or_resize_coding(self, item:dict[str,Any]):
+    def move_or_resize_coding(self, item):
         """ Move or resize a coding rectangle, in pixels.
-        Args:
-            item: Dictionary of image id, x1, y1, width, height, memo, date, owner, cid, important
+
+        params:
+        :name item: Dictionary of image id, x1, y1, width, height, memo, date, owner, cid, important
         """
 
         ui = DialogMoveResizeRectangle(self.app)
@@ -2352,9 +1878,11 @@ class DialogCodeImage(QtWidgets.QDialog):
 
     def find_coded_areas_for_pos(self, pos):
         """ Find any coded areas for this position AND for all visible coders.
-        Args:
-           pos:
-        Returns: [] or coded items
+
+        params:
+        :name pos:
+        :type pos:
+        returns: [] or coded items
         """
 
         if self.file_ is None:
@@ -2379,10 +1907,7 @@ class DialogCodeImage(QtWidgets.QDialog):
 
     def fill_coded_area_label(self, items):
         """ Fill details of label about the currently clicked on coded area.
-        Called by: right click scene menu.
-        Args:
-            items :  
-        """
+        Called by: right click scene menu, """
 
         if not items:
             return
@@ -2421,9 +1946,9 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.app.delete_backup = False
         self.draw_coded_areas()
 
-    def coded_area_memo(self, item:dict[str,Any]):
+    def coded_area_memo(self, item):
         """ Add memo to this coded area.
-        Args:
+        param:
             item : dictionary of coded area """
 
         ui = DialogMemo(self.app, _("Memo for code: ") + item['name'],
@@ -2461,7 +1986,7 @@ class DialogCodeImage(QtWidgets.QDialog):
 
     def unmark(self, item):
         """ Remove coded area.
-        Args:
+        param:
             item : dictionary of coded area """
 
         self.undo_deleted_code = deepcopy(item)
@@ -2702,776 +2227,18 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.redraw_scene()
         self.app.delete_backup = False
 
-    def _category_is_descendant(self, candidate_catid, ancestor_catid):
-        """ Return True if candidate_catid is ancestor_catid or one of its descendant
-        sub-categories. Used to prevent cycles when moving a category under another. <- L """
-        if candidate_catid == ancestor_catid:
-            return True
-        children = {}
-        for c in self.categories:
-            sup = c.get('supercatid')
-            if sup is not None:
-                children.setdefault(sup, []).append(c['catid'])
-        stack = list(children.get(ancestor_catid, []))
-        seen = set()
-        while stack:
-            catid = stack.pop()
-            if catid == candidate_catid:
-                return True
-            if catid in seen:
-                continue
-            seen.add(catid)
-            stack.extend(children.get(catid, []))
-        return False
-
-    def item_moved_update_data(self, item:QtWidgets.QTreeWidgetItem, parent:QtWidgets.QTreeWidgetItem):
-        """ Called from drop event in treeWidget view port.
-        identify code or category to move.
-        Also merge codes if one code is dropped on another code.
-        param:
-            item : QTreeWidgetItem
-            parent : QTreeWidgetItem """
-
-        # Find the category in the list
-        if item.text(1)[0:3] == 'cat':
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(item.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            if parent is None:
-                self.categories[found]['supercatid'] = None
-            else:
-                if parent.text(1).split(':')[0] == 'cid':
-                    # parent is code (leaf) cannot add child
-                    return
-                supercatid = int(parent.text(1).split(':')[1])
-                if supercatid == self.categories[found]['catid']:
-                    # Cannot be its own parent.
-                    return
-                # Guard against cycles: moving a category under one of its own sub-categories
-                # would make the branch disappear and corrupt the tree. <- L
-                if self._category_is_descendant(supercatid, self.categories[found]['catid']):
-                    Message(self.app, _("Cannot move category"),
-                            _("Cannot move a category under one of its own sub-categories.")).exec()
-                    return
-                self.categories[found]['supercatid'] = supercatid
-            cur = self.app.conn.cursor()
-            cur.execute("update code_cat set supercatid=? where catid=?",
-                        [self.categories[found]['supercatid'], self.categories[found]['catid']])
-            self.app.conn.commit()
-            self.update_dialog_codes_and_categories(["code_cat"])
-            self.app.delete_backup = False
-            return
-
-        # Find the code in the list
-        if item.text(1)[0:3] == 'cid':
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(item.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            if parent is None:
-                # Move code to top level: clear both parents. <- L
-                self.codes[found]['catid'] = None
-                self.codes[found]['supercid'] = None
-            else:
-                if parent.text(1).split(':')[0] == 'cid':
-                    parent_cid = int(parent.text(1).split(':')[1])
-                    # Ctrl held while dropping a code on a code merges (previous behaviour);
-                    # otherwise the code is nested as a sub-code. <- L
-                    ctrl = bool(QtWidgets.QApplication.keyboardModifiers() &
-                                QtCore.Qt.KeyboardModifier.ControlModifier)
-                    if ctrl:
-                        self.merge_codes(self.codes[found], parent)
-                        return
-                    if parent_cid == self.codes[found]['cid']:
-                        return  # cannot nest under itself
-                    if self._code_is_descendant(parent_cid, self.codes[found]['cid']):
-                        Message(self.app, _("Cannot nest code"),
-                                _("Cannot move a code under one of its own sub-codes.")).exec()
-                        return
-                    # Nest as a sub-code (mutually exclusive with category). <- L
-                    self.codes[found]['supercid'] = parent_cid
-                    self.codes[found]['catid'] = None
-                else:
-                    # Dropped onto a category. <- L
-                    catid = int(parent.text(1).split(':')[1])
-                    self.codes[found]['catid'] = catid
-                    self.codes[found]['supercid'] = None
-            cur = self.app.conn.cursor()
-            cur.execute("update code_name set catid=?, supercid=? where cid=?",
-                        [self.codes[found]['catid'], self.codes[found].get('supercid'),
-                         self.codes[found]['cid']])
-            self.app.conn.commit()
-            self.update_dialog_codes_and_categories(["code_name"])
-            self.app.delete_backup = False
-
-    def _code_is_descendant(self, candidate_cid, ancestor_cid):
-        """ Return True if candidate_cid is ancestor_cid or one of its descendant sub-codes.
-        Used to prevent cycles when nesting a code under another code. <- L """
-        if candidate_cid == ancestor_cid:
-            return True
-        children = {}
-        for c in self.codes:
-            sup = c.get('supercid')
-            if sup is not None:
-                children.setdefault(sup, []).append(c['cid'])
-        stack = list(children.get(ancestor_cid, []))
-        seen = set()
-        while stack:
-            cid = stack.pop()
-            if cid == candidate_cid:
-                return True
-            if cid in seen:
-                continue
-            seen.add(cid)
-            stack.extend(children.get(cid, []))
-        return False
-
-    def recursive_non_merge_item(self, item, no_merge_list):
-        """ Find matching item to be the current selected item.
-        Recurse through any child categories.
-        Tried to use QTreeWidget.finditems - but this did not find matching item text
-        Called by: textEdit recent codes menu option
-        Required for: merge_category()
-        """
-
-        child_count = item.childCount()
-        for i in range(child_count):
-            if item.child(i).text(1)[0:3] == "cat":
-                no_merge_list.append(item.child(i).text(1)[6:])
-            self.recursive_non_merge_item(item.child(i), no_merge_list)
-        return no_merge_list
-
-    def merge_category(self, catid):
-        """ Select another category to merge this category into.
-        params:
-            catid: Integer category id that is to be merged and removed. """
-
-        do_not_merge_list = []
-        do_not_merge_list = self.recursive_non_merge_item(self.ui.treeWidget.currentItem(), do_not_merge_list)
-        do_not_merge_list.append(str(catid))
-        do_not_merge_ids_str = "(" + ",".join(do_not_merge_list) + ")"
-        sql = "select name, catid, supercatid from code_cat where catid not in "
-        sql += do_not_merge_ids_str + " order by name"
-        cur = self.app.conn.cursor()
-        cur.execute(sql)
-        res = cur.fetchall()
-        category_list = [{'name': "", 'catid': None, 'supercatid': None}]
-        for r in res:
-            category_list.append({'name': r[0], 'catid': r[1], "supercatid": r[2]})
-        ui = DialogSelectItems(self.app, category_list, _("Select blank or category"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        category = ui.get_selected()
-        try:
-            # Always record merge information in the target category's memo <- L
-            source_cat = None
-            for c in self.categories:
-                if c['catid'] == catid:
-                    source_cat = c
-                    break
-            if source_cat is not None and category['catid'] is not None:
-                target_cat = None
-                for c in self.categories:
-                    if c['catid'] == category['catid']:
-                        target_cat = c
-                        break
-                if target_cat is not None:
-                    merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
-                    source_memo = (source_cat.get('memo', '') or '').strip()
-                    source_owner = source_cat.get('owner', self.app.settings['codername'])
-                    merged_block = f"\n\n[{_('Merged from category:')} {source_cat['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"  
-                    if source_memo:
-                        merged_block += f"\n{source_memo}"
-                    target_memo = target_cat.get('memo', '') or ''
-                    new_memo = (target_memo + merged_block).strip()
-                    cur.execute("update code_cat set memo=? where catid=?", [new_memo, category['catid']])
-                    target_cat['memo'] = new_memo 
-            for code in self.codes:
-                if code['catid'] == catid:
-                    cur.execute("update code_name set catid=? where catid=?", [category['catid'], catid])
-            cur.execute("delete from code_cat where catid=?", [catid])
-            for cat in self.categories:
-                if cat['supercatid'] == catid:
-                    cur.execute("update code_cat set supercatid=? where supercatid=?", [category['catid'], catid])
-            # Clear any orphan supercatids
-            sql = "select supercatid from code_cat where supercatid not in (select catid from code_cat)"
-            cur.execute(sql)
-            orphans = cur.fetchall()
-            sql = "update code_cat set supercatid=Null where supercatid=?"
-            for orphan in orphans:
-                cur.execute(sql, [orphan[0]])
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            self.app.conn.rollback()  # revert all changes
-            self.update_dialog_codes_and_categories()
-            raise
-        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
-
-    def merge_code_into_code(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Merge the selected code into another code chosen from a list.
-        Reuses merge_codes (the same logic used by drag-and-drop with Ctrl). The source code
-        and all of its descendant sub-codes are excluded from the candidate targets to avoid
-        creating a supercid cycle when merging a code into one of its own sub-codes. <- L
-        param:
-            selected: QTreeWidgetItem
-        """
-
-        if selected is None or selected.text(1)[0:3] != 'cid':
-            return
-        src_cid = int(selected.text(1)[4:])
-        source_code = next((c for c in self.codes if c['cid'] == src_cid), None)
-        if source_code is None:
-            return
-        # Candidate targets: every code that is not the source nor a descendant of the source.
-        target_list = []
-        for c in self.codes:
-            if not self._code_is_descendant(c['cid'], src_cid):
-                target_list.append({'name': c['name'], 'cid': c['cid']})
-        if not target_list:
-            Message(self.app, _("Merge code into code"),
-                    _("There is no other code to merge into.")).exec()
-            return
-        target_list = sorted(target_list, key=lambda x: x['name'].lower())
-        ui = DialogSelectItems(self.app, target_list, _("Select code to merge into"), "single")
-        ok = ui.exec()
-        if not ok:
-            return
-        target = ui.get_selected()
-        if not target:
-            return
-        # merge_codes expects the target as a QTreeWidgetItem, so find it in the tree.
-        target_item = None
-        it = QtWidgets.QTreeWidgetItemIterator(self.ui.treeWidget)
-        while it.value():
-            node = it.value()
-            if node.text(1) == f"cid:{target['cid']}":
-                target_item = node
-                break
-            it += 1
-        if target_item is None:
-            return
-        self.merge_codes(source_code, target_item)
-
-    def merge_codes(self, item:QtWidgets.QTreeWidgetItem, parent):
-        """ Merge code with another code.
-        Called by item_moved_update_data when a code is moved onto another code.
-        param:
-            item : QTreeWidgetItem
-            parent : QTreeWidgetItem
-        """
-
-        # Check item dropped on itself. Error can occur on Ubuntu 22.04.
-        if item['name'] == parent.text(0):
-            return
-        # Prevent a supercid cycle <- L
-        target_cid = int(parent.text(1).split(':')[1])
-        if self._code_is_descendant(target_cid, item['cid']):
-            Message(self.app, _("Cannot merge code"),
-                    _("Cannot merge a code into itself or one of its own sub-codes.")).exec()
-            return
-        msg = _("Merge code: ") + item['name'] + " ==> " + parent.text(0)
-        reply = QtWidgets.QMessageBox.question(self, _('Merge codes'),
-                                               msg, QtWidgets.QMessageBox.StandardButton.Yes,
-                                               QtWidgets.QMessageBox.StandardButton.No)
-        if reply == QtWidgets.QMessageBox.StandardButton.No:
-            return
-        cur = self.app.conn.cursor()
-        old_cid = item['cid']
-        new_cid = int(parent.text(1).split(':')[1])
-        # Always record merge information in the target code's memo <- L
-        target_code = None
-        for c in self.codes:
-            if c['cid'] == new_cid:
-                target_code = c
-                break
-        if target_code is not None:
-            merge_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
-            source_memo = item.get('memo', '').strip()
-            source_owner = item.get('owner', self.app.settings['codername'])
-            merged_block = f"\n\n[{_('Merged from code:')} {item['name']}, {_('Coder:')} {source_owner}, {_('Merger date:')} {merge_date}]"  
-            if source_memo:
-                merged_block += f"\n{source_memo}"
-            target_memo = target_code.get('memo', '') or ''
-            new_memo = (target_memo + merged_block).strip()
-            cur.execute("update code_name set memo=? where cid=?", [new_memo, new_cid])
-            target_code['memo'] = new_memo
-        # Update cid for each coded segment in text, av, image. Delete where there is an Integrity error
-        ct_sql = "select ctid from code_text where cid=?"
-        cur.execute(ct_sql, [old_cid])
-        ct_res = cur.fetchall()
-        try:
-            for ct in ct_res:
-                try:
-                    cur.execute("update code_text set cid=? where ctid=?", [new_cid, ct[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_text where ctid=?", [ct[0]])
-            av_sql = "select avid from code_av where cid=?"
-            cur.execute(av_sql, [old_cid])
-            av_res = cur.fetchall()
-            for av in av_res:
-                try:
-                    cur.execute("update code_av set cid=? where avid=?", [new_cid, av[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_av where avid=?", [av[0]])
-            img_sql = "select imid from code_image where cid=?"
-            cur.execute(img_sql, [old_cid])
-            img_res = cur.fetchall()
-            for img in img_res:
-                try:
-                    cur.execute("update code_image set cid=? where imid=?", [new_cid, img[0]])
-                except sqlite3.IntegrityError:
-                    cur.execute("delete from code_image where imid=?", [img[0]])
-
-            # Re-parent the merged code's sub-codes onto the target code (no orphans). <- L
-            cur.execute("update code_name set supercid=?, catid=null where supercid=?", [new_cid, old_cid])
-            cur.execute("delete from code_name where cid=?", [old_cid, ])
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            logger.warning(e_)
-            self.app.conn.rollback()  # revert all changes
-            raise
-        self.parent_textEdit.append(msg)
-        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
-        self.app.delete_backup = False
-
-    def add_code(self, catid=None, supercid=None):
-        """  Use add_item dialog to get new code text. Add_code_name dialog checks for
-        duplicate code name. A random color is selected for the code.
-        New code is added to data and database.
-        param:
-            catid : None to add to without category, catid to add to category.
-            supercid : None, or Integer to add the code as a sub-code of another code. <- L """
-
-        # Mutual exclusivity: a sub-code never belongs to a category as well. <- L
-        if supercid is not None:
-            catid = None
-        ui = DialogAddItemName(self.app, self.codes, _("Add new code"), _("Code name"))
-        ui.exec()
-        new_code_name = ui.get_new_name()
-        if new_code_name is None:
-            return
-        code_color = colors[randint(0, len(colors) - 1)]
-        if self.default_new_code_color:
-            code_color = self.default_new_code_color
-        item = {'name': new_code_name, 'memo': "", 'owner': self.app.settings['codername'],
-                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S"), 'catid': catid,
-                'color': code_color, 'supercid': supercid}
-        cur = self.app.conn.cursor()
-        cur.execute("insert into code_name (name,memo,owner,date,catid,color,supercid) values(?,?,?,?,?,?,?)",
-                    (item['name'], item['memo'], item['owner'], item['date'], item['catid'], item['color'],
-                     item['supercid']))
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_name"])
-        self.parent_textEdit.append(_("New code: ") + item['name'])
-        self.app.delete_backup = False
-
-    def add_category(self, supercatid=None):
-        """ Add a new category.
-        Note: the addItem dialog does the checking for duplicate category names
-        param:
-            suoercatid : None to add without category, supercatid to add to category. """
-
-        ui = DialogAddItemName(self.app, self.categories, _("Category"), _("Category name"))
-        ui.exec()
-        new_category_text = ui.get_new_name()
-        if new_category_text is None:
-            return
-        # add to database
-        item = {'name': new_category_text, 'cid': None, 'memo': "",
-                'owner': self.app.settings['codername'],
-                'date': datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")}
-        cur = self.app.conn.cursor()
-        cur.execute("insert into code_cat (name, memo, owner, date, supercatid) values(?,?,?,?,?)",
-                    (item['name'], item['memo'], item['owner'], item['date'], supercatid))
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_cat"])
-        self.parent_textEdit.append(_("New category: ") + item['name'])
-        self.app.delete_backup = False
-
-    '''def delete_category_or_code(self, selected):
-        """ Delete the selected category or code.
-        If category deleted, sublevel items are retained.
-        param:
-            selected : QTreeWidgetItem """
-
-        if selected.text(1)[0:3] == 'cat':
-            self.delete_category(selected)
-            return  # Avoids error as selected is now None
-        if selected.text(1)[0:3] == 'cid':
-            self.delete_code(selected)'''
-
-    def delete_code(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Find code, remove from database, refresh and code_name data and fill
-        treeWidget.
-        param:
-            selected : QTreeWidgetItem """
-
-        # Find the code_in the list, check to delete
-        found = -1
-        for i in range(0, len(self.codes)):
-            if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                found = i
-        if found == -1:
-            return
-        code_ = self.codes[found]
-        ui = DialogConfirmDelete(self.app, _("Code: ") + selected.text(0))
-        ok = ui.exec()
-        if not ok:
-            return
-        self.parent_textEdit.append(_("Code deleted: ") + code_['name'])
-        cur = self.app.conn.cursor()
-        # Re-parent this code's sub-codes so they are not orphaned by the deletion. <- L
-        if code_.get('supercid') is not None:
-            # Was itself a sub-code: lift its children to the grandparent code.
-            cur.execute("update code_name set supercid=? where supercid=?", [code_['supercid'], code_['cid']])
-        else:
-            # Was top level (possibly under a category): move children into that category (or top level).
-            cur.execute("update code_name set supercid=null, catid=? where supercid=?",
-                        [code_['catid'], code_['cid']])
-        cur.execute("delete from code_name where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_image where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_av where cid=?", [code_['cid'], ])
-        cur.execute("delete from code_text where cid=?", [code_['cid'], ])
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_name", "code_text", "code_av", "code_image"])
-        self.app.delete_backup = False
-
-    '''def delete_category(self, selected):
-        """ Find category, remove from database, refresh categories and code data
-        and fill treeWidget. Sublevel items are retained.
-        param:
-            selected : QTreeWidgetItem """
-
-        found = -1
-        for i in range(0, len(self.categories)):
-            if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                found = i
-        if found == -1:
-            return
-        category = self.categories[found]
-        ui = DialogConfirmDelete(self.app, _("Category: ") + selected.text(0))
-        ok = ui.exec()
-        if not ok:
-            return
-        cur = self.app.conn.cursor()
-        cur.execute("update code_name set catid=null where catid=?", [category['catid'], ])
-        cur.execute("update code_cat set supercatid=null where catid = ?", [category['catid'], ])
-        cur.execute("delete from code_cat where catid = ?", [category['catid'], ])
-        self.app.conn.commit()
-        # An extra check. Fix 'lost' categories if present.
-        sql = "update code_cat set supercatid=null where supercatid is not null and supercatid not in " \
-              "(select catid from code_cat)"
-        cur.execute(sql)
-        self.app.conn.commit()
-        self.parent_textEdit.append(_("Category deleted: ") + category['name'])
-        self.update_dialog_codes_and_categories(["code_cat", "code_name"])
-        self.app.delete_backup = False'''
-
-    def get_branch_catids_and_cids(self, catid:int):
-            """ Gather every category and code that hangs below a category, including the category itself.
-            Sub-codes (supercid) nested under branch codes are collected too.
-            Read straight from the database, not from the cached self.codes / self.categories, so a
-            stale dialog snapshot can never delete or miss the wrong rows.
-            Iterative walk, so cyclic or malformed data cannot cause infinite recursion. <- L
-            Args:
-                catid: Integer, category id of the branch root
-            Returns:
-                Tuple: (list of category ids, list of code ids)
-            """
-    
-            cur = self.app.conn.cursor()
-            cur.execute("select catid, supercatid from code_cat")
-            db_cats = cur.fetchall()
-            cur.execute("select cid, catid, supercid from code_name")
-            db_codes = cur.fetchall()
-            catids = [catid]
-            i = 0
-            while i < len(catids):
-                for cat_ in db_cats:
-                    if cat_[1] == catids[i] and cat_[0] not in catids:
-                        catids.append(cat_[0])
-                i += 1
-            cids = []
-            for code_ in db_codes:
-                if code_[1] in catids and code_[0] not in cids:
-                    cids.append(code_[0])
-            i = 0
-            while i < len(cids):
-                for code_ in db_codes:
-                    if code_[2] == cids[i] and code_[0] not in cids:
-                        cids.append(code_[0])
-                i += 1
-            return catids, cids
-    
-    def delete_category_branch(self, selected:QtWidgets.QTreeWidgetItem):
-        """ Delete a category and everything underneath it: nested categories, codes, sub-codes
-        and all the codings (text, audio/video, image) made with those codes.
-        Unlike Delete, which only removes the category and re-parents its contents,
-        this cascades down the whole branch. All writes run in a single transaction. <- L
+    def delete_category_or_code(self, selected):
+        """ Determine if selected item is a code or category before deletion.
+        Category deletion now cascades down the whole branch, matching the
+        Delete category branch option propagated from the text coding page. <- L
         Args:
             selected: QTreeWidgetItem
         """
-
-        if selected is None or selected.text(1)[0:3] != 'cat':
-            return
-        cur = self.app.conn.cursor()
-        cur.execute("select catid, name from code_cat where catid=?", [int(selected.text(1)[6:]), ])
-        res = cur.fetchone()
-        if res is None:  # Already deleted elsewhere, the tree item is stale
-            self.update_dialog_codes_and_categories([])
-            return
-        category = {'catid': res[0], 'name': res[1]}
-        catids, cids = self.get_branch_catids_and_cids(category['catid'])
-        # Count the codings that will be lost, so the user knows what is at stake.
-        # One grouped scan per table, instead of one query per code. <- L
-        cids_set = set(cids)
-        codings = 0
-        for table in ("code_text", "code_av", "code_image"):
-            cur.execute(f"select cid, count(*) from {table} group by cid")
-            for row in cur.fetchall():
-                if row[0] in cids_set:
-                    codings += row[1]
-        msg = _("Category branch") + ": " + category['name'] + "\n\n"
-        msg += _("All categories and codes under this category will also be deleted.") + "\n"
-        msg += _("All codings made with these codes across all files will be deleted.") + "\n\n"
-        msg += _("Categories to delete") + f": {len(catids)}\n"
-        msg += _("Codes to delete") + f": {len(cids)}\n"
-        msg += _("Codings to delete") + f": {codings}\n\n"
-        msg += _("Make a project backup first. This action cannot be undone.")
-        ui = DialogConfirmDelete(self.app, msg)
-        # Cancel is the default button here, so a stray Enter cannot wipe out the branch. <- L
-        button_box = ui.findChild(QtWidgets.QDialogButtonBox)
-        if button_box is not None:
-            ok_button = button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
-            cancel_button = button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
-            if ok_button is not None:
-                ok_button.setAutoDefault(False)
-                ok_button.setDefault(False)
-            if cancel_button is not None:
-                cancel_button.setAutoDefault(True)
-                cancel_button.setDefault(True)
-                cancel_button.setFocus()
-        ok = ui.exec()
-        if not ok:
-            return
-        try:
-            for cid in cids:
-                cur.execute("delete from code_text where cid=?", [cid, ])
-                cur.execute("delete from code_av where cid=?", [cid, ])
-                cur.execute("delete from code_image where cid=?", [cid, ])
-                cur.execute("delete from code_name where cid=?", [cid, ])
-                # Saved graphs: drop nodes and links pointing at this code, so that a reused
-                # cid cannot silently re-bind an old graph node to an unrelated code. <- L
-                cur.execute("delete from gr_cdct_text_item where cid=?", [cid, ])
-                cur.execute("delete from gr_cdct_line_item where fromcid=? or tocid=?", [cid, cid])
-                cur.execute("delete from gr_free_line_item where fromcid=? or tocid=?", [cid, cid])
-            for cat_id in catids:
-                cur.execute("delete from code_cat where catid=?", [cat_id, ])
-                cur.execute("delete from gr_cdct_text_item where catid=?", [cat_id, ])
-                cur.execute("delete from gr_cdct_line_item where fromcatid=? or tocatid=?", [cat_id, cat_id])
-                cur.execute("delete from gr_free_line_item where fromcatid=? or tocatid=?", [cat_id, cat_id])
-            # Drop the deleted codes from the stored recently used codes. <- L
-            cur.execute("select recently_used_codes from project")
-            recent_res = cur.fetchone()
-            if recent_res is not None and recent_res[0]:
-                keep = []
-                for token in recent_res[0].split():
-                    try:
-                        if int(token) in cids:
-                            continue
-                    except ValueError:
-                        pass
-                    keep.append(token)
-                cur.execute("update project set recently_used_codes=?", [" ".join(keep), ])
-            # Extra check. Clear any dangling references left behind by the deletion. <- L
-            cur.execute("update code_cat set supercatid=null where supercatid is not null and supercatid not in "
-                        "(select catid from code_cat)")
-            cur.execute("update code_name set catid=null where catid is not null and catid not in "
-                        "(select catid from code_cat)")
-            cur.execute("update code_name set supercid=null where supercid is not null and supercid not in "
-                        "(select cid from code_name)")
-            self.app.conn.commit()
-        except Exception as e_:
-            print(e_)
-            self.app.conn.rollback()  # Revert all changes
-            self.update_dialog_codes_and_categories([])
-            raise
-        # Remove the deleted codes from the recent codes list
-        self.recent_codes = [c for c in self.recent_codes if c['cid'] not in cids]
-        self.app.delete_backup = False
-        msg = _("Category branch deleted") + ": " + category['name'] + ". "
-        msg += _("Categories") + f": {len(catids)}, " + _("Codes") + f": {len(cids)}, "
-        msg += _("Codings") + f": {codings}"
-        self.parent_textEdit.append(msg)
-        self.update_dialog_codes_and_categories(["code_cat", "code_name", "code_text", "code_av", "code_image"])
-
-    def add_edit_cat_or_code_memo(self, selected):
-        """ View and edit a memo.
-        param:
-            selected : QTreeWidgetItem """
-
-        changed_tables = []
-
-        if selected.text(1)[0:3] == 'cid':
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            ui = DialogMemo(self.app, _("Memo for Code ") + self.codes[found]['name'],
-                            self.codes[found]['memo'])
-            ui.exec()
-            memo = ui.memo
-            if memo == "":
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
-            else:
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
-            # Update codes list and database
-            if memo != self.codes[found]['memo']:
-                self.codes[found]['memo'] = memo
-                cur = self.app.conn.cursor()
-                cur.execute("update code_name set memo=? where cid=?", (memo, self.codes[found]['cid']))
-                self.app.conn.commit()
-                self.app.delete_backup = False
-                changed_tables = ["code_name"]
-
         if selected.text(1)[0:3] == 'cat':
-            # Find the category in the list
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            ui = DialogMemo(self.app, _("Memo for Category: ") + self.categories[found]['name'],
-                            self.categories[found]['memo'])
-            ui.exec()
-            memo = ui.memo
-            if memo == "":
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, "")
-            else:
-                selected.setData(2, QtCore.Qt.ItemDataRole.DisplayRole, _("Memo"))
-            # update codes list and database
-            if memo != self.categories[found]['memo']:
-                self.categories[found]['memo'] = memo
-                cur = self.app.conn.cursor()
-                cur.execute("update code_cat set memo=? where catid=?", (memo, self.categories[found]['catid']))
-                self.app.conn.commit()
-                self.app.delete_backup = False
-                changed_tables = ["code_cat"]
-        self.update_dialog_codes_and_categories(changed_tables)
-
-    def rename_category_or_code(self, selected):
-        """ Rename a code or category. Checks that the proposed code or category name is
-        not currently in use.
-        param:
-            selected : QTreeWidgetItem """
-
+            self.code_tree.delete_category_branch(selected)
+            return  # Avoid error as selected is now None
         if selected.text(1)[0:3] == 'cid':
-            found_code = None
-            check_codes = []
-            for code_ in self.codes:
-                if code_['cid'] == int(selected.text(1)[4:]):
-                    found_code = code_
-                else:
-                    check_codes.append(code_)
-            ui = DialogAddItemName(self.app, check_codes, _("Rename code"), _("Code name"))
-            ui.ui.lineEdit.setText(found_code['name'])
-            ui.exec()
-            new_name = ui.get_new_name()
-            if new_name is None or new_name == found_code['name']:
-                return
-            # Find the code in the list
-            found = -1
-            for i in range(0, len(self.codes)):
-                if self.codes[i]['cid'] == int(selected.text(1)[4:]):
-                    found = i
-            if found == -1:
-                return
-            # Update codes list and database
-            cur = self.app.conn.cursor()
-            cur.execute("update code_name set name=? where cid=?", (new_name, self.codes[found]['cid']))
-            self.app.conn.commit()
-            old_name = self.codes[found]['name']
-            self.update_dialog_codes_and_categories(["code_name"])
-            self.parent_textEdit.append(_("Code renamed: ") +
-                                        old_name + " ==> " + new_name)
-            self.app.delete_backup = False
-            return
-
-        if selected.text(1)[0:3] == 'cat':
-            found_cat = None
-            check_categories = []
-            for category in self.categories:
-                if category['catid'] == int(selected.text(1)[6:]):
-                    found_cat = category
-                else:
-                    check_categories.append(category)
-            ui = DialogAddItemName(self.app, check_categories, _("Rename category"), _("Category name"))
-            ui.ui.lineEdit.setText(found_cat['name'])
-            ui.exec()
-            new_name = ui.get_new_name()
-            if new_name is None or new_name == found_cat['name']:
-                return
-
-            # Find the category in the list
-            found = -1
-            for i in range(0, len(self.categories)):
-                if self.categories[i]['catid'] == int(selected.text(1)[6:]):
-                    found = i
-            if found == -1:
-                return
-            # Update category list and database
-            cur = self.app.conn.cursor()
-            cur.execute("update code_cat set name=? where catid=?",
-                        (new_name, self.categories[found]['catid']))
-            self.app.conn.commit()
-            old_name = self.categories[found]['name']
-            # self.categories[found]['name'] = new_name
-            # selected.setData(0, QtCore.Qt.DisplayRole, new_name)
-            self.parent_textEdit.append(_("Category renamed from: ") +
-                                        f"{old_name} ==> {new_name}")
-            self.update_dialog_codes_and_categories(["code_cat"])
-            self.app.delete_backup = False
-
-    def change_code_color(self, selected):
-        """ Change the color of the currently selected code.
-        param:
-            selected : QTreeWidgetItem """
-
-        cid = int(selected.text(1)[4:])
-        found = -1
-        for i in range(0, len(self.codes)):
-            if self.codes[i]['cid'] == cid:
-                found = i
-        if found == -1:
-            return
-        ui = DialogColorSelect(self.app, self.codes[found])  # ['color'])
-        ok = ui.exec()
-        if not ok:
-            return
-        new_color = ui.get_color()
-        if new_color is None:
-            return
-        selected.setBackground(0, QBrush(QtGui.QColor(new_color), Qt.BrushStyle.SolidPattern))
-        # Update codes list and database
-        self.codes[found]['color'] = new_color
-        cur = self.app.conn.cursor()
-        cur.execute("update code_name set color=? where cid=?",
-                    (self.codes[found]['color'], self.codes[found]['cid']))
-        self.app.conn.commit()
-        self.update_dialog_codes_and_categories(["code_name"])
-        self.app.delete_backup = False
-
+            self.code_tree.delete_code(selected)
 
 class DialogViewImage(QtWidgets.QDialog):
     """ View image. View and edit displayed memo.

--- a/src/qualcoder/view_image.py
+++ b/src/qualcoder/view_image.py
@@ -32,14 +32,15 @@ import PIL.Image
 from PIL import Image, ImageDraw, ImageFilter, ImageFont, ImageOps
 import qtawesome as qta  # see: https://pictogrammers.com/library/mdi/
 import sqlite3
+from typing import Any
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtCore import Qt, QBuffer
 from PyQt6.QtGui import QBrush
 
 from .code_in_all_files import DialogCodeInAllFiles
-from .coder_names import DialogCoderNames
 from .code_tree import CodeTreeController
+from .coder_names import DialogCoderNames
 from .color_selector import DialogColorSelect
 from .color_selector import colour_ranges, show_codes_of_colour_range
 from .GUI.ui_dialog_code_image import Ui_Dialog_code_image
@@ -79,17 +80,16 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.log = ""
         self.scale = 1.0  # Image scaling
         self.selection = None  # Initial code rectangle point
-        # State variables for interactive resizing functionality <- L
-        self.item_to_resize = None         # Stores the segment dictionary selected for resizing <- L
-        self.is_dragging_handle = False    # Flag indicating if a resize handle is being dragged <- L
-        self.active_handle = None          # Identifies the active corner ("TL", "TR", "BL", "BR") <- L
-        self.interactive_rect_item = None  # Visual dashed rectangle shown during drag <- L
-        self.original_resize_geom = None   # Stores original geometry (x, y, w, h) before drag <- L
+        # State variables for interactive resizing functionality
+        self.item_to_resize = None         # Stores the segment dictionary selected for resizing
+        self.is_dragging_handle = False    # Flag indicating if a resize handle is being dragged
+        self.active_handle = None          # Identifies the active corner ("TL", "TR", "BL", "BR")
+        self.interactive_rect_item = None  # Visual dashed rectangle shown during drag
+        self.original_resize_geom = None   # Stores original geometry (x, y, w, h) before drag
         self.important = False  # Show/hide important flagged codes
         self.attributes = []
         self.degrees = 0  # For image rotation
         self.get_codes_and_categories()
-        self.tree_sort_option = "all asc"  # all desc, cat then code asc
         self.show_code_captions = 0  # 0 = no, 1 = code name, 2 = codename + memo
         self.default_new_code_color = None
         self.show_codes_like_filter = ""  # gets filled when text strings are used to show specific code names
@@ -138,7 +138,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         # Shared code tree controller: tree loading, common context menu, drag and drop
         # reparenting, F2-F6 shortcuts and category branch deletion live in code_tree.py,
-        # so the four coding pages no longer duplicate this logic by hand. <- L
+        # so the four coding pages no longer duplicate this logic by hand.
         self.code_tree = CodeTreeController(self.app, self.ui.treeWidget, self)
         self.ui.treeWidget.customContextMenuRequested.connect(self.code_tree.tree_menu)
         self.code_tree.fill_counts_callback = self.fill_code_counts_in_tree
@@ -147,7 +147,6 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.code_tree.show_codes_like_callback = self.show_codes_like
         self.code_tree.show_codes_of_colour_callback = self.show_codes_of_color
         self.code_tree.codes_changed.connect(self.update_dialog_codes_and_categories)
-
         self.ui.treeWidget.itemClicked.connect(self.tree_item_clicked)
         init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodeimage_tree_widths')
         # Header widgets
@@ -178,7 +177,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.ui.pushButton_document_memo.pressed.connect(self.active_file_memo)
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable', options=[{'scale_factor': 1.3}]))
         self.ui.pushButton_file_attributes.pressed.connect(self.get_files_from_attributes)
-        self.ui.pushButton_clear_filter_file.setIcon(qta.icon('mdi6.filter-off-outline', options=[{'scale_factor': 1.3}]))  # for clear filter file <- L
+        self.ui.pushButton_clear_filter_file.setIcon(qta.icon('mdi6.filter-off-outline', options=[{'scale_factor': 1.3}]))  # for clear filter file
         self.ui.pushButton_clear_filter_file.pressed.connect(self.clear_file_filter)
         self.ui.pushButton_clear_filter_file.setToolTip(_("Clear file filter"))
         self.ui.pushButton_clear_filter_file.setVisible(False)  # hidden until a filter is active        
@@ -394,7 +393,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         selection_blocker = QtCore.QSignalBlocker(selection_model) if selection_model is not None else None
         self.ui.listWidget.clear()
         cur = self.app.conn.cursor()
-        sql = "select name, id, memo, owner, date, mediapath, risid from source where "  # Missing parentheses <- L
+        sql = "select name, id, memo, owner, date, mediapath, risid from source where "
         sql += "((substr(mediapath,1,7) in ('/images', 'images:')) or "  # added outer opening parenthesis to group OR conditions
         sql += "(lower(substr(mediapath, -4)) = '.pdf')) "  # added closing parenthesis so AND id IN(...) applies to both branches
         sql += bad_link_sql + " "
@@ -513,7 +512,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable'))
         self.ui.pushButton_file_attributes.setToolTip(ui.tooltip_msg)
         self.get_files(ui.result_file_ids)
-        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter <- L
+        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter
         self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
 
     def fill_code_counts_in_tree(self):
@@ -538,7 +537,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             code_counts.append([c['cid'], result[0], result[1]])
 
         # Sub-code roll-up. Build own counts, the parent/children maps and an effective
-        # category for each code (a sub-code is attributed to its top ancestor's category). <- L
+        # category for each code (a sub-code is attributed to its top ancestor's category).
         own_count = {cc[0]: cc[2] for cc in code_counts}
         code_by_cid = {c['cid']: c for c in self.codes}
         children_of = {}
@@ -548,7 +547,7 @@ class DialogCodeImage(QtWidgets.QDialog):
                 children_of.setdefault(sup, []).append(c['cid'])
 
         def _effective_catid(cid):
-            """ Resolve a (possibly nested) code to the catid of its top ancestor code. <- L """
+            """ Resolve a (possibly nested) code to the catid of its top ancestor code. """
             seen = set()
             cur_c = code_by_cid.get(cid)
             while cur_c is not None and cur_c['cid'] not in seen:
@@ -566,7 +565,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         total_cache = {}
 
         def _code_total(cid):
-            """ Code count rolled up with all descendant sub-codes. Memoized, cycle-safe. <- L """
+            """ Code count rolled up with all descendant sub-codes. Memoized, cycle-safe. """
             if cid in total_cache:
                 return total_cache[cid]
             total_cache[cid] = own_count.get(cid, 0)  # seed guards against cycles
@@ -581,7 +580,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         for category in categories:
             category['count'] = 0
         # Add each code's own count to its effective category (sub-codes roll up to the
-        # category of their top ancestor code, not to a raw catid that is None). <- L
+        # category of their top ancestor code, not to a raw catid that is None).
         for category in categories:
             for code in code_counts:
                 if eff_catid.get(code[0]) == category['catid']:
@@ -780,7 +779,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             return
         if selection['id'] == -1:
             self.get_files()
-            self.ui.pushButton_clear_filter_file.setVisible(False)  # reset filter button when showing all <- L
+            self.ui.pushButton_clear_filter_file.setVisible(False)  # reset filter button when showing all
             self.ui.pushButton_clear_filter_file.setStyleSheet("")
             return
         cur = self.app.conn.cursor()
@@ -790,14 +789,14 @@ class DialogCodeImage(QtWidgets.QDialog):
         for r in res:
             file_ids.append(r[0])
         self.get_files(file_ids)
-        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter <- L
+        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter
         self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
 
     def show_files_like(self):
         """ Show files that contain specified filename text.
         If blank, show all files. """
 
-        dialog = QtWidgets.QInputDialog(None) #correct: dialog embedded in workspace instead of floating <- L
+        dialog = QtWidgets.QInputDialog(None) #correct: dialog embedded in workspace instead of floating
         dialog.setStyleSheet(f"* {{font-size:{self.app.settings['fontsize']}pt}} ")
         dialog.setWindowTitle(_("Show files like"))
         dialog.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowType.WindowContextHelpButtonHint)
@@ -810,18 +809,18 @@ class DialogCodeImage(QtWidgets.QDialog):
         text_ = str(dialog.textValue())
         if text_ == "":
             self.get_files()
-            self.ui.pushButton_clear_filter_file.setVisible(False)  # hide filter button when showing all <- L
+            self.ui.pushButton_clear_filter_file.setVisible(False)  # hide filter button when showing all
             self.ui.pushButton_clear_filter_file.setStyleSheet("")
             return
         cur = self.app.conn.cursor()
-        cur.execute("select id from source where name like ? and "  # restrict to image/pdf files only <- L
+        cur.execute("select id from source where name like ? and "  # restrict to image/pdf files only
                     "((substr(mediapath,1,7) in ('/images', 'images:')) or "
                     "(lower(substr(mediapath, -4)) = '.pdf'))",
                     ['%' + text_ + '%'])
         res = cur.fetchall()
         file_ids = [r[0] for r in res]
         self.get_files(file_ids)
-        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter file <- L
+        self.ui.pushButton_clear_filter_file.setVisible(True)  # for clear filter file
         self.ui.pushButton_clear_filter_file.setStyleSheet("background-color: #1e90ff; color: white;")
 
     def file_selection_changed(self):
@@ -1263,7 +1262,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.get_coded_areas()
         self.redraw_scene()
 
-    def show_codes_like(self, preset=None):
+    def show_codes_like(self, preset:str|None=None):
         """ Show all codes if text is empty.
          Show selected codes that contain entered text.
          The input dialog is too narrow, so it is re-created.
@@ -1328,7 +1327,7 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.show_codes_colour_filter = ""
         show_codes_of_colour_range(self.app, self.ui.treeWidget, self.codes, selected)
         self.show_codes_like_filter = ""
-        if self.show_codes_colour_filter == "":  # for clear filter code<- L
+        if self.show_codes_colour_filter == "":  # for clear filter code
             self.ui.pushButton_clear_filter_code.setVisible(False)
             self.ui.pushButton_clear_filter_code.setStyleSheet("")
         else:
@@ -1348,7 +1347,7 @@ class DialogCodeImage(QtWidgets.QDialog):
 
     def clear_file_filter(self):
         """ Clear any active file filter (show files like, case files, attributes)
-        and reload all files. """ # <- L
+        and reload all files. """ 
         self.attributes = []
         self.ui.pushButton_file_attributes.setIcon(qta.icon('mdi6.variable', options=[{'scale_factor': 1.3}]))
         self.ui.pushButton_file_attributes.setToolTip(_("Attributes"))
@@ -1357,7 +1356,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.ui.pushButton_clear_filter_file.setVisible(False)
         self.ui.pushButton_clear_filter_file.setStyleSheet("")  # reset blue style
 
-    def recursive_traverse(self, item, text_="", case_sensitive=False):
+    def recursive_traverse(self, item, text_:str="", case_sensitive=False):
         """ Find all children codes of this item that match or not and hide or unhide based on 'text'.
         Recurse through all child categories and sub-codes. A code stays visible if it matches or
         if any of its descendant sub-codes matches, so a match is never hidden under a
@@ -1445,11 +1444,11 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.zoom_in()
             return
 
-        # Tree widget menu items keys F2 - F6
         # Tree widget menu item keys F2 - F6, handled by the shared controller. <- L
         if self.ui.treeWidget.hasFocus():
             if self.code_tree.handle_key_press(event):
                 return
+
         # Ctrl 0 to 9, G
         if mods & QtCore.Qt.KeyboardModifier.ControlModifier:
             if key == QtCore.Qt.Key.Key_G:
@@ -1488,12 +1487,14 @@ class DialogCodeImage(QtWidgets.QDialog):
             return
         self.ui.horizontalSlider.setValue(v)
 
-    def image_highlight(self, image_operation="gray", coded_area=None, code_id=None):
+    def image_highlight(self, image_operation:str="gray", coded_area=None, code_id:int|None=None):
         """ Gray, blurred or solarised image with coloured coded highlight(s).
         Highlight all coded area, or selected coded area, or all areas coded by one specific code.
         Takes a few seconds to build and show image.
-        :param: coded_area Dictionary of coded area
-        :param: coded_id Integer code id
+        Args:
+            image_operation: gray, blurred, solarised
+            coded_area: Dictionary of coded area
+            coded_id: Integer code id
         """
 
         img = self.pixmap.toImage()
@@ -1560,7 +1561,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         Message(self.app, _('Image saved'), msg, "information").exec()
         self.parent_textEdit.append(msg)
 
-    def text_box(self, draw, background_width, position, text, memo):
+    def text_box(self, draw, background_width, position, text:str, memo:str):
         """ Draw codename caption if show_code_captions=1, or codename plus memo if show_code_captions=2. """
 
         if self.show_code_captions == 0:
@@ -1834,11 +1835,10 @@ class DialogCodeImage(QtWidgets.QDialog):
             self.degrees = 270
         self.redraw_scene()
 
-    def move_or_resize_coding(self, item):
+    def move_or_resize_coding(self, item:dict[str,Any]):
         """ Move or resize a coding rectangle, in pixels.
-
-        params:
-        :name item: Dictionary of image id, x1, y1, width, height, memo, date, owner, cid, important
+        Args:
+            item: Dictionary of image id, x1, y1, width, height, memo, date, owner, cid, important
         """
 
         ui = DialogMoveResizeRectangle(self.app)
@@ -1878,11 +1878,9 @@ class DialogCodeImage(QtWidgets.QDialog):
 
     def find_coded_areas_for_pos(self, pos):
         """ Find any coded areas for this position AND for all visible coders.
-
-        params:
-        :name pos:
-        :type pos:
-        returns: [] or coded items
+        Args:
+           pos:
+        Returns: [] or coded items
         """
 
         if self.file_ is None:
@@ -1907,7 +1905,10 @@ class DialogCodeImage(QtWidgets.QDialog):
 
     def fill_coded_area_label(self, items):
         """ Fill details of label about the currently clicked on coded area.
-        Called by: right click scene menu, """
+        Called by: right click scene menu.
+        Args:
+            items :  
+        """
 
         if not items:
             return
@@ -1946,9 +1947,9 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.app.delete_backup = False
         self.draw_coded_areas()
 
-    def coded_area_memo(self, item):
+    def coded_area_memo(self, item:dict[str,Any]):
         """ Add memo to this coded area.
-        param:
+        Args:
             item : dictionary of coded area """
 
         ui = DialogMemo(self.app, _("Memo for code: ") + item['name'],
@@ -1986,7 +1987,7 @@ class DialogCodeImage(QtWidgets.QDialog):
 
     def unmark(self, item):
         """ Remove coded area.
-        param:
+        Args:
             item : dictionary of coded area """
 
         self.undo_deleted_code = deepcopy(item)
@@ -2043,19 +2044,19 @@ class DialogCodeImage(QtWidgets.QDialog):
             y = y + height
             height = abs(height)
         # instead of cancelling when the selection goes outside the image,
-        # clamp it to the image bounds so it cannot exceed the limits but still codes <- L
+        # clamp it to the image bounds so it cannot exceed the limits but still codes
         for item in self.scene.items():
             if type(item) == QtWidgets.QGraphicsPixmapItem:
                 max_w = item.boundingRect().width()
                 max_h = item.boundingRect().height()
-                # Clamp top-left corner inside the image <- L
+                # Clamp top-left corner inside the image
                 if x < 0:
-                    width += x  # reduce width by the part that fell off the left edge <- L
+                    width += x  # reduce width by the part that fell off the left edge
                     x = 0
                 if y < 0:
-                    height += y  # reduce height by the part that fell off the top edge <- L
+                    height += y  # reduce height by the part that fell off the top edge
                     y = 0
-                # Clamp bottom-right corner to the image edges <- L
+                # Clamp bottom-right corner to the image edges
                 if x + width > max_w:
                     width = max_w - x
                 if y + height > max_h:
@@ -2091,7 +2092,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.app.delete_backup = False
         self.fill_code_counts_in_tree()
 
-    # Functions responsible for mathematically processing the interactive resizing <- L
+    # Functions responsible for mathematically processing the interactive resizing
     def update_interactive_resize(self, pos):
         """ Update the visual dashed rectangle during mouse movement. """ 
         if not self.interactive_rect_item or not self.original_resize_geom:
@@ -2111,10 +2112,10 @@ class DialogCodeImage(QtWidgets.QDialog):
 
         # clamp the mouse position to the visible image bounds before using it,
         # so dragging outside the image cannot push the rectangle past the edges
-        # and removes the "jump" / over-reach when leaving the image area <- L
+        # and removes the "jump" / over-reach when leaving the image area
         scaled_w = self.pixmap.width() * self.scale
         scaled_h = self.pixmap.height() * self.scale
-        # When rotated 90/270 the visible image swaps width/height on screen <- L
+        # When rotated 90/270 the visible image swaps width/height on screen
         if self.degrees in (90, 270):
             scaled_w, scaled_h = scaled_h, scaled_w
         if mouse_x < 0:
@@ -2208,7 +2209,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         
         # Execute SQL statement to permanently update SQLite
         cur = self.app.conn.cursor()
-        # Prevent app crash if the user resizes the segment to perfectly match an existing identical one <- L
+        # Prevent app crash if the user resizes the segment to perfectly match an existing identical one
         try:
             cur.execute("update code_image set x1=?, y1=?, width=?, height=? where imid=?",
                         (item['x1'], item['y1'], item['width'], item['height'], item['imid']))
@@ -2226,19 +2227,6 @@ class DialogCodeImage(QtWidgets.QDialog):
         
         self.redraw_scene()
         self.app.delete_backup = False
-
-    def delete_category_or_code(self, selected):
-        """ Determine if selected item is a code or category before deletion.
-        Category deletion now cascades down the whole branch, matching the
-        Delete category branch option propagated from the text coding page. <- L
-        Args:
-            selected: QTreeWidgetItem
-        """
-        if selected.text(1)[0:3] == 'cat':
-            self.code_tree.delete_category_branch(selected)
-            return  # Avoid error as selected is now None
-        if selected.text(1)[0:3] == 'cid':
-            self.code_tree.delete_code(selected)
 
 class DialogViewImage(QtWidgets.QDialog):
     """ View image. View and edit displayed memo.


### PR DESCRIPTION
code_tree.py module: brings together in a single place all the behaviour of the code tree: how it is loaded, its context menu, drag and drop for reorganising, the F2 to F6 shortcuts and category branch deletion.

This behaviour is now included in every coding module (text, image, audio/video and PDF).

Bugs fixed:

- Moving a code could create a circular reference. When moving a top level code, its own sub-codes appeared in the list of destinations. Choosing one left parent and child pointing at each other in the database, with a broken tree.
- The category frequency calculation had a badly written condition (or instead of and) in all four modules: its safety limit never took effect, so a circular reference between categories left the application hanging. On top of that, with normal data it ran 10,000 empty iterations every time the counts were refreshed.

 - - the same condition is also present in reports.py and view_charts.py

- F6 on a category in view_image called the move method with the wrong data type.

