### PR TITLE
Fix: Translated combobox options broke exports 

### DIFF
--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -2193,6 +2193,9 @@ class DialogCodePdf(QtWidgets.QWidget):
             pass
         
         try:
+            # Canonical keys for .ui-defined items, labels may be translated
+            self.ui.comboBox_exports.setItemData(1, "pdf_highlight")
+            self.ui.comboBox_exports.setItemData(2, "odt_report")
             self.ui.comboBox_exports.currentIndexChanged.connect(self.export_option_selected)
         except AttributeError:
             pass
@@ -6378,10 +6381,10 @@ class DialogCodePdf(QtWidgets.QWidget):
         Routes the option chosen in the export combobox to the corresponding method (highlighted
         PDF or ODT report) and resets the combobox to index 0.
         """
-        text = self.ui.comboBox_exports.currentText().lower()
-        if "pdf highlight" in text:
+        key = self.ui.comboBox_exports.currentData()  # canonical key, translation-safe
+        if key == "pdf_highlight":
             self.export_pdf_highlight()
-        elif "odt report" in text:
+        elif key == "odt_report":
             self.export_odt_report()
         self.ui.comboBox_exports.setCurrentIndex(0)
 

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -6527,10 +6527,10 @@ class DialogCodePdf(QtWidgets.QWidget):
             except AttributeError:
                 project_name = "Project"
 
-            cursor.insertText(f"Project: {project_name}\n", header_fmt)
-            cursor.insertText(f"File: {self.file_['name']}\n", header_fmt)
+            cursor.insertText(f"{_('Project')}: {project_name}\n", header_fmt)
+            cursor.insertText(f"{_('File')}: {self.file_['name']}\n", header_fmt)
             report_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
-            cursor.insertText(f"Generated report: {report_date}\n\n", header_fmt)
+            cursor.insertText(f"{_('Generated report')}: {report_date}\n\n", header_fmt)
 
             seg_co_occurrences = defaultdict(set)
             area_co_occurrences = defaultdict(set)
@@ -6558,7 +6558,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                             pair = tuple(sorted([a1['name'], a2['name']]))
                             co_occur[pair] += 1
 
-            cursor.insertText("Code Frequency Table\n\n", title_fmt)
+            cursor.insertText(_("Code Frequency Table") + "\n\n", title_fmt)
             code_stats = {}
             all_codings = self.code_text + self.code_areas
             for c in all_codings:
@@ -6575,7 +6575,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             if code_stats:
                 freq_rows = len(code_stats) + 1
                 freq_table = cursor.insertTable(freq_rows, 3, table_fmt)
-                freq_headers = ["Code", "Frequency", "Coder(s)"]
+                freq_headers = [_("Code"), _("Frequency"), _("Coder(s)")]
                 for col, text in enumerate(freq_headers):
                     freq_table.cellAt(0, col).firstCursorPosition().insertText(text, head_fmt)
 
@@ -6596,11 +6596,11 @@ class DialogCodePdf(QtWidgets.QWidget):
                 cursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
                 cursor.insertText("\n\n", norm_fmt)
 
-            cursor.insertText("Code Co-occurrences\n\n", title_fmt)
+            cursor.insertText(_("Code Co-occurrences") + "\n\n", title_fmt)
             if co_occur:
                 co_rows = len(co_occur) + 1
                 co_table = cursor.insertTable(co_rows, 3, table_fmt)
-                co_headers = ["Code A", "Code B", "Co-occurrence frequency"]
+                co_headers = [_("Code A"), _("Code B"), _("Co-occurrence frequency")]
                 for col, text in enumerate(co_headers):
                     co_table.cellAt(0, col).firstCursorPosition().insertText(text, head_fmt)
                 r = 1
@@ -6612,10 +6612,10 @@ class DialogCodePdf(QtWidgets.QWidget):
                 cursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
                 cursor.insertText("\n\n", norm_fmt)
             else:
-                cursor.insertText("No co-occurrences found in this file.\n\n", norm_fmt)
+                cursor.insertText(_("No co-occurrences found in this file.") + "\n\n", norm_fmt)
 
             if self.code_text:
-                cursor.insertText("Coded Text Segments\n\n", title_fmt)
+                cursor.insertText(_("Coded Text Segments") + "\n\n", title_fmt)
                 codes_sorted = sorted(self.code_text, key=lambda x: x.get('pos0', 0))
                 for c in codes_sorted:
                     p0 = c.get('pos0', 0)
@@ -6635,21 +6635,21 @@ class DialogCodePdf(QtWidgets.QWidget):
                     c_header_bold.setFontWeight(QtGui.QFont.Weight.Bold)
 
                     cursor.insertText(f"[{p0}-{p1}] ", c_header_bold)
-                    cursor.insertText(f"Code: {c['name']}, Coder: {c.get('owner', '')}\n\n", c_header_fmt)
+                    cursor.insertText(f"{_('Code')}: {c['name']}, {_('Coder')}: {c.get('owner', '')}\n\n", c_header_fmt)
                     
                     cursor.insertText(seg + "\n\n", it_fmt)
                     
                     co_key = (c['pos0'], c['pos1'], c['cid'])
                     co_codes = seg_co_occurrences.get(co_key, set())
                     if co_codes:
-                        cursor.insertText(f"[Co-occurring codes: {', '.join(sorted(co_codes))}]\n\n", norm_fmt)
+                        cursor.insertText(f"[{_('Co-occurring codes')}: {', '.join(sorted(co_codes))}]\n\n", norm_fmt)
 
                     coded_memo = c.get('memo', '')
                     if coded_memo and str(coded_memo).strip():
-                        cursor.insertText(f"[Coded memo: {coded_memo}]\n\n", norm_fmt)
+                        cursor.insertText(f"[{_('Coded memo')}: {coded_memo}]\n\n", norm_fmt)
 
             if self.code_areas:
-                cursor.insertText("Coded Areas (Pages)\n\n", title_fmt)
+                cursor.insertText(_("Coded Areas (Pages)") + "\n\n", title_fmt)
                 
                 pdf_doc = None
                 filepath = self._resolve_filepath(self.file_)
@@ -6669,8 +6669,8 @@ class DialogCodePdf(QtWidgets.QWidget):
                     a_header_bold = QtGui.QTextCharFormat(a_header_fmt)
                     a_header_bold.setFontWeight(QtGui.QFont.Weight.Bold)
 
-                    cursor.insertText(f"[Page {page}] ", a_header_bold)
-                    cursor.insertText(f"Code: {a.get('name', '')}, Coder: {a.get('owner', '')}\n\n", a_header_fmt)
+                    cursor.insertText(f"[{_('Page')} {page}] ", a_header_bold)
+                    cursor.insertText(f"{_('Code')}: {a.get('name', '')}, {_('Coder')}: {a.get('owner', '')}\n\n", a_header_fmt)
                     coords = f"Coordinates: X:{a.get('x1')}, Y:{a.get('y1')}, Width:{a.get('width')}, Height:{a.get('height')}\n\n"
                     cursor.insertText(coords, norm_fmt)
 
@@ -6700,17 +6700,17 @@ class DialogCodePdf(QtWidgets.QWidget):
 
                     co_codes_area = area_co_occurrences.get(a['imid'], set())
                     if co_codes_area:
-                        cursor.insertText(f"[Co-occurring codes: {', '.join(sorted(co_codes_area))}]\n\n", norm_fmt)
+                        cursor.insertText(f"[{_('Co-occurring codes')}: {', '.join(sorted(co_codes_area))}]\n\n", norm_fmt)
 
                     coded_memo = a.get('memo', '')
                     if coded_memo and str(coded_memo).strip():
-                        cursor.insertText(f"[Coded memo: {coded_memo}]\n\n", norm_fmt)
+                        cursor.insertText(f"[{_('Coded memo')}: {coded_memo}]\n\n", norm_fmt)
 
                 if pdf_doc is not None:
                     pdf_doc.close()
 
             # 5. Software Citation
-            cursor.insertText("\nSoftware citation\n", title_fmt)
+            cursor.insertText("\n" + _("Software citation") + "\n", title_fmt)
             cursor.insertText(self.app.citation + "\n", norm_fmt)
 
             tw = QtGui.QTextDocumentWriter()

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -340,6 +340,10 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.pushButton_exit_edit.pressed.connect(self.edit_mode_toggle)
         self.ui.pushButton_undo_edit.setIcon(qta.icon('mdi6.undo', options=[{'scale_factor': 1.3}]))
         self.ui.pushButton_undo_edit.pressed.connect(self.undo_edited_text)
+        # Canonical keys for .ui-defined items, labels may be translated
+        export_keys = ["", "odt_highlight", "odt_comment", "odt_report", "txt", "html", "codebook"]
+        for i, key in enumerate(export_keys):
+            self.ui.comboBox_export.setItemData(i, key)
         self.ui.comboBox_export.currentIndexChanged.connect(self.export_option_selected)
         # Tree widget
         self.ui.treeWidget.setDragEnabled(True)
@@ -2992,33 +2996,23 @@ class DialogCodeText(QtWidgets.QWidget):
 
     def export_option_selected(self):
         """ ComboBox export option selected.
-        Routes the expanded comboBox options to their corresponding export methods.
-        indexes:
-        0
-        1 odt highlight
-        2 odt comment
-        3 odt report
-        4 txt
-        5 html
-        6 codebook
+        Routes the option to its export method via the item's canonical key (userData).
         """
 
-        # Must use indexes not names for translations, if there are translations
-        # export_option = self.ui.comboBox_export.currentText()
-        index = self.ui.comboBox_export.currentIndex()
-        if index == 0:
+        key = self.ui.comboBox_export.currentData()  # canonical key, translation-safe
+        if key in (None, ""):
             return
-        if index == 1:
+        if key == "odt_highlight":
             self.export_odt_file("highlight")
-        elif index == 2:
+        elif key == "odt_comment":
             self.export_odt_file("comment")
-        elif index == 3:
+        elif key == "odt_report":
             self.export_odt_file("report")
-        elif index == 4:
+        elif key == "txt":
             self.export_tagged_text()
-        elif index == 5:
+        elif key == "html":
             self.export_html_file()
-        elif index == 6:
+        elif key == "codebook":
             self.export_codebook()
         self.ui.comboBox_export.setCurrentIndex(0)
 

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -132,7 +132,7 @@ class DialogCodeText(QtWidgets.QWidget):
 
         # Visual options for code stripes margin and highlight style.
         # show_margin_stripes and highlight_style are INDEPENDENT preferences,
-        # persisted under separate keys and changed via the margin context menu <- L
+        # persisted under separate keys and changed via the margin context menu
         try:
             saved_pref = self.app.settings.get('codetext_show_margin_stripes', 'True')
             if isinstance(saved_pref, bool):
@@ -353,7 +353,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.treeWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         # Shared code tree controller: tree loading, common context menu, drag and drop
         # reparenting, F2-F6 shortcuts and category branch deletion live in code_tree.py,
-        # so the four coding pages no longer duplicate this logic by hand. <- L
+        # so the four coding pages no longer duplicate this logic by hand.
         self.code_tree = CodeTreeController(self.app, self.ui.treeWidget, self)
         self.ui.treeWidget.customContextMenuRequested.connect(self.code_tree.tree_menu)
         self.code_tree.fill_counts_callback = self.fill_code_counts_in_tree
@@ -368,7 +368,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.treeWidget.itemPressed.connect(self.fill_code_label_with_selected_code)
         init_persistent_tree_header(self.ui.treeWidget, self.app, 'dialogcodetext_tree_widths')
 
-        self.ui.splitter.setSizes([150, 400, 0])  # 3 values; right pane starts collapsed <- L
+        self.ui.splitter.setSizes([150, 400, 0])  # 3 values; right pane starts collapsed
         try:
             s0 = int(self.app.settings['dialogcodetext_splitter0'])
             s1 = int(self.app.settings['dialogcodetext_splitter1'])
@@ -3106,7 +3106,7 @@ class DialogCodeText(QtWidgets.QWidget):
     def _export_project_header(self):
         """ Return project name and APA software citation string for export. """  
 
-        project_name = Path(self.app.projectpath).stem
+        project_name = Path(self.app.project_path).stem  # attr is project_path
         header = f"{_('Project')}: {project_name}"
         apa_cite = ("Curtain, C., & Dröge, K. (2026). QualCoder (Version 4.0) "  
                     "[Computer software]. https://github.com/ccbogel/QualCoder/releases/")

--- a/src/qualcoder/memo.py
+++ b/src/qualcoder/memo.py
@@ -352,7 +352,7 @@ class DialogSelectQuote(QtWidgets.QDialog):
                 insert += f'**{_("CODED MEMO")}:** "{r[8]}"\n'
             insert += self.detail_line(f"[{pos}]", r[5], r[6], r[1], r[7],
                                        self.segment_cases(r[6], r[2], r[3]))
-            self.quotes.append({"type": _("Text"), "code": r[0], "file": r[1], "pos": pos,
+            self.quotes.append({"type": "text", "code": r[0], "file": r[1], "pos": pos,
                                 "text": text_, "memo": r[8], "insert": insert})
         cur.execute(image_sql + where_i + order_i, params_i)
         for r in cur.fetchall():
@@ -360,7 +360,7 @@ class DialogSelectQuote(QtWidgets.QDialog):
             insert = f'**{_("CODED MEMO")}:** "{r[6]}"\n' if r[6] != "" else ""
             insert += self.detail_line(f'[{_("Image")} {pos}]', r[7], r[8], r[1], r[9],
                                        self.segment_cases(r[8]))
-            self.quotes.append({"type": _("Image"), "code": r[0], "file": r[1], "pos": pos,
+            self.quotes.append({"type": "image", "code": r[0], "file": r[1], "pos": pos,
                                 "text": r[6], "memo": r[6], "insert": insert})
         cur.execute(av_sql + where_a + order_a, params_a)
         for r in cur.fetchall():
@@ -368,7 +368,7 @@ class DialogSelectQuote(QtWidgets.QDialog):
             insert = f'**{_("CODED MEMO")}:** "{r[4]}"\n' if r[4] != "" else ""
             insert += self.detail_line(f"[A/V {pos}]", r[5], r[6], r[1], r[7],
                                        self.segment_cases(r[6]))
-            self.quotes.append({"type": "A/V", "code": r[0], "file": r[1], "pos": pos,
+            self.quotes.append({"type": "av", "code": r[0], "file": r[1], "pos": pos,
                                 "text": r[4], "memo": r[4], "insert": insert})
 
     def detail_line(self, pos_bracket, cid, fid, file_name, owner, cases_):
@@ -383,6 +383,11 @@ class DialogSelectQuote(QtWidgets.QDialog):
             parts.append(_("Coder: ") + owner)
         return f"{pos_bracket} " + ", ".join(parts) + "."
 
+    @staticmethod
+    def type_label(key):
+        """ Translated label for a canonical segment type key. """
+        return {"text": _("Text"), "image": _("Image"), "av": "A/V"}.get(key, key)
+
     def fill_table(self):
         """ Fill table rows from self.quotes. """
 
@@ -391,7 +396,7 @@ class DialogSelectQuote(QtWidgets.QDialog):
         tw.setHorizontalHeaderLabels([_("Type"), _("Code"), _("File"), _("Position"), _("Text / Memo")])
         tw.setRowCount(len(self.quotes))
         for row, q in enumerate(self.quotes):
-            tw.setItem(row, self.TYPE_COL, QtWidgets.QTableWidgetItem(q["type"]))
+            tw.setItem(row, self.TYPE_COL, QtWidgets.QTableWidgetItem(self.type_label(q["type"])))
             tw.setItem(row, self.CODE_COL, QtWidgets.QTableWidgetItem(q["code"]))
             tw.setItem(row, self.FILE_COL, QtWidgets.QTableWidgetItem(q["file"]))
             tw.setItem(row, self.POS_COL, QtWidgets.QTableWidgetItem(q["pos"]))
@@ -400,7 +405,7 @@ class DialogSelectQuote(QtWidgets.QDialog):
                 text_ = text_[:200] + "..."
             item = QtWidgets.QTableWidgetItem(text_)
             tip = q["text"]
-            if q["type"] == _("Text") and q["memo"] != "":
+            if q["type"] == "text" and q["memo"] != "":
                 tip += "\n\n" + _("CODED MEMO") + ": " + q["memo"]
             item.setToolTip(tip)
             tw.setItem(row, self.TEXT_COL, item)
@@ -416,7 +421,10 @@ class DialogSelectQuote(QtWidgets.QDialog):
         for q in self.quotes:
             if q["type"] not in types:
                 types.append(q["type"])
-        self.ui.comboBox_type.addItems([_("All")] + types)
+        # Canonical keys in userData, labels translatable
+        self.ui.comboBox_type.addItem(_("All"), "all")
+        for t in types:
+            self.ui.comboBox_type.addItem(self.type_label(t), t)
         if len(types) < 2:
             self.ui.comboBox_type.hide()
 
@@ -424,18 +432,18 @@ class DialogSelectQuote(QtWidgets.QDialog):
         """ Hide rows not matching the type combobox and the filter text. """
 
         text_ = self.ui.lineEdit_filter.text().lower()
-        type_ = self.ui.comboBox_type.currentText()
+        type_ = self.ui.comboBox_type.currentData()  # canonical key, translation-safe
         tw = self.ui.tableWidget
         for row in range(tw.rowCount()):
-            match = type_ in (_("All"), "", self.quotes[row]["type"])
+            match = type_ in (None, "all", self.quotes[row]["type"])
             if match and text_ != "":
                 match = any(text_ in tw.item(row, col).text().lower()
                             for col in range(tw.columnCount()))
             tw.setRowHidden(row, not match)
         # Header of the last column follows the selected type
-        if type_ == _("Text"):
+        if type_ == "text":
             header = _("Text")
-        elif type_ in (_("Image"), "A/V"):
+        elif type_ in ("image", "av"):
             header = _("Memo")
         else:
             header = _("Text / Memo")
@@ -483,12 +491,13 @@ class DialogSelectReference(QtWidgets.QDialog):
         scope_labels = {"file": _("This file"), "case": _("This case"),
                         "code": _("This code"), "category": _("This category")}
         self.scope_label = scope_labels.get(entity_type, "")
+        # Canonical keys in userData, labels translatable
         if self.scope_label != "":
-            self.ui.comboBox_type.addItem(self.scope_label)
-        self.ui.comboBox_type.addItem(_("All references"))
+            self.ui.comboBox_type.addItem(self.scope_label, "scoped")
+        self.ui.comboBox_type.addItem(_("All references"), "all")
         if self.scope_label == "" or not self.scoped_risids:
             # Project memo, or owner without linked references: start at All
-            self.ui.comboBox_type.setCurrentText(_("All references"))
+            self.ui.comboBox_type.setCurrentIndex(self.ui.comboBox_type.findData("all"))
         if self.ui.comboBox_type.count() < 2:
             self.ui.comboBox_type.hide()
         self.fill_table()
@@ -528,7 +537,7 @@ class DialogSelectReference(QtWidgets.QDialog):
     def fill_table(self):
         """ Fill rows: scoped references or all, per the combobox. """
 
-        scoped = self.ui.comboBox_type.currentText() == self.scope_label and self.scope_label != ""
+        scoped = self.ui.comboBox_type.currentData() == "scoped"  # canonical key, translation-safe
         self.rows = []
         for ref in self.all_refs:
             if scoped and ref['risid'] not in self.scoped_risids:

--- a/src/qualcoder/report_codes.py
+++ b/src/qualcoder/report_codes.py
@@ -137,13 +137,21 @@ class DialogReportCodes(QtWidgets.QDialog):
         self.ui.pushButton_search_next.setIcon(qta.icon('mdi6.arrow-right'))
         self.ui.pushButton_search_next.pressed.connect(self.search_results_next)
         self.ui.checkBox_show_refs.toggled.connect(self.select_reference_style)
-        options = ["", _("Top categories by case"), _("Top categories by file"), _("Categories by case"),
-                   _("Categories by file"), _("Codes by case"), _("Codes by file")]
-        self.ui.comboBox_matrix.addItems(options)
+        # Canonical keys in userData, labels translatable
+        matrix_options = [("", ""), ("top_cat_case", _("Top categories by case")),
+                          ("top_cat_file", _("Top categories by file")),
+                          ("cat_case", _("Categories by case")), ("cat_file", _("Categories by file")),
+                          ("codes_case", _("Codes by case")), ("codes_file", _("Codes by file"))]
+        for key_, label_ in matrix_options:
+            self.ui.comboBox_matrix.addItem(label_, key_)
         self.ui.label_memos.setPixmap(qta.icon('mdi6.text-box-outline').pixmap(22, 22))
-        options = [_("None"), _("Also code memos"), _("Also coded memos"), _("Also all memos"), _("Only memos"),
-                   _("Only coded memos"), _("Annotations"), _("Codebook memos")]
-        self.ui.comboBox_memos.addItems(options)
+        # Canonical keys in userData, labels translatable
+        memo_options = [("none", _("None")), ("also_code", _("Also code memos")),
+                        ("also_coded", _("Also coded memos")), ("also_all", _("Also all memos")),
+                        ("only_memos", _("Only memos")), ("only_coded", _("Only coded memos")),
+                        ("annotations", _("Annotations")), ("codebook", _("Codebook memos"))]
+        for key_, label_ in memo_options:
+            self.ui.comboBox_memos.addItem(label_, key_)
         cur = self.app.conn.cursor()
         sql = "select count(name) from attribute_type"
         cur.execute(sql)
@@ -151,6 +159,11 @@ class DialogReportCodes(QtWidgets.QDialog):
         if res[0] == 0:
             self.ui.pushButton_attributeselect.setEnabled(False)
         self.ui.pushButton_attributeselect.clicked.connect(self.select_attributes)
+        # Canonical keys for .ui-defined items, labels may be translated
+        for i_, key_ in enumerate(["", "html", "txt", "odt", "xlsx", "csv", "iramuteq"]):
+            self.ui.comboBox_export.setItemData(i_, key_)
+        for i_, key_ in enumerate(["az", "za", "10-1", "1-10"]):
+            self.ui.comboBox_sort.setItemData(i_, key_)
         self.ui.comboBox_export.currentIndexChanged.connect(self.export_option_selected)
         self.ui.comboBox_export.setEnabled(False)
         self.ui.textEdit.installEventFilter(self)
@@ -674,20 +687,20 @@ class DialogReportCodes(QtWidgets.QDialog):
         Exporta main tex tedit results.
         Separate action to export matrix results. """
 
-        text_ = self.ui.comboBox_export.currentText()
-        if text_ == "":
+        key_ = self.ui.comboBox_export.currentData()  # canonical key, translation-safe
+        if key_ in (None, ""):
             return
-        if text_ == "html":
+        if key_ == "html":
             self.export_html_file()
-        if text_ == "odt":
+        if key_ == "odt":
             self.export_odt_file()
-        if text_ == "txt":
+        if key_ == "txt":
             self.export_text_file()
-        if text_ == "csv":
+        if key_ == "csv":
             self.export_csv_file()
-        if text_ == "xlsx":
+        if key_ == "xlsx":
             self.export_xlsx_file()
-        if text_ in ("iramuteq", "IRaMuTeQ"):
+        if key_ == "iramuteq":
             self.export_iramuteq_file()
         self.ui.comboBox_export.setCurrentIndex(0)
 
@@ -1507,11 +1520,11 @@ class DialogReportCodes(QtWidgets.QDialog):
         4. codebook memo selection
         """
 
-        memo_choice = self.ui.comboBox_memos.currentText()
-        if memo_choice == _("Annotations"):
+        memo_choice = self.ui.comboBox_memos.currentData()  # canonical key, translation-safe
+        if memo_choice == "annotations":
             self.search_annotations()
             return
-        if memo_choice == _("Codebook memos"):
+        if memo_choice == "codebook":
             self.search_codebook()
             return
 
@@ -1548,9 +1561,9 @@ class DialogReportCodes(QtWidgets.QDialog):
         self.html_links = []  # For html file output with media
 
         # Add search terms to textEdit
-        if memo_choice == _("Only memos"):
+        if memo_choice == "only_memos":
             self.ui.textEdit.insertPlainText(_("Only memos shown. Coded data not shown.") + "\n")
-        if memo_choice == _("Only coded memos"):
+        if memo_choice == "only_coded":
             self.ui.textEdit.insertPlainText(_("Coded memos shown if available. Coded data not shown.") + "\n")
         self.ui.textEdit.insertPlainText(_("Search parameters") + "\n==========\n")
         coder = self.ui.comboBox_coders.currentText()
@@ -1626,7 +1639,7 @@ class DialogReportCodes(QtWidgets.QDialog):
         QtCore.QCoreApplication.processEvents()
         prog_dialog.setValue(2)
         # Trim results for option: Only coded memos
-        if self.ui.comboBox_memos.currentText() in (_("Only memos"), _("Only coded memos")):  # wrap with _() <- L
+        if self.ui.comboBox_memos.currentData() in ("only_memos", "only_coded"):  # canonical key
             tmp = []
             for r in self.results:
                 if r['coded_memo'] != "":
@@ -1877,8 +1890,8 @@ class DialogReportCodes(QtWidgets.QDialog):
             av_sql += " and code_av.memo like ? "
             parameters.append("%" + str(search_text) + "%")
         if important:
-            av_sql += " and code_av.important=1 "  # was sql, should target av_sql <- L
-        av_sql += " order by code_name.name, cases.name"  # was sql, should target av_sql <- L
+            av_sql += " and code_av.important=1 "  # was sql, should target av_sql
+        av_sql += " order by code_name.name, cases.name"  # was sql, should target av_sql
         if not parameters:
             cur.execute(av_sql)
         else:
@@ -1903,16 +1916,16 @@ class DialogReportCodes(QtWidgets.QDialog):
     def sort_search_results(self):
         """ Sort results by alphabet or by code count, ascending or descending. """
 
-        sort_by = self.ui.comboBox_sort.currentText()
-        if sort_by == "A - z":
+        sort_by = self.ui.comboBox_sort.currentData()  # canonical key, translation-safe
+        if sort_by == "az":
             self.results = sorted(self.results, key=lambda i_: i_['codename'])
             return
-        if sort_by == "Z - a":
+        if sort_by == "za":
             self.results = sorted(self.results, key=lambda i_: i_['codename'], reverse=True)
             return
 
-        # Sort alphabetically by category hierarchy (root>...>nearest), fallback to codename <- L
-        if sort_by in ("Category A - z", "Category Z - a"):
+        # Sort alphabetically by category hierarchy (root>...>nearest), fallback to codename
+        if sort_by in ("cat_az", "cat_za"):  # items not yet in the .ui
             def category_sort_key(item):
                 hierarchy = self.categories_of_code(item['cid'])
                 # categories_of_code returns nearest-first, reverse for root-first ordering
@@ -1920,7 +1933,7 @@ class DialogReportCodes(QtWidgets.QDialog):
                 # Items without category get an empty hierarchy_str -> grouped together,
                 # then sorted by codename within that group.
                 return (hierarchy_str.lower(), item['codename'].lower())
-            reverse_order = (sort_by == "Category Z - a")  # descending when Z - a
+            reverse_order = (sort_by == "cat_za")  # descending when Z - a
             self.results = sorted(self.results, key=category_sort_key, reverse=reverse_order)
             return
 
@@ -1937,7 +1950,7 @@ class DialogReportCodes(QtWidgets.QDialog):
                     count += 1
             name_and_count.append({'codename': codename, 'count': count})
         tmp_results = []
-        if sort_by == "1 - 10":
+        if sort_by == "1-10":
             small_to_large = sorted(name_and_count, key=lambda d: d['count'])
             for s in small_to_large:
                 for r in self.results:
@@ -1945,7 +1958,7 @@ class DialogReportCodes(QtWidgets.QDialog):
                         tmp_results.append(r)
             self.results = tmp_results
             return
-        if sort_by == "10 - 1":
+        if sort_by == "10-1":
             large_to_small = sorted(name_and_count, key=lambda d: d['count'], reverse=True)
             for s in large_to_small:
                 for r in self.results:
@@ -2293,13 +2306,12 @@ class DialogReportCodes(QtWidgets.QDialog):
         fmt_italic.setFontItalic(True)
         fmt_larger = QtGui.QTextCharFormat()
         fmt_larger.setFontPointSize(self.app.settings['docfontsize'] + 2)
-        # memo_choice, use current index, as other languages will not match
-        memo_choice_index = self.ui.comboBox_memos.currentIndex()
+        memo_key = self.ui.comboBox_memos.currentData()  # canonical key, translation-safe
 
         for i, row in enumerate(self.results):
             self.heading(row)
             # Add code memo
-            if row['coded_memo'] != "" and memo_choice_index in (4, 5):  # Only memos, Only coded memos
+            if row['coded_memo'] != "" and memo_key in ("only_memos", "only_coded"):
                 self.ui.textEdit.insertPlainText("\n")
                 self.ui.textEdit.insertPlainText(row['coded_memo'] + "\n")
 
@@ -2307,7 +2319,7 @@ class DialogReportCodes(QtWidgets.QDialog):
             if row.get('overlaps'):  # skip when 'overlaps' is missing OR empty string
                 self.ui.textEdit.insertPlainText(row['overlaps'] + "\n")
 
-            if row['result_type'] == 'text' and memo_choice_index not in (4, 5):  # Only memos, Only coded memos
+            if row['result_type'] == 'text' and memo_key not in ("only_memos", "only_coded"):
                 cursor = self.ui.textEdit.textCursor()
                 pos0 = len(self.ui.textEdit.toPlainText())
                 self.ui.textEdit.insertPlainText("\n")
@@ -2316,7 +2328,7 @@ class DialogReportCodes(QtWidgets.QDialog):
                 cursor.setPosition(pos0, QtGui.QTextCursor.MoveMode.MoveAnchor)
                 cursor.setPosition(pos1, QtGui.QTextCursor.MoveMode.KeepAnchor)
                 cursor.setCharFormat(fmt_normal)
-                self.ui.textEdit.insertPlainText("\n")  # separator before coded segment <- L
+                self.ui.textEdit.insertPlainText("\n")  # separator before coded segment
                 pos0 = len(self.ui.textEdit.toPlainText())
                 self.ui.textEdit.insertPlainText(row['text'])
                 pos1 = len(self.ui.textEdit.toPlainText())
@@ -2331,7 +2343,7 @@ class DialogReportCodes(QtWidgets.QDialog):
                 if self.ui.checkBox_text_context.isChecked() and self.app.settings[
                     'report_text_context_style'] == 'Bigger':
                     cursor.setCharFormat(fmt_larger)
-                self.ui.textEdit.insertPlainText("\n")  # separator after coded segment <- L
+                self.ui.textEdit.insertPlainText("\n")  # separator after coded segment
                 pos0 = len(self.ui.textEdit.toPlainText())
                 self.ui.textEdit.insertPlainText(row['posttext'])
                 pos1 = len(self.ui.textEdit.toPlainText())
@@ -2339,20 +2351,20 @@ class DialogReportCodes(QtWidgets.QDialog):
                 cursor.setPosition(pos1, QtGui.QTextCursor.MoveMode.KeepAnchor)
                 if self.ui.checkBox_text_context.isChecked():
                     cursor.setCharFormat(fmt_normal)
-                if memo_choice_index != 5:  # Only coded memos:
+                if memo_key != "only_coded":
                     self.ui.textEdit.insertPlainText("\n")
-                if row['coded_memo'] != "" and memo_choice_index in (1, 2, 3):  # added 3 -> Also all memos now shows coded_memo
+                if row['coded_memo'] != "" and memo_key in ("also_code", "also_coded", "also_all"):  # also_all shows coded_memo
                     self.ui.textEdit.insertPlainText(f"{_('MEMO:')} {row['coded_memo']}\n")
-            if row['result_type'] == 'image' and memo_choice_index not in (4, 5):  # Only memos, Only coded memos
+            if row['result_type'] == 'image' and memo_key not in ("only_memos", "only_coded"):
                 self.put_image_into_textedit(row, i, self.ui.textEdit)
-            if row['result_type'] == 'av' and memo_choice_index not in (4, 5):  # Only memos, Only coded memos
+            if row['result_type'] == 'av' and memo_key not in ("only_memos", "only_coded"):
                 self.ui.textEdit.insertPlainText(f"\n{row['text']}\n")
 
             # File reference, below the coded memo
             self.insert_reference(row)
 
             # Show co-ocurrences after coded memo (skip on memo-only modes for consistency)
-            if memo_choice_index not in (4, 5):  # hide co-occurrences in "Only memos" / "Only coded memos"
+            if memo_key not in ("only_memos", "only_coded"):  # hide co-occurrences in memo-only modes
                 overlaps = self.get_cooccurring_codes(row)  # Adds ctids, imids, avids of the overlaps as Dict{[list]}
                 if overlaps:
                     self.ui.textEdit.insertPlainText(f"{_('Overlapping codes:')} [{', '.join(overlaps)}]\n")
@@ -2363,22 +2375,22 @@ class DialogReportCodes(QtWidgets.QDialog):
         # Fill matrix or clear third splitter pane.
         self.ui.tableWidget.setColumnCount(0)
         self.ui.tableWidget.setRowCount(0)
-        matrix_option_index = self.ui.comboBox_matrix.currentIndex()
+        matrix_key = self.ui.comboBox_matrix.currentData()  # canonical key, translation-safe
 
-        if matrix_option_index == 0:
+        if matrix_key in (None, ""):
             self.ui.splitter.setSizes([200, 400, 0])
             return
         # Categories by case, Top categories by case, Codes by case
-        if self.case_ids_string == "" and matrix_option_index in (1, 3, 5):
+        if self.case_ids_string == "" and matrix_key in ("top_cat_case", "cat_case", "codes_case"):
             Message(self.app, _("No case matrix"), _("Cases not selected")).exec()
             self.ui.splitter.setSizes([200, 400, 0])
             return
-        if self.case_ids_string != "" and matrix_option_index == 1:  # Top categories by case
+        if self.case_ids_string != "" and matrix_key == "top_cat_case":
             self.matrix_by_top_categories(self.results, self.case_ids_string, "case")
-        if self.case_ids_string == "" and matrix_option_index == 2:  # Top categories by file
+        if self.case_ids_string == "" and matrix_key == "top_cat_file":
             self.matrix_by_top_categories(self.results, self.file_ids_string)
         # Top categories BY FILE for SELECTED CASES
-        if self.case_ids_string != "" and matrix_option_index == 2:  # Top categories by file
+        if self.case_ids_string != "" and matrix_key == "top_cat_file":
             # Need to create file ids comma separated string
             files_id_name = self.app.get_filenames()
             file_ids = []
@@ -2391,12 +2403,12 @@ class DialogReportCodes(QtWidgets.QDialog):
                         r['file_or_casename'] = f['name']
             file_ids = str(list(set(file_ids)))[1:-1]  # Remove '[' ']'
             self.matrix_by_top_categories(self.results, file_ids)
-        if self.case_ids_string != "" and matrix_option_index == 3:  # Categories by case
+        if self.case_ids_string != "" and matrix_key == "cat_case":
             self.matrix_by_categories(self.results, self.case_ids_string, "case")
-        if self.case_ids_string == "" and matrix_option_index == 4:  # Categories by file
+        if self.case_ids_string == "" and matrix_key == "cat_file":
             self.matrix_by_categories(self.results, self.file_ids_string)
         # Categories BY FILE for SELECTED CASES
-        if self.case_ids_string != "" and matrix_option_index == 4:  # Categories by file
+        if self.case_ids_string != "" and matrix_key == "cat_file":
             # Need to create file ids comma separated string
             files_id_name = self.app.get_filenames()
             file_ids = []
@@ -2410,12 +2422,12 @@ class DialogReportCodes(QtWidgets.QDialog):
             file_ids = str(list(set(file_ids)))[1:-1]  # Remove '[' ']'
             self.matrix_by_categories(self.results, file_ids)
 
-        if self.case_ids_string != "" and matrix_option_index == 5:  # Codes by case
+        if self.case_ids_string != "" and matrix_key == "codes_case":
             self.matrix_by_codes(self.results, self.case_ids_string, "case")
-        if self.case_ids_string == "" and matrix_option_index == 6:  # Codes by file
+        if self.case_ids_string == "" and matrix_key == "codes_file":
             self.matrix_by_codes(self.results, self.file_ids_string)
         # Codes BY FILE for SELECTED CASES
-        if self.case_ids_string != "" and matrix_option_index == 6:  # Codes by file
+        if self.case_ids_string != "" and matrix_key == "codes_file":
             # Need to create file ids comma separated string
             files_id_name = self.app.get_filenames()
             file_ids = []
@@ -2532,23 +2544,23 @@ class DialogReportCodes(QtWidgets.QDialog):
         head = "\n"
         if item['result_type'] == 'text':
             head += f"[{item['pos0']}-{item['pos1']}] "
-        # prepend category hierarchy (root > ... > nearest) before code name <- L
+        # prepend category hierarchy (root > ... > nearest) before code name
         category_hierarchy = self.categories_of_code(item['cid'])
         if category_hierarchy:
             # categories_of_code returns nearest-first, reverse for root-first display
             head += " > ".join(reversed(category_hierarchy)) + " > "
         head += item['codename'] + ", "
-        memo_choice = self.ui.comboBox_memos.currentText()
-        if memo_choice in (_("Also code memos"), _("Also all memos"), _("Only memos")) and item['codename_memo'] != "":
+        memo_choice = self.ui.comboBox_memos.currentData()  # canonical key, translation-safe
+        if memo_choice in ("also_code", "also_all", "only_memos") and item['codename_memo'] != "":
             # A real newline, not <br />: head starts with "\n", so mightBeRichText stops there,
             # append treats it as plain text and the tag would show literally
             head += _("CODE MEMO: ") + item['codename_memo'] + "\n"
         head += _("File: ") + filename + ", "
-        if memo_choice in (_("Also all memos"), _("Only memos")) and item['source_memo'] != "":
+        if memo_choice in ("also_all", "only_memos") and item['source_memo'] != "":
             head += _(" FILE MEMO: ") + item['source_memo']
         if item['file_or_case'] == 'Case':
             head += " " + _("Case: ") + item['file_or_casename']
-            if memo_choice in (_("Also all memos"), _("Only memos")):
+            if memo_choice in ("also_all", "only_memos"):
                 cur = self.app.conn.cursor()
                 cur.execute("select memo from cases where name=?", [item['file_or_casename']])
                 res = cur.fetchone()
@@ -2995,21 +3007,21 @@ class DialogReportCodes(QtWidgets.QDialog):
         res = cur.fetchone()
         if res is not None:
             filename = res[0]
-        memo_choice = self.ui.comboBox_memos.currentText()
+        memo_choice = self.ui.comboBox_memos.currentData()  # canonical key, translation-safe
         head = f"\n{item['codename']}, "
-        if memo_choice in (_("Also all memos"), _("Also code memos"), _("Only memos")) and item['codename_memo'] != "":
+        if memo_choice in ("also_all", "also_code", "only_memos") and item['codename_memo'] != "":
             # A real newline, not <br />: inserted with append as plain text
             head += _("CODE MEMO: ") + f"{item['codename_memo']}\n"
         head += f"{_('File:')} {filename}, "
-        if memo_choice in (_("Also all memos"), _("Only memos")) and item['source_memo'] != "":  # typo 'alll' -> 'all' <- L
+        if memo_choice in ("also_all", "only_memos") and item['source_memo'] != "":  # typo 'alll' -> 'all'
             head += f" {_('FILE MEMO:')} {item['source_memo']}"
-        if item['file_or_case'] == 'Case':  # removed stray colon in 'Case:' <- L
+        if item['file_or_case'] == 'Case':  # removed stray colon in 'Case:'
             head += f" {item['file_or_case']}: {item['file_or_casename']}, "
-            if memo_choice in (_("Also all memos"), _("Only memos")):
+            if memo_choice in ("also_all", "only_memos"):
                 cur = self.app.conn.cursor()
                 cur.execute("select ifnull(memo,'') from cases where name=?", [item['file_or_casename']])
                 res = cur.fetchone()
-                if res is not None and res[0] != "":  # was res != "", should be res[0] <- L
+                if res is not None and res[0] != "":  # was res != "", should be res[0]
                     head += f", {_('CASE MEMO:')} {res[0]}"
         head += item['coder']
         cursor = text_edit.textCursor()
@@ -3238,7 +3250,7 @@ class DialogReportCodes(QtWidgets.QDialog):
                 column_list.append(tedit)
             self.te.append(column_list)
         self.matrix_links = []
-        memo_choice = self.ui.comboBox_memos.currentText()
+        memo_choice = self.ui.comboBox_memos.currentData()  # canonical key, translation-safe
         if self.ui.checkBox_matrix_transpose.isChecked():
             for row in range(len(vertical_labels)):
                 for col in range(len(horizontal_labels)):
@@ -3247,21 +3259,19 @@ class DialogReportCodes(QtWidgets.QDialog):
                             r['row'] = row
                             r['col'] = col
                             self.te[row][col].insertHtml(self.matrix_heading(r, self.te[row][col]))
-                            if r['result_type'] == 'text' and memo_choice in (_("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'text' and memo_choice in ("only_memos", "only_coded"):
                                 self.te[row][col].append(r['coded_memo'])
-                            if r['result_type'] == 'text' and memo_choice not in (
-                                    _("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'text' and memo_choice not in ("only_memos", "only_coded"):
                                 self.te[row][col].append(r['text'])
-                                if memo_choice in (_("Also all memos"), _("Also coded memos")) and r[
+                                if memo_choice in ("also_all", "also_coded") and r[
                                     'coded_memo'] != "":
                                     self.te[row][col].append(f"{_('MEMO:')} {r['coded_memo']}")
                                 self.te[row][col].insertPlainText("\n")
-                            if r['result_type'] == 'image' and memo_choice in (_("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'image' and memo_choice in ("only_memos", "only_coded"):
                                 self.te[row][col].append(r['coded_memo'])
-                            if r['result_type'] == 'image' and memo_choice not in (
-                                    _("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'image' and memo_choice not in ("only_memos", "only_coded"):
                                 self.put_image_into_textedit(r, counter, self.te[row][col])
-                            if r['result_type'] == 'av' and memo_choice not in (_("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'av' and memo_choice not in ("only_memos", "only_coded"):
                                 self.te[row][col].insertPlainText(f"{r['text']}\n")
                             self.matrix_links.append(r)
                     self.ui.tableWidget.setCellWidget(row, col, self.te[row][col])
@@ -3273,13 +3283,12 @@ class DialogReportCodes(QtWidgets.QDialog):
                             r['row'] = row
                             r['col'] = col
                             self.te[row][col].insertHtml(self.matrix_heading(r, self.te[row][col]))
-                            if r['result_type'] == 'text' and memo_choice in (_("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'text' and memo_choice in ("only_memos", "only_coded"):
                                 self.te[row][col].append(r['coded_memo'])
-                            if r['result_type'] == 'text' and memo_choice not in (
-                                    _("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'text' and memo_choice not in ("only_memos", "only_coded"):
                                 self.te[row][col].append(r['text'])
                                 try:
-                                    if memo_choice in (_("Also all memos"), "Also coded memos") and r[
+                                    if memo_choice in ("also_all", "also_coded") and r[
                                         'coded_memo'] != "":
                                         self.te[row][col].append(_("MEMO: ") + r['coded_memo'])
                                 except TypeError as err:
@@ -3288,12 +3297,11 @@ class DialogReportCodes(QtWidgets.QDialog):
                                     msg += f"Result dictionary:\n{r}\n"
                                     logger.error(msg)
                                 self.te[row][col].insertPlainText("\n")
-                            if r['result_type'] == 'image' and memo_choice in (_("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'image' and memo_choice in ("only_memos", "only_coded"):
                                 self.te[row][col].append(r['coded_memo'])
-                            if r['result_type'] == 'image' and memo_choice not in (
-                                    _("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'image' and memo_choice not in ("only_memos", "only_coded"):
                                 self.put_image_into_textedit(r, counter, self.te[row][col])
-                            if r['result_type'] == 'av' and memo_choice not in (_("Only memos"), _("Only coded memos")):
+                            if r['result_type'] == 'av' and memo_choice not in ("only_memos", "only_coded"):
                                 self.te[row][col].insertPlainText(r['text'] + "\n")
                             self.matrix_links.append(r)
                     self.ui.tableWidget.setCellWidget(row, col, self.te[row][col])

--- a/src/qualcoder/select_items.py
+++ b/src/qualcoder/select_items.py
@@ -107,10 +107,12 @@ class DialogSelectItems(QtWidgets.QDialog):
         self.ui.comboBox.hide()
         if self.groups:
             self.groups = list(set(self.groups))
-            self.groups.insert(0, _("All"))
             self.ui.comboBox.setEnabled(True)
             self.ui.comboBox.show()
-            self.ui.comboBox.addItems(self.groups)
+            # Canonical key in userData, label translatable
+            self.ui.comboBox.addItem(_("All"), "All")
+            for group in self.groups:
+                self.ui.comboBox.addItem(group, group)
 
         if self.selection_mode == "single":
             self.ui.listView.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
@@ -137,8 +139,8 @@ class DialogSelectItems(QtWidgets.QDialog):
         """ Show data items considering comboBox group selection. """
 
         self.data_refined = copy.copy(self.data)
-        grouper = self.ui.comboBox.currentText()
-        if not self.groups or grouper == "All":
+        grouper = self.ui.comboBox.currentData()  # canonical key, translation-safe
+        if not self.groups or grouper in (None, "All"):
             self.model = ListModel(self.data_refined, checkable=self.with_checkboxes,
                                    checked_keys=self._checked_keys, key_func=self._item_key)
             self.ui.listView.setModel(self.model)

--- a/src/qualcoder/view_charts.py
+++ b/src/qualcoder/view_charts.py
@@ -184,8 +184,9 @@ class ViewCharts(QDialog):
         self.ui.comboBox_char_attributes.currentIndexChanged.connect(self.character_attribute_charts)
         self.ui.comboBox_num_attributes.currentIndexChanged.connect(self.numeric_attribute_charts)
         # Heatmaps
-        heatmap_combobox_list = ["", "File", "Case"]
-        self.ui.comboBox_heatmap.addItems(heatmap_combobox_list)
+        # Canonical keys in userData, labels translatable
+        for key, label in [("", ""), ("File", _("File")), ("Case", _("Case"))]:
+            self.ui.comboBox_heatmap.addItem(label, key)
         self.ui.comboBox_heatmap.currentIndexChanged.connect(self.make_heatmap)
         # Word cloud default stopwords based on default language
         index = self.ui.comboBox_stopwords.findText(self.app.settings['language'],
@@ -515,7 +516,7 @@ class ViewCharts(QDialog):
                 if code['catid'] == cat['catid']:
                     selected_codes.append(code)
         # Include descendant sub-codes (supercid) of the selected codes, cascading, so a
-        # category selection also charts the sub-codes nested under its codes. <- L
+        # category selection also charts the sub-codes nested under its codes.
         selected_cids = {c['cid'] for c in selected_codes}
         changed = True
         while changed:
@@ -1349,7 +1350,7 @@ class ViewCharts(QDialog):
 
     @staticmethod
     def _contrast_text(hex_colour):
-        """ Black or white label for readability over a given sector colour. <- L """
+        """ Black or white label for readability over a given sector colour. """
         h = (hex_colour or '').lstrip('#')
         if len(h) != 6:
             return '#000000'
@@ -1363,7 +1364,7 @@ class ViewCharts(QDialog):
     def _apply_code_colours(self, fig, colours_map):
         """ Colour each sunburst/treemap sector with its code colour (neutral grey for
         categories) and set a black or white label per sector for readable contrast.
-        Sectors are matched by name read from the trace, so the order stays correct. <- L """
+        Sectors are matched by name read from the trace, so the order stays correct. """
         try:
             labels = list(fig.data[0].labels)
         except (IndexError, AttributeError, TypeError):
@@ -1372,7 +1373,7 @@ class ViewCharts(QDialog):
         fig.update_traces(insidetextfont_color=text_colours)
 
     def _rollup_subcodes_into_parent_codes(self):
-        """ Hierarchy charts: nest sub-codes under their parent code. <- L
+        """ Hierarchy charts: nest sub-codes under their parent code.
         Sub-codes have a null catid, so the category roll-up leaves them parentless and they
         float at the root. Here each sub-code count is rolled up the code hierarchy (deepest
         first) so a parent code total includes its descendants, and each sub-code parentname
@@ -1434,7 +1435,7 @@ class ViewCharts(QDialog):
             for coded_item in coded_data:
                 if coded_item[0] == code_['cid']:
                     code_['count'] += 1
-        self._rollup_subcodes_into_parent_codes()  # sub-codes nest under their parent code <- L
+        self._rollup_subcodes_into_parent_codes()  # sub-codes nest under their parent code
         # Add the code count directly to each parent category, add parentname to each code
         for category in self.categories:
             for code_ in self.codes:
@@ -1469,7 +1470,7 @@ class ViewCharts(QDialog):
         items = []
         values = []
         parents = []
-        colors_map = {}  # sector colour: the code's own colour, neutral grey for categories <- L
+        colors_map = {}  # sector colour: the code's own colour, neutral grey for categories
         for sb_combined in combined:
             items.append(sb_combined['name'])
             values.append(sb_combined['count'])
@@ -1487,14 +1488,14 @@ class ViewCharts(QDialog):
             fig = px.sunburst(df[mask], names='item', parents='parent', values='value', branchvalues='total',
                               color='item', color_discrete_map=colors_map,
                               title=title + subtitle)
-            self._apply_code_colours(fig, colors_map)  # sectors match code colours, labels stay readable <- L
+            self._apply_code_colours(fig, colors_map)  # sectors match code colours, labels stay readable
             fig.show()
             self.helper_export_html(fig)
         if chart == "treemap":
             fig = px.treemap(df[mask], names='item', parents='parent', values='value', branchvalues='total',
                              color='item', color_discrete_map=colors_map,
                              title=title + subtitle)
-            self._apply_code_colours(fig, colors_map)  # sectors match code colours, labels stay readable <- L
+            self._apply_code_colours(fig, colors_map)  # sectors match code colours, labels stay readable
             fig.show()
             self.helper_export_html(fig)
 
@@ -1521,7 +1522,7 @@ class ViewCharts(QDialog):
             for coded_item in coded_data:
                 if coded_item[0] == code_['cid']:
                     code_['count'] += coded_item[1]
-        self._rollup_subcodes_into_parent_codes()  # sub-codes nest under their parent code <- L
+        self._rollup_subcodes_into_parent_codes()  # sub-codes nest under their parent code
         # Add the code count directly to each parent category, add parentname to each code
         for category in self.categories:
             for code_ in self.codes:
@@ -1893,10 +1894,10 @@ class ViewCharts(QDialog):
             codes = codes[:40]
             Message(self.app, _("Too many codes"), _("Too many codes for display. Restricted to 40")).exec()
         # Filters
-        heatmap_type = self.ui.comboBox_heatmap.currentText()
-        if heatmap_type == "":
+        heatmap_type = self.ui.comboBox_heatmap.currentData()  # canonical key, translation-safe
+        if heatmap_type in (None, ""):
             return
-        title = heatmap_type + " " + _("Heatmap")
+        title = self.ui.comboBox_heatmap.currentText() + " " + _("Heatmap")
         self.get_selected_categories_and_codes()
         y_labels = []
         for c in codes:


### PR DESCRIPTION
Translated combobox options broke exports and other combobox-driven actions: dispatch code compared the visible currentText() against English literals, while .ui item labels are translatable. Issue: https://github.com/ccbogel/QualCoder/issues/1471 

Fix: store a canonical key in each item's userData and dispatch on currentData(). Labels stay translatable, no .ui changes, independent of translation and item order. Applied consistently across 6 files.

cat_az/cat_za keys are reserved for the Category sort branches not yet in the .ui.