### PR TITLE
Add LaTeX file import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ json_repair
 mcp>=1.0.0
 markdown-it-py
 pyinstaller<=6.15 
+pylatexenc>=2.10,<3
 # The bootloader in the most recent version of pyinstaller is often falsely detected as malware
 # by anti virus software, so, it's safer to use a version that has been released a few months ago.
 pefile<2024.8.26  # see: https://github.com/pyinstaller/pyinstaller/issues/8832#issuecomment-2413203254

--- a/src/qualcoder/latex_import.py
+++ b/src/qualcoder/latex_import.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from pylatexenc.latex2text import LatexNodes2Text
+from pylatexenc.macrospec import MacroSpec, MacroStandardArgsParser
+
+from .text_decoding import decode_text_with_best_encoding
+
+
+class LatexImportError(Exception):
+    """Raised when LaTeX content cannot be imported."""
+
+
+_INPUT_INCLUDE_RE = re.compile(r"\\(?:input|include)\s*(?:\[[^\]]*\]\s*)?\{[^{}]*\}")
+_SECTIONING_MACROS = {"section", "subsection", "subsubsection", "paragraph", "subparagraph"}
+_TIKZ_BEGIN_OPTIONS_RE = re.compile(r"^\s*\[(?:[^\[\]]|\[[^\[\]]*\])*\]\s*")
+_TIKZ_NODE_OPTIONS_RE = re.compile(r"\[anchor=[^\]]*\]")
+_TIKZ_NODE_PLACEMENT_RE = re.compile(r"\bat\s*\(current page\.[^)]+\)")
+_TIKZ_TRAILING_SEMICOLON_RE = re.compile(r";\s*(?=\n|$)")
+_RULE_DIMENSION_ARTIFACT_RE = re.compile(r"\b\d+\.\d+\d+\.\d+(?:pt|cm|mm|in|em|ex|bp|pc|dd|cc|sp)\b")
+_LAYOUT_MACROS = {"rule", "includegraphics", "vspace", "vspace*", "hspace", "hspace*"}
+
+
+def _build_latex_context():
+    context = LatexNodes2Text().latex_context
+    context.add_context_category(
+        "qualcoder_layout_cleanup",
+        macros=[
+            MacroSpec("includegraphics", args_parser=MacroStandardArgsParser("[{")),
+            MacroSpec("rule", args_parser=MacroStandardArgsParser("{{")),
+            MacroSpec("vspace", args_parser=MacroStandardArgsParser("{")),
+            MacroSpec("vspace*", args_parser=MacroStandardArgsParser("{")),
+            MacroSpec("hspace", args_parser=MacroStandardArgsParser("{")),
+            MacroSpec("hspace*", args_parser=MacroStandardArgsParser("{")),
+        ],
+        prepend=True,
+    )
+    return context
+
+
+class _LatexToText(LatexNodes2Text):
+    """Keep the conversion conservative and readable for coding purposes."""
+
+    def __init__(self):
+        super().__init__(latex_context=_build_latex_context())
+
+    def macro_node_to_text(self, node):
+        if node.macroname in _LAYOUT_MACROS:
+            return ""
+        if node.macroname in _SECTIONING_MACROS:
+            title = ""
+            if getattr(node, "nodeargd", None) is not None:
+                for arg in reversed(node.nodeargd.argnlist):
+                    if arg is not None and getattr(arg, "nodelist", None) is not None:
+                        title = self.nodelist_to_text(arg.nodelist).strip()
+                        if title:
+                            break
+            if title:
+                return "\n\n" + title + "\n\n"
+            return "\n\n"
+        return super().macro_node_to_text(node)
+
+    def environment_node_to_text(self, node):
+        if node.environmentname == "tikzpicture":
+            text = self.nodelist_to_text(node.nodelist)
+            text = _TIKZ_BEGIN_OPTIONS_RE.sub("", text, count=1)
+            text = _TIKZ_NODE_OPTIONS_RE.sub("", text)
+            text = _TIKZ_NODE_PLACEMENT_RE.sub("", text)
+            text = _TIKZ_TRAILING_SEMICOLON_RE.sub("", text)
+            return text
+        return super().environment_node_to_text(node)
+
+
+def _normalize_plain_text(text: str) -> str:
+    text = _RULE_DIMENSION_ARTIFACT_RE.sub("", text)
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def latex_to_plain_text(raw_tex: str) -> str:
+    """Convert LaTeX source code into readable plain text."""
+
+    if raw_tex == "":
+        return ""
+    cleaned_tex = _INPUT_INCLUDE_RE.sub(" ", raw_tex)
+    try:
+        text = _LatexToText().latex_to_text(cleaned_tex)
+    except Exception as err:
+        raise LatexImportError("Cannot convert LaTeX content to plain text.") from err
+    return _normalize_plain_text(text or "")
+
+
+def tex_file_to_plain_text(import_file: str | Path) -> str:
+    """Read a LaTeX source file and convert it to readable plain text."""
+
+    path = Path(import_file)
+    try:
+        raw_tex, _encoding = decode_text_with_best_encoding(path)
+    except Exception as err:
+        raise LatexImportError(f"Cannot import LaTeX file: {path.name}") from err
+    if raw_tex.strip() == "":
+        return ""
+    try:
+        return latex_to_plain_text(raw_tex)
+    except Exception as err:
+        raise LatexImportError(f"Cannot import LaTeX file: {path.name}") from err

--- a/src/qualcoder/manage_files.py
+++ b/src/qualcoder/manage_files.py
@@ -21,7 +21,6 @@ https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 from PyQt6.QtWidgets import QProgressDialog
-from charset_normalizer import from_bytes
 import datetime
 import ebooklib
 from ebooklib import epub
@@ -56,6 +55,7 @@ from .edit_textfile import DialogEditTextFile
 from .GUI.ui_dialog_manage_files import Ui_Dialog_manage_files
 from .helpers import ExportDirectoryPathDialog, Message, msecs_to_hours_mins_secs
 from .html_parser import *
+from .latex_import import LatexImportError, tex_file_to_plain_text
 from .memo import DialogMemo
 from .pseudonyms import Pseudonyms
 from .report_codes import DialogReportCodes  # for isInstance()
@@ -64,6 +64,7 @@ from .select_items import DialogSelectItems
 from .view_av import DialogViewAV
 from .code_av import DialogCodeAV  # for isinstance update files
 from .view_image import DialogViewImage, DialogCodeImage  # for isinstance update files
+from .text_decoding import decode_text_with_best_encoding as decode_text_with_best_encoding_helper
 
 # If VLC not installed, it will not crash
 vlc = None
@@ -2934,9 +2935,9 @@ class DialogManageFiles(QtWidgets.QDialog):
     def import_files(self, link:bool=False):
         """ Import files and store into relevant directories (documents, images, audio, video).
         Convert documents to plain text and store this in data.qda
-        Can import from plain text files, also import from html, odt, docx, rtf, and md.
+        Can import from plain text files, also import from html, odt, docx, rtf, tex, and md.
         md is text Markdown format.
-        Note importing from html, odt, docx, rtf all formatting is lost.
+        Note importing from html, odt, docx, rtf, tex all formatting is lost.
         Imports images as jpg, jpeg, png which are stored in an images directory.
         Imports audio as flac, mp3, wav, ogg, m4a which are stored in an audio directory.
         Imports video as mp4, mov, wmv, webm, m4v which are stored in a video directory.
@@ -2970,13 +2971,13 @@ class DialogManageFiles(QtWidgets.QDialog):
         progress.setAutoReset(False)
         progress.setAutoClose(False)
         progress.show()
-        known_file_type = False
         self.default_import_directory = str(Path(imports[0]).parent)
         pdf_msg = ""
         # Highlight coding option, asked ONCE per batch and only when the first PDF
         # with highlight annotations is detected (tri-state: None = not asked yet).
         self.pdf_import_code_highlights = None
         for import_path in imports:
+            known_file_type = False
             link_path = ""
             if link:
                 link_path = import_path
@@ -2996,8 +2997,23 @@ class DialogManageFiles(QtWidgets.QDialog):
                                               _("Duplicate filename.\nFile not imported") + f"\n{filename}")
                 file_number += 1
                 continue
-            destination = self.app.project_path
-            if Path(import_path).suffix.lower() in ('.docx', '.odt', '.rtf', '.tex','.txt', '.htm', '.html', '.epub', '.md'):
+            suffix = Path(import_path).suffix.lower()
+            if suffix in ('.docx', '.odt', '.rtf', '.tex', '.txt', '.htm', '.html', '.epub', '.md'):
+                if suffix == '.tex':
+                    try:
+                        imported_ok = self.load_file_text(import_path, f"docs:{import_path}")
+                    except LatexImportError as err:
+                        logger.warning(f"LaTeX import error: {filename} {err}")
+                        Message(self.app, _("Cannot import LaTeX file"),
+                                _("Could not convert LaTeX to readable text") + f":\n{filename}",
+                                "warning").exec()
+                        continue
+                    if not imported_ok:
+                        continue
+                    known_file_type = True
+                    file_number += 1
+                    continue
+                destination = self.app.project_path
                 destination += f"/documents/{filename}"
                 if link_path == "":
                     try:
@@ -3019,7 +3035,8 @@ class DialogManageFiles(QtWidgets.QDialog):
                 else:
                     self.load_file_text(import_path, f"docs:{link_path}")
                 known_file_type = True
-            if Path(import_path).suffix.lower() == '.pdf':
+            if suffix == '.pdf':
+                destination = self.app.project_path
                 destination += f"/documents/{filename}"
                 if link_path == "":
                     try:
@@ -3211,32 +3228,7 @@ class DialogManageFiles(QtWidgets.QDialog):
     def decode_text_with_best_encoding(self, import_file:str):
         """ Decode text file bytes using robust encoding detection and fallbacks. """
 
-        with open(import_file, "rb") as sourcefile:
-            raw_bytes = sourcefile.read()
-        if not raw_bytes:
-            return "", "empty"
-
-        # try Unicode first, with and without BOM
-        decode_order = ("utf-8-sig", "utf-8")
-        for encoding in decode_order:
-            try:
-                return raw_bytes.decode(encoding), encoding
-            except UnicodeDecodeError:
-                pass
-
-        # no Unicode, try to detect charset with charset-normalizer, then fall back to common encodings
-        best_match = from_bytes(raw_bytes).best()
-        if best_match is not None:
-            detected_encoding = best_match.encoding if best_match.encoding else "unknown"
-            return str(best_match), detected_encoding
-
-        for encoding in ("cp1252", "latin-1"):
-            try:
-                return raw_bytes.decode(encoding), encoding
-            except UnicodeDecodeError:
-                pass
-
-        return raw_bytes.decode("utf-8", errors="backslashreplace"), "utf-8(backslashreplace)"
+        return decode_text_with_best_encoding_helper(import_file)
 
     def load_file_text(self, import_file:str, link_path:str="", progress_:QProgressDialog|None=None):
         """ Import from file types of odt, docx, rtf, pdf, epub, txt, html, htm.
@@ -3261,17 +3253,18 @@ class DialogManageFiles(QtWidgets.QDialog):
                                           _("Duplicate filename.\nFile not imported"))
             return False
         text_ = ""
+        suffix = Path(import_file).suffix.lower()
         # Import from odt
-        if Path(import_file).suffix.lower() == ".odt":
+        if suffix == ".odt":
             text_ = self.convert_odt_to_text(import_file)
             text_ = text_.replace("\n", "\n\n")  # add line to paragraph spacing for visual format
         # Import from docx
-        if Path(import_file).suffix.lower() == ".docx":
+        if suffix == ".docx":
             document = opendocx(import_file)
             list_ = getdocumenttext(document)
             text_ = "\n\n".join(list_)  # add line to paragraph spacing for visual format
         # Import from rtf
-        if Path(import_file).suffix.lower() == ".rtf":
+        if suffix == ".rtf":
             # text_ = rtf_to_text(import_file, encoding="latin-1", errors="replace")
             with open(import_file, "r", encoding="latin-1") as sourcefile:
                 text_ = ""
@@ -3283,7 +3276,7 @@ class DialogManageFiles(QtWidgets.QDialog):
                     logger.debug(f"rtf_to_text error Not Latin-1: {err}")
                     Message(self.app, "rtf to text error", msg).exec()
         # Import from epub
-        if Path(import_file).suffix.lower() == ".epub":
+        if suffix == ".epub":
             book = epub.read_epub(import_file)
             for d in book.get_items_of_type(ebooklib.ITEM_DOCUMENT):
                 try:
@@ -3293,7 +3286,7 @@ class DialogManageFiles(QtWidgets.QDialog):
                 except TypeError as err:
                     logger.debug(f"ebooklib get_body_content error: {err}")
         # Import from html
-        if Path(import_file).suffix.lower() in (".html", ".htm"):
+        if suffix in (".html", ".htm"):
             import_errors = 0
             with open(import_file, "r", encoding="utf-8", errors="surrogateescape") as sourcefile:
                 html_text = ""
@@ -3306,7 +3299,7 @@ class DialogManageFiles(QtWidgets.QDialog):
                 if import_errors > 0:
                     Message(self.app, _("Warning"), str(import_errors) + _(" lines not imported"), "warning").exec()
         # Import PDF
-        if Path(import_file).suffix.lower() == '.pdf':
+        if suffix == '.pdf':
             # Extraction with the SAME extractor as the viewer (code_pdf.extract_pdf_fulltext),
             # otherwise coding positions do not map onto the PDF pages.
             def pdf_progress(current_page, total_pages):
@@ -3336,11 +3329,20 @@ class DialogManageFiles(QtWidgets.QDialog):
                          "but text coding and text search will not.")
                 Message(self.app, _("PDF without text"),
                         f"{Path(import_file).name}\n{msg}", "warning").exec()
+        if suffix == ".tex":
+            try:
+                text_ = tex_file_to_plain_text(import_file)
+            except LatexImportError as err:
+                logger.warning(f"LaTeX import error: {Path(import_file).name} {err}")
+                Message(self.app, _("Cannot import LaTeX file"),
+                        _("Could not convert LaTeX to readable text") + f":\n{Path(import_file).name}",
+                        "warning").exec()
+                return False
         # Try importing as a plain text file.
         # Never decode a PDF as plain text (it would produce unreadable binary).
-        if text_ == "" and Path(import_file).suffix.lower() != '.pdf':
+        if text_ == "" and suffix not in ('.pdf', '.tex'):
             try:
-                text_, detected_encoding = self.decode_text_with_best_encoding(import_file)
+                text_, detected_encoding = decode_text_with_best_encoding_helper(import_file)
                 logger.debug(f"Importing plain text file: {import_file} decoded as {detected_encoding}")
                 if text_ and text_[0] == "\ufeff":  # associated with notepad files
                     text_ = text_[1:]
@@ -3356,7 +3358,7 @@ class DialogManageFiles(QtWidgets.QDialog):
             return False
         # Normalise line endings and strip BOM: Qt converts \r\n/\r to \n on
         # setPlainText, so mismatches make stored positions drift. <- L
-        if Path(import_file).suffix.lower() != '.pdf': # skip PDF
+        if suffix != '.pdf': # skip PDF
             text_ = text_.replace("\r\n", "\n").replace("\r", "\n")
             if text_ and text_[0] == "\ufeff":
                 text_ = text_[1:]
@@ -3364,7 +3366,7 @@ class DialogManageFiles(QtWidgets.QDialog):
 
         # Apply pseudonym text replacement
         pseudonyms = self.load_pseudonyms()
-        if Path(import_file).suffix.lower() != '.pdf':
+        if suffix != '.pdf':
             for pseudonym in pseudonyms:
                 pseudonymised = re.sub(rf"\b{pseudonym['original']}\b", pseudonym['pseudonym'], text_)
                 text_ = pseudonymised
@@ -3409,7 +3411,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.source.append(entry)
         # Offer (once per batch) to code highlight annotations; they are not
         # painted in the coding view (annots=False).
-        if Path(import_file).suffix.lower() == '.pdf':
+        if suffix == '.pdf':
             # Non-highlight annotations with text are appended to the file memo.
             try:
                 notes = extract_pdf_annotations(import_file)

--- a/src/qualcoder/text_decoding.py
+++ b/src/qualcoder/text_decoding.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from charset_normalizer import from_bytes
+
+
+def decode_text_with_best_encoding(import_file: str | Path) -> tuple[str, str]:
+    """Decode text bytes using UTF-8 first, then charset-normalizer and fallbacks."""
+
+    path = Path(import_file)
+    with open(path, "rb") as sourcefile:
+        raw_bytes = sourcefile.read()
+    if not raw_bytes:
+        return "", "empty"
+
+    for encoding in ("utf-8-sig", "utf-8"):
+        try:
+            return raw_bytes.decode(encoding), encoding
+        except UnicodeDecodeError:
+            pass
+
+    best_match = from_bytes(raw_bytes).best()
+    if best_match is not None:
+        detected_encoding = best_match.encoding if best_match.encoding else "unknown"
+        return str(best_match), detected_encoding
+
+    for encoding in ("cp1252", "latin-1"):
+        try:
+            return raw_bytes.decode(encoding), encoding
+        except UnicodeDecodeError:
+            pass
+
+    return raw_bytes.decode("utf-8", errors="backslashreplace"), "utf-8(backslashreplace)"

--- a/src/qualcoder/text_file_replacement.py
+++ b/src/qualcoder/text_file_replacement.py
@@ -21,7 +21,6 @@ https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
-from charset_normalizer import from_bytes
 import datetime
 import ebooklib
 from ebooklib import epub
@@ -40,6 +39,8 @@ import zipfile
 from .docx import opendocx, getdocumenttext
 from .helpers import Message
 from .html_parser import *
+from .latex_import import LatexImportError, tex_file_to_plain_text
+from .text_decoding import decode_text_with_best_encoding as decode_text_with_best_encoding_helper
 
 
 logger = logging.getLogger(__name__)
@@ -242,17 +243,18 @@ class ReplaceTextFile:
         """
 
         text = ""
+        suffix = Path(self.new_file_path).suffix.lower()
         # Import from odt
-        if Path(self.new_file_path).suffix.lower() == ".odt":
+        if suffix == ".odt":
             text = self.convert_odt_to_text(self.new_file_path)
             text = text.replace("\n", "\n\n")  # Add line to paragraph spacing for visual format
         # Import from docx
-        if Path(self.new_file_path).suffix.lower() == ".docx":
+        if suffix == ".docx":
             document = opendocx(self.new_file_path)
             list_ = getdocumenttext(document)
             text = "\n\n".join(list_)  # Add line to paragraph spacing for visual format
         # Import from rtf
-        if Path(self.new_file_path).suffix.lower() == ".rtf":
+        if suffix == ".rtf":
             # text_ = rtf_to_text(import_file, encoding="latin-1", errors="replace")
             with open(self.new_file_path, "r", encoding="latin-1") as sourcefile:
                 text = ""
@@ -264,7 +266,7 @@ class ReplaceTextFile:
                     logger.debug(f"rtf_to_text error Not Latin-1: {err}")
                     Message(self.app, "rtf to text error", msg).exec()
         # Import from epub
-        if Path(self.new_file_path).suffix.lower() == ".epub":
+        if suffix == ".epub":
             book = epub.read_epub(self.new_file_path)
             for d in book.get_items_of_type(ebooklib.ITEM_DOCUMENT):
                 try:
@@ -274,7 +276,7 @@ class ReplaceTextFile:
                 except TypeError as e:
                     logger.debug("ebooklib get_body_content error " + str(e))
         # Import from html
-        if Path(self.new_file_path).suffix.lower() in (".html", ".htm"):
+        if suffix in (".html", ".htm"):
             import_errors = 0
             with open(self.new_file_path, "r", encoding="utf-8", errors="surrogateescape") as sourcefile:
                 html_text = ""
@@ -287,7 +289,7 @@ class ReplaceTextFile:
                 if import_errors > 0:
                     Message(self.app, _("Warning"), str(import_errors) + _(" lines not imported"), "warning").exec()
         # Import PDF
-        if Path(self.new_file_path).suffix.lower() == '.pdf':
+        if suffix == '.pdf':
             pdf_file = open(self.new_file_path, 'rb')
             resource_manager = PDFResourceManager()
             laparams = LAParams()
@@ -304,10 +306,19 @@ class ReplaceTextFile:
                 for lobj in layout:
                     self.get_item_and_hierarchy(page, lobj)
                 text += self.pdf_page_text
+        if suffix == ".tex":
+            try:
+                text = tex_file_to_plain_text(self.new_file_path)
+            except LatexImportError as err:
+                logger.warning(f"LaTeX import error: {self.new_file_path} {err}")
+                Message(self.app, _("Cannot import LaTeX file"),
+                        _("Could not convert LaTeX to readable text") + f":\n{self.new_file_path}",
+                        "warning").exec()
+                return
         # Try importing as a plain text file.
         if text == "":
             try:
-                text_, detected_encoding = self.decode_text_with_best_encoding(self.new_file_path)
+                text_, detected_encoding = decode_text_with_best_encoding_helper(self.new_file_path)
                 logger.debug(f"Importing plain text file: {self.new_file_path} decoded as {detected_encoding}")
                 if text_ and text_[0] == "\ufeff":  # associated with notepad files
                     text = text_[1:]
@@ -323,7 +334,7 @@ class ReplaceTextFile:
             return
         # Normalise line endings and strip BOM: Qt converts \r\n/\r to \n on
         # setPlainText, so mismatches make stored positions drift.
-        if Path(self.new_file_path).suffix.lower() != '.pdf':  # skip PDF
+        if suffix != '.pdf':  # skip PDF
             text = text.replace("\r\n", "\n").replace("\r", "\n")
             if text and text[0] == "\ufeff":
                 text = text[1:]
@@ -333,7 +344,7 @@ class ReplaceTextFile:
 
         # Apply pseudonym text replacement
         pseudonyms = self.load_pseudonyms()
-        if Path(self.new_file_path).suffix.lower() != '.pdf':
+        if suffix != '.pdf':
             for pseudonym in pseudonyms:
                 pseudonymised = re.sub(rf"\b{pseudonym['original']}\b", pseudonym['pseudonym'], text)
                 text = pseudonymised
@@ -397,28 +408,7 @@ class ReplaceTextFile:
     def decode_text_with_best_encoding(import_file:str):
         """ Decode text file bytes using robust encoding detection and fallbacks. """
 
-        with open(import_file, "rb") as sourcefile:
-            raw_bytes = sourcefile.read()
-        if not raw_bytes:
-            return "", "empty"
-        # Try Unicode first, with and without BOM
-        decode_order = ("utf-8-sig", "utf-8")
-        for encoding in decode_order:
-            try:
-                return raw_bytes.decode(encoding), encoding
-            except UnicodeDecodeError:
-                pass
-        # no Unicode, try to detect charset with charset-normalizer, then fall back to common encodings
-        best_match = from_bytes(raw_bytes).best()
-        if best_match is not None:
-            detected_encoding = best_match.encoding if best_match.encoding else "unknown"
-            return str(best_match), detected_encoding
-        for encoding in ("cp1252", "latin-1"):
-            try:
-                return raw_bytes.decode(encoding), encoding
-            except UnicodeDecodeError:
-                pass
-        return raw_bytes.decode("utf-8", errors="backslashreplace"), "utf-8(backslashreplace)"
+        return decode_text_with_best_encoding_helper(import_file)
 
     @staticmethod
     def convert_odt_to_text(import_file:str) -> str:

--- a/tests/test_latex_import.py
+++ b/tests/test_latex_import.py
@@ -1,0 +1,152 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from qualcoder.latex_import import LatexImportError, latex_to_plain_text, tex_file_to_plain_text
+
+
+class TestLatexImport(TestCase):
+    def test_latex_to_plain_text_preserves_title_page_text_without_tikz_artifacts(self):
+        raw_tex = r"""\documentclass[12pt,a4paper]{article}
+
+\begin{document}
+
+\begin{titlepage}
+
+  \centering
+
+\begin{tikzpicture}[remember picture, overlay]
+  \node[anchor=north east, xshift=-1.5cm, yshift=-1.2cm]
+  at (current page.north east)
+  {\includegraphics[width=0.4\textwidth]{images/example-logo.png}};
+\end{tikzpicture}
+
+\vspace*{1.5cm}
+
+    {\Large\textsc{Example Programme}}\\[0.2cm]
+    {\large Example Research Project}\\[0.2cm]
+    {\normalsize Fach: History \& Language}\\[0.8]
+
+    \rule{0.80\textwidth}{0.5pt}\\[1.0cm]
+
+    {\Huge\bfseries
+    Example Main Title\\[0.25cm]
+    Second Title Line
+    }\\[0.8cm]
+
+    {\Large
+    Example Subtitle
+    }\\[0.9cm]
+
+    \rule{0.80\textwidth}{0.5pt}\\[2.5cm]
+
+    \begin{tabular}{@{}ll}
+        	textbf{Supervisors:} & Teacher 1, \\
+                                 & Teacher 2 \\[6pt]
+
+
+        	textbf{Autoren:} & Person 1, \\
+                             & Person 2 \\[6pt]
+
+        \vspace{0.5cm} \\
+        	textbf{Klasse:} & Test \\[6pt]
+        	textbf{Schule:} & Example Schule \\[6pt]
+        	textbf{Datum:} & \today \\
+    \end{tabular}
+
+\end{titlepage}
+
+\end{document}
+"""
+
+        text = latex_to_plain_text(raw_tex)
+
+        self.assertNotIn("remember picture", text)
+        self.assertNotIn("overlay", text)
+        self.assertNotIn("anchor", text)
+        self.assertNotIn("xshift", text)
+        self.assertNotIn("yshift", text)
+        self.assertNotIn("current page.north east", text)
+        self.assertNotIn("<graphics>", text)
+        self.assertNotIn("0.800.5pt", text)
+        self.assertNotIn("0.600.4pt", text)
+        self.assertIn("Example Programme", text)
+        self.assertIn("Example Research Project", text)
+        self.assertIn("Fach: History & Language", text)
+        self.assertIn("Example Main Title", text)
+        self.assertIn("Second Title Line", text)
+        self.assertIn("Example Subtitle", text)
+        self.assertIn("Supervisors:", text)
+        self.assertIn("Teacher 1", text)
+        self.assertIn("Teacher 2", text)
+        self.assertIn("Autoren:", text)
+        self.assertIn("Person 1", text)
+        self.assertIn("Person 2", text)
+        self.assertIn("Klasse:", text)
+        self.assertIn("Test", text)
+        self.assertIn("Schule:", text)
+        self.assertIn("Example Schule", text)
+        self.assertIn("Datum:", text)
+
+    def test_latex_to_plain_text_without_tikz_stays_readable(self):
+        raw_tex = r"""\section{Interview}
+
+This is \textbf{important} and \emph{quoted} text.
+
+\begin{itemize}
+\item First answer
+\item Second answer
+\end{itemize}
+"""
+
+        text = latex_to_plain_text(raw_tex)
+
+        self.assertEqual(
+            "Interview\n\nThis is important and quoted text.\n\n  * First answer\n\n  * Second answer",
+            text,
+        )
+
+    def test_latex_to_plain_text_handles_common_markup(self):
+        raw_tex = r"""\section{Interview}
+
+This is \textbf{important} and \emph{quoted} text.
+
+\begin{itemize}
+\item First answer
+\item Second answer
+\end{itemize}
+
+Cafe \'{e} and $x^2$.
+
+\input{ignored}
+"""
+
+        text = latex_to_plain_text(raw_tex)
+
+        self.assertIn("Interview", text)
+        self.assertIn("important", text)
+        self.assertIn("quoted", text)
+        self.assertIn("First answer", text)
+        self.assertIn("Second answer", text)
+        self.assertIn("Cafe é", text)
+        self.assertIn("x^2", text)
+        self.assertNotIn("ignored", text)
+
+    def test_tex_file_to_plain_text_reads_file(self):
+        with TemporaryDirectory() as temp_dir:
+            tex_path = Path(temp_dir) / "sample.tex"
+            tex_path.write_text(r"""\subsection{Notes}
+A short line.
+""", encoding="utf-8")
+
+            text = tex_file_to_plain_text(tex_path)
+
+        self.assertIn("Notes", text)
+        self.assertIn("A short line.", text)
+
+    def test_tex_file_to_plain_text_raises_on_missing_file(self):
+        with TemporaryDirectory() as temp_dir:
+            tex_path = Path(temp_dir) / "missing.tex"
+
+            with self.assertRaises(LatexImportError):
+                tex_file_to_plain_text(tex_path)


### PR DESCRIPTION
## Summary

Adds direct `.tex` file import to QualCoder using `pylatexenc`.

The importer converts LaTeX source files into readable plain text for coding and analysis while preserving the original `.tex` file as a linked source.

## Changes

- Add `.tex` support to the existing Manage Files import workflow
- Convert LaTeX content to readable plain text with `pylatexenc`
- Preserve the original `.tex` source path
- Reuse shared text encoding detection
- Support replacing existing text sources with `.tex` files
- Add focused tests for LaTeX conversion and import behaviour

## Limitations

- `\input` and `\include` files are not resolved
- LaTeX is not compiled or executed
- Complex presentation-only constructs such as TikZ may not always convert perfectly
- Pandoc is not required or used

## Testing

Tested inside a Debian 12 Distrobox running on a Gentoo Linux host, using Python 3.11 and libVLC 3. 
_The implementation itself uses only Python and pylatexenc and does not depend on Distrobox or Linux-specific tools._

```bash
PYTHONPATH=src python -m unittest tests.test_latex_import
python -m compileall src/qualcoder/latex_import.py src/qualcoder/text_decoding.py
git diff --check
```

Refs ccbogel/QualCoder#1417