### PR TITLE
Missing emissions

### DIFF
--- a/src/qualcoder/case_file_manager.py
+++ b/src/qualcoder/case_file_manager.py
@@ -14,7 +14,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
 https://qualcoder-org.github.io
@@ -137,6 +137,12 @@ class DialogCaseFileManager(QtWidgets.QDialog):
         self.app.settings['dialogcasefilemanager_splitter0'] = sizes[0]
         self.app.settings['dialogcasefilemanager_splitter1'] = sizes[1]
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def get_files(self):
         """ Get files for this case. """
 
@@ -218,6 +224,7 @@ class DialogCaseFileManager(QtWidgets.QDialog):
         cur.execute(sql, (link['caseid'], link['fid'], link['pos0'], link['pos1'],
                           link['owner'], link['date'], link['memo']))
         self.app.conn.commit()
+        self._emit_project_table_changes(['case_text'])
         msg = f'{file_[1]} {_("added to case.")}\n'
 
         # Update table entry assigned to Yes
@@ -263,6 +270,7 @@ class DialogCaseFileManager(QtWidgets.QDialog):
         self.get_files()
         self.fill_table()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['case_text'])
 
     def show_or_hide_rows(self):
         """ Show or hide table rows if check box hide is checked or not. """
@@ -552,6 +560,7 @@ class DialogCaseFileManager(QtWidgets.QDialog):
         self.get_files()
         self.fill_table()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['case_text'])
 
     def unmark(self, position):
         """ Remove case marking from selected text in selected file. """
@@ -584,6 +593,7 @@ class DialogCaseFileManager(QtWidgets.QDialog):
         self.get_files()
         self.fill_table()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['case_text'])
 
     def automark(self):
         """ Automark text in one or more files with selected case.
@@ -655,6 +665,8 @@ class DialogCaseFileManager(QtWidgets.QDialog):
                     else:
                         already_assigned = _("\nAlready assigned.")
         # Update messages and table widget
+        if entries > 0:
+            self._emit_project_table_changes(['case_text'])
         self.get_files()
         self.fill_table()
         # Text file is loaded in browser then update the highlights

--- a/src/qualcoder/cases.py
+++ b/src/qualcoder/cases.py
@@ -14,7 +14,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
 https://qualcoder-org.github.io
@@ -221,7 +221,7 @@ class DialogCases(QtWidgets.QDialog):
         self.ui.textBrowser.clear()
 
     def _emit_project_table_changes(self, tables):
-        """ Notify other open dialogs about changed project tables."""
+        """Notify other open dialogs about changed project tables."""
 
         if getattr(self.app, "project_events", None) is not None:
             self.app.project_events.emit_table_changes(tables, source=self)
@@ -237,6 +237,7 @@ class DialogCases(QtWidgets.QDialog):
         cur = self.app.conn.cursor()
         cur.execute("select name from attribute_type where caseOrFile='case'")
         attribute_names = cur.fetchall()
+        inserted = False
         for c in self.cases:
             for att_name in attribute_names:
                 cur.execute("select value from attribute where id=? and name=? and attr_type='case'",
@@ -246,6 +247,9 @@ class DialogCases(QtWidgets.QDialog):
                     cur.execute("insert into attribute (value,id,name,attr_type, date,owner) values(?,?,?,'case',?,?)",
                                 ("", c['caseid'], att_name[0], now_date, self.app.settings['codername']))
                     self.app.conn.commit()
+                    inserted = True
+        if inserted:
+            self._emit_project_table_changes(['attribute'])
     def help(self):
         """ Open help for transcribe section in browser. """
         self.app.help_wiki("3.3.-Cases")
@@ -384,6 +388,8 @@ class DialogCases(QtWidgets.QDialog):
                     cur.execute("insert into attribute (name,attr_type,value,id,date,owner) values(?,?,?,?,?,?)",
                                 [attribute_name, "case", "", c['caseid'],  now_date, self.app.settings['codername']])
                     self.app.conn.commit()
+        # No event here: this runs on every refresh and sort, including refreshes
+        # triggered by the bus itself. The user actions that write attributes emit.
 
         self.fill_table()
 
@@ -655,6 +661,7 @@ class DialogCases(QtWidgets.QDialog):
         self.fill_table()
         self.parent_text_edit.append(_("Case added: ") + item['name'])
         self.app.delete_backup = False
+        self._emit_project_table_changes(['cases', 'attribute'])
 
     def delete_case(self):
         """ When delete button pressed, case is deleted from model and database. """
@@ -688,6 +695,7 @@ class DialogCases(QtWidgets.QDialog):
         self.load_cases_data()
         self.app.delete_backup = False
         self.fill_table()
+        self._emit_project_table_changes(['cases', 'case_text', 'attribute'])
 
     def cell_modified(self):
         """ If the case name has been changed in the table widget update the database.
@@ -696,6 +704,7 @@ class DialogCases(QtWidgets.QDialog):
         row = self.ui.tableWidget.currentRow()
         col = self.ui.tableWidget.currentColumn()
         value = str(self.ui.tableWidget.item(row, col).text()).strip()
+        changed_tables = []
         if col == self.NAME_COLUMN:  # update case name
             # Check that no other case name has this text and this is not empty
             update = True
@@ -709,6 +718,7 @@ class DialogCases(QtWidgets.QDialog):
                 cur.execute("update cases set name=? where caseid=?", (value, self.cases[row]['caseid']))
                 self.app.conn.commit()
                 self.cases[row]['name'] = value
+                changed_tables.append("cases")
             else:  # put the original text in the cell
                 self.ui.tableWidget.item(row, col).setText(self.cases[row]['name'])
         if col >= self.ATTRIBUTE_START_COLUMN:  # Update attribute value
@@ -739,7 +749,8 @@ class DialogCases(QtWidgets.QDialog):
             cur.execute("update attribute set value=?, date=?, owner=? where id=? and name=? and attr_type='case'",
                         (value, now_date, self.app.settings['codername'], self.cases[row]['caseid'], attribute_name))
             self.app.conn.commit()
-        self._emit_project_table_changes(["attribute"])
+            changed_tables.append("attribute")
+        self._emit_project_table_changes(changed_tables)
 
         # Update self.cases[attributes]
         # Add list of attribute values to cases, order matches header columns
@@ -784,6 +795,7 @@ class DialogCases(QtWidgets.QDialog):
                                        'pos1': row[3], 'owner': row[4], 'date': row[5], 'memo': row[6]})
 
         if y == self.MEMO_COLUMN:
+            previous_memo = self.cases[x]['memo']
             ui = DialogMemo(self.app, _("Memo for case ") + self.cases[x]['name'],
                             self.cases[x]['memo'], entity_type="case", entity_id=self.cases[x]['caseid'])
             ui.exec()
@@ -791,6 +803,9 @@ class DialogCases(QtWidgets.QDialog):
             cur = self.app.conn.cursor()
             cur.execute('update cases set memo=? where caseid=?', (self.cases[x]['memo'], self.cases[x]['caseid']))
             self.app.conn.commit()
+            if self.cases[x]['memo'] != previous_memo:
+                # Opening a memo to read it must not wake up the other dialogs
+                self._emit_project_table_changes(['cases'])
             if self.cases[x]['memo'] == "" or self.cases[x]['memo'] is None:
                 self.ui.tableWidget.setItem(x, self.MEMO_COLUMN, QtWidgets.QTableWidgetItem())
             else:

--- a/src/qualcoder/code_av.py
+++ b/src/qualcoder/code_av.py
@@ -16,8 +16,8 @@ If not, see <https://www.gnu.org/licenses/>.
 
 Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
-https://qualcoder-org.github.io
 https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -565,6 +565,8 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.parent_textEdit.append(msg)
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
+        if undo_list:
+            self._emit_project_table_changes(['code_text'])
 
     def _record_speakers_undo(self, ctids_before):
         """ Register the Mark speakers run in the autocode undo history: deletes the
@@ -729,12 +731,17 @@ class DialogCodeAV(QtWidgets.QDialog):
                 cur.execute("select cid, pos0, pos1, ifnull(seltext,'') from code_text "
                             "where fid=? and owner=? and avid is null",
                             [self.transcription[0], speaker_coder_name])
+                mirrored = False
                 for s_cid, s_p0, s_p1, s_text in cur.fetchall():
-                    self._create_av_segment_from_text_code(s_cid, s_p0, s_p1, s_text,
-                                                           owner=speaker_coder_name)
+                    if self._create_av_segment_from_text_code(s_cid, s_p0, s_p1, s_text,
+                                                              owner=speaker_coder_name):
+                        mirrored = True
                 self.load_segments()
                 self.fill_code_counts_in_tree()
                 self.get_coded_text_update_eventfilter_tooltips()
+                if mirrored:
+                    # One event for the whole speaker run, not one per turn
+                    self._emit_project_table_changes(['code_av', 'code_text'])
             self._record_speakers_undo(ctids_before)
             if self.app.conn is not None and speaker_coder_name not in self.app.get_coder_names_in_project(
                     only_visible=True):
@@ -1436,6 +1443,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.get_files()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['source'])
 
     def go_to_latest_coded_file(self):
         """ Vertical splitter button activates this """
@@ -1755,6 +1763,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             self.file_['av_text_id'] = tr_id
             cur.execute("update source set av_text_id=? where id=?", [tr_id, self.file_['id']])
             self.app.conn.commit()
+            self._emit_project_table_changes(['source'])
             cur.execute("select id, fulltext, name from source where id=?", [tr_id])
             self.transcription = cur.fetchone()
             if self.transcription is not None and self.transcription[1] is None:
@@ -1997,6 +2006,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         cur.execute("select avid, memo from code_av where id=? and cid=? and pos0=? and pos1=? and owner=?",
                     [self.file_['id'], cid, ms0, ms1, owner])
         existing = cur.fetchone()
+        written = False
         if existing:
             avid, old_memo = existing[0], existing[1] or ""
             if entry not in old_memo:
@@ -2004,6 +2014,7 @@ class DialogCodeAV(QtWidgets.QDialog):
                 cur.execute("update code_av set memo=? where avid=?", [memo, avid])
                 self.app.conn.commit()
                 self.app.delete_backup = False
+                written = True
         else:
             cur.execute("insert into code_av (id, pos0, pos1, cid, memo, date, owner, important) "
                         "values(?,?,?,?,?,?,?, null)",
@@ -2012,6 +2023,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             avid = cur.lastrowid
             self.app.conn.commit()
             self.app.delete_backup = False
+            written = True
             self.load_segments()
             self.fill_code_counts_in_tree()
         # --- Text coding (code_text): link it to the wave segment (native code_text.avid)
@@ -2030,7 +2042,10 @@ class DialogCodeAV(QtWidgets.QDialog):
                         [tmemo, avid, cid, self.transcription[0], pos0_char, pos1_char, owner])
             self.app.conn.commit()
             self.app.delete_backup = False
+            written = True
             self.get_coded_text_update_eventfilter_tooltips()
+        # The caller emits one event for the whole action, so no event is sent here
+        return written
 
     def _delete_linked_av_segment(self, item):
         """ Remove the wave segment linked to a text coding. Uses the native code_text.avid
@@ -2178,7 +2193,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             cur.execute("update code_text set avid=? where ctid=?", [avid, already[0]])
             self.app.conn.commit()
             self.app.delete_backup = False
-            return
+            return True
         audio_info = (f"[Audio: {ms0}-{ms1} ms "
                       f"({msecs_to_hours_mins_secs(ms0)} - {msecs_to_hours_mins_secs(ms1)})]")
         now = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
@@ -2194,6 +2209,8 @@ class DialogCodeAV(QtWidgets.QDialog):
             return
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
+        # The caller emits one event for the whole action, so no event is sent here
+        return True
 
     def _seek_to_clicked_timestamp(self, event):
         """ If a left click landed on a transcript timestamp, seek the media to that time.
@@ -2491,6 +2508,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.delete_backup = False
         self.load_segments()
         self.fill_code_counts_in_tree()
+        self._emit_project_table_changes(['code_av'])
 
     def _wave_recent_codes_menu(self, global_pos):
         """ Popup of recent codes to assign to the current wave selection (the 'Mark with
@@ -3013,6 +3031,12 @@ class DialogCodeAV(QtWidgets.QDialog):
                 any_visible_descendant = True
         return any_visible_descendant
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def update_dialog_codes_and_categories(self, tables: list[str]|None = None):
         """Refresh the local dialog after code/category changes and optionally notify other dialogs.
 
@@ -3028,8 +3052,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.highlight()
         self.get_coded_text_update_eventfilter_tooltips()
 
-        if self.app.project_events is not None:
-            self.app.project_events.emit_table_changes(tables, source=self)
+        self._emit_project_table_changes(tables)
 
     def _on_project_data_changed(self, tables, source):
         """Handle project change events from other dialogs.
@@ -3381,6 +3404,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             return
         Message(self.app, _("Screenshot imported"), file_path).exec()
         self.parent_textEdit.append(_("Screenshot imports: ") + image_name)
+        self._emit_project_table_changes(['source'])
 
     def eventFilter(self, object_, event):
         """ Using this event filter to identify treeWidgetItem drop events.
@@ -3602,6 +3626,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def extend_right(self, code_):
         """ Extend to right coded text. Shift right arrow """
@@ -3620,6 +3645,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def shrink_to_left(self, code_):
         """ Alt left arrow, shrinks coded text from the right end of the coded text. """
@@ -3638,6 +3664,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def shrink_to_right(self, code_):
         """ Alt right arrow shrinks coded text from the left end of the coded text. """
@@ -3656,6 +3683,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def increase_play_rate(self):
         """ Several increased rate options """
@@ -3722,10 +3750,12 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.load_segments()
         # Reverse mirror: also code the transcript text spanning this segment's times
-        self._create_text_code_from_av_segment(cid, self.segment['start_msecs'], self.segment['end_msecs'])
+        mirrored = self._create_text_code_from_av_segment(cid, self.segment['start_msecs'],
+                                                          self.segment['end_msecs'])
         self.clear_segment()
         self.app.delete_backup = False
         self.fill_code_counts_in_tree()
+        self._emit_project_table_changes(['code_av', 'code_text'] if mirrored else ['code_av'])
 
     def clear_segment(self):
         """ Called by assign_segment_to code. """
@@ -4117,6 +4147,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.get_coded_text_update_eventfilter_tooltips()
         self.load_segments()
         self.fill_code_counts_in_tree()
+        self._emit_project_table_changes(['code_av', 'code_text'])
 
     def is_annotated(self, position):
         """ Check if position is annotated to provide annotation menu option.
@@ -4171,6 +4202,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def coded_text_memo(self, position=None):
         """ Add or edit a memo for this coded text.
@@ -4216,6 +4248,7 @@ class DialogCodeAV(QtWidgets.QDialog):
                 i['memo'] = memo
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def play_text(self, avid):
         """ Play the audio/video for this coded text selection that is mapped to an a/v segment. """
@@ -4400,14 +4433,19 @@ class DialogCodeAV(QtWidgets.QDialog):
                                                                    coded['memo'], coded['date'], coded['important']))
             self.app.conn.commit()
             self.app.delete_backup = False
+            coded_written = True
         except Exception as e_:
             logger.debug(str(e_))
             print(e_)
+            coded_written = False
         # update coded, filter for tooltip
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
         # EXPERIMENTAL: mirror this text coding onto the wave via bracketing timestamps
-        self._create_av_segment_from_text_code(cid, coded['pos0'], coded['pos1'], coded['seltext'])
+        mirrored = self._create_av_segment_from_text_code(cid, coded['pos0'], coded['pos1'], coded['seltext'])
+        if coded_written or mirrored:
+            # One event for the whole mark, covering the wave mirror when it wrote
+            self._emit_project_table_changes(['code_text', 'code_av'] if mirrored else ['code_text'])
 
         # Update recent_codes
         tmp_code = next((item for item in self.codes if item['cid'] == cid), None)
@@ -4469,6 +4507,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.get_coded_text_update_eventfilter_tooltips()
         self.app.delete_backup = False
         self.fill_code_counts_in_tree()
+        self._emit_project_table_changes(['code_av', 'code_text'])
 
     def restore_unmarked_text_codes(self):
         """ Restore the last deleted code(s).
@@ -4524,6 +4563,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             self.load_segments()
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
+        self._emit_project_table_changes(['code_av', 'code_text'] if av_restored else ['code_text'])
 
     def unmark(self, location):
         """ Remove code marking by this coder from selected text in current file.
@@ -4573,6 +4613,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['code_av', 'code_text'] if av_removed else ['code_text'])
 
     def annotate(self, cursor_pos):
         """ Add view, or remove an annotation for selected text.
@@ -4624,6 +4665,7 @@ class DialogCodeAV(QtWidgets.QDialog):
                                             + f"{item['pos0']}-{item['pos1']}" + _(" for: ") +
                                             self.transcription[2])
                 self.get_coded_text_update_eventfilter_tooltips()
+                self._emit_project_table_changes(['annotation'])
             return
 
         # Edit existing annotation
@@ -4639,6 +4681,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             self.app.delete_backup = False
             self.annotations = self.app.get_annotations()
             self.get_coded_text_update_eventfilter_tooltips()
+            self._emit_project_table_changes(['annotation'])
             return
 
         # If blank delete the annotation
@@ -4649,6 +4692,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             self.annotations = self.app.get_annotations()
             self.parent_textEdit.append(_("Annotation removed from position ")
                                         + f"{item['pos0']}" + _(" for: ") + self.transcription[2])
+            self._emit_project_table_changes(['annotation'])
         self.get_coded_text_update_eventfilter_tooltips()
 
     # Segment menu. A hack to fix when pyinstaller Segment.contextMenu does not work.
@@ -4731,6 +4775,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.delete_backup = False
         self.load_segments()
         self.fill_code_counts_in_tree()
+        self._emit_project_table_changes(['code_av'])
 
     def change_segment_code(self, segment):
         """ Change this segment's code to another one chosen from a selection dialog,
@@ -4762,6 +4807,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.load_segments()
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
+        self._emit_project_table_changes(['code_av', 'code_text'])
 
     def set_segment_importance(self, segment):
         """ Set or unset importance to self.segment.
@@ -4781,6 +4827,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
         self.load_segments()
+        self._emit_project_table_changes(['code_av'])
 
     def edit_segment_memo(self, segment):
         """ View, edit or delete memo for this segment.
@@ -4800,6 +4847,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.load_segments()
+        self._emit_project_table_changes(['code_av'])
 
     def play_segment(self, segment):
         """ Play segment section. Stop at end of segment. """
@@ -4845,6 +4893,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.get_coded_text_update_eventfilter_tooltips()
         self.app.delete_backup = False
         self.load_segments()
+        self._emit_project_table_changes(['code_av', 'code_text'])
 
     def edit_segment_start(self, segment):
         """ Edit segment start time. """
@@ -4864,6 +4913,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.load_segments()
+        self._emit_project_table_changes(['code_av'])
 
     def edit_segment_end(self, segment):
         """ Edit segment end time """
@@ -4884,6 +4934,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.load_segments()
+        self._emit_project_table_changes(['code_av'])
 
     def on_segment_resized(self, segment, new_pos0, new_pos1):
         """ A coded band was resized by dragging an edge on the wave. Persist and reload. """
@@ -4899,6 +4950,7 @@ class DialogCodeAV(QtWidgets.QDialog):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.load_segments()
+        self._emit_project_table_changes(['code_av'])
 
     # --- handles experimental
     def display_handles_for_code(self, position):
@@ -5020,6 +5072,7 @@ class DialogCodeAV(QtWidgets.QDialog):
             cur.execute(sql, [code_item['pos0'], code_item['pos1'], seltext, code_item['ctid']])
             self.app.conn.commit()
             self.app.delete_backup = False
+            self._emit_project_table_changes(['code_text'])
         except sqlite3.IntegrityError:
             self.app.conn.rollback()
             # Revert in-memory positions to undo temporary highlight
@@ -5249,6 +5302,7 @@ class SegmentGraphicsItem(QtWidgets.QGraphicsLineItem):
         self.code_av_dialog.load_segments()
         self.app.delete_backup = False
         self.code_av_dialog.fill_code_counts_in_tree()
+        self.code_av_dialog._emit_project_table_changes(['code_av'])
 
     def replace_code(self):
         """ Change code via the selection dialog (code_text style). """
@@ -5326,6 +5380,7 @@ class SegmentGraphicsItem(QtWidgets.QGraphicsLineItem):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.code_av_dialog.get_coded_text_update_eventfilter_tooltips()
+        self.code_av_dialog._emit_project_table_changes(['code_av'])
         self.set_segment_tooltip()
 
     def link_segment_to_text(self):
@@ -5359,6 +5414,7 @@ class SegmentGraphicsItem(QtWidgets.QGraphicsLineItem):
                                                           seg['owner'], seg['memo'], seg['date'], seg['avid']))
             self.code_av_dialog.app.conn.commit()
             self.app.delete_backup = False
+            self.code_av_dialog._emit_project_table_changes(['code_text'])
         except Exception as e_:
             print(e_)
         self.code_av_dialog.text_for_segment = {'cid': None, 'fid': None, 'seltext': None, 'pos0': None, 'pos1': None,
@@ -5385,6 +5441,7 @@ class SegmentGraphicsItem(QtWidgets.QGraphicsLineItem):
         self.code_av_dialog.app.conn.commit()
         self.draw_segment()
         self.app.delete_backup = False
+        self.code_av_dialog._emit_project_table_changes(['code_av'])
 
     def edit_segment_end(self):
         """ Edit segment end time """
@@ -5405,6 +5462,7 @@ class SegmentGraphicsItem(QtWidgets.QGraphicsLineItem):
         self.code_av_dialog.app.conn.commit()
         self.draw_segment()
         self.app.delete_backup = False
+        self.code_av_dialog._emit_project_table_changes(['code_av'])
 
     def play_segment(self):
         """ Play segment section. Stop at end of segment. """
@@ -5449,6 +5507,7 @@ class SegmentGraphicsItem(QtWidgets.QGraphicsLineItem):
         self.code_av_dialog.app.conn.commit()
         self.code_av_dialog.get_coded_text_update_eventfilter_tooltips()
         self.app.delete_backup = False
+        self.code_av_dialog._emit_project_table_changes(['code_av', 'code_text'])
 
     def edit_memo(self):
         """ View, edit or delete memo for this segment.
@@ -5468,6 +5527,7 @@ class SegmentGraphicsItem(QtWidgets.QGraphicsLineItem):
         cur.execute(sql, values)
         self.code_av_dialog.app.conn.commit()
         self.app.delete_backup = False
+        self.code_av_dialog._emit_project_table_changes(['code_av'])
         self.set_segment_tooltip()
 
     def set_segment_tooltip(self):

--- a/src/qualcoder/code_color_scheme.py
+++ b/src/qualcoder/code_color_scheme.py
@@ -14,10 +14,10 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
-https://qualcoder-org.github.io
 https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -86,6 +86,12 @@ class DialogCodeColorScheme(QtWidgets.QDialog):
         self.ui.pushButton_undo.setIcon(qta.icon('mdi6.undo', options=[{'scale_factor': 1.3}]))
         self.ui.pushButton_undo.pressed.connect(self.undo_color_changes)
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def get_codes_and_categories(self):
         """ Called from init, delete category/code, event_filter """
 
@@ -103,6 +109,7 @@ class DialogCodeColorScheme(QtWidgets.QDialog):
         for c in self.original_code_colors:
             cur.execute(sql, [c['color'], c['cid']])
         self.app.conn.commit()
+        self._emit_project_table_changes(['code_name'])
         self.get_codes_and_categories()
         self.perspective_idx = 0
         self.fill_tree()
@@ -135,6 +142,7 @@ class DialogCodeColorScheme(QtWidgets.QDialog):
                     ci.setForeground(0, QBrush(QtGui.QColor(color)))
                     cur.execute(sql, [color_list[i], int(ci.text(1)[4:])])
         self.app.conn.commit()
+        self._emit_project_table_changes(['code_name'])
         self.perspective_idx = 4
         self.change_perspective()
         self.ui.treeWidget.clearSelection()

--- a/src/qualcoder/code_in_all_files.py
+++ b/src/qualcoder/code_in_all_files.py
@@ -97,6 +97,15 @@ class DialogCodeInAllFiles(QtWidgets.QDialog):
         self.te.cursorPositionChanged.connect(self.show_context_of_clicked_heading)
         self.exec()
 
+    # Coded segment type -> database table, for project change notifications
+    CODED_TABLES = {'text': ['code_text'], 'image': ['code_image'], 'av': ['code_av']}
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def get_coded_segments_all_files(self):
         """ Get coded segments by file for this code. """
 
@@ -422,6 +431,7 @@ class DialogCodeInAllFiles(QtWidgets.QDialog):
                 self.app.conn.commit()
             self.get_coded_segments_all_files()
             self.app.delete_backup = False
+            self._emit_project_table_changes(self.CODED_TABLES.get(item['type'], []))
             return
         if action == action_memo:
             self.edit_memo(item)
@@ -446,6 +456,7 @@ class DialogCodeInAllFiles(QtWidgets.QDialog):
         self.app.conn.commit()
         self.get_coded_segments_all_files()
         self.app.delete_backup = False
+        self._emit_project_table_changes(self.CODED_TABLES.get(item['type'], []))
 
     def remove_important_flag(self, item:dict[str, Any]):
 
@@ -459,6 +470,7 @@ class DialogCodeInAllFiles(QtWidgets.QDialog):
         self.app.conn.commit()
         self.get_coded_segments_all_files()
         self.app.delete_backup = False
+        self._emit_project_table_changes(self.CODED_TABLES.get(item['type'], []))
 
     def edit_memo(self, item:dict[str, Any]):
         """ Edit item memo.
@@ -481,6 +493,7 @@ class DialogCodeInAllFiles(QtWidgets.QDialog):
         self.app.conn.commit()
         self.get_coded_segments_all_files()
         self.app.delete_backup = False
+        self._emit_project_table_changes(self.CODED_TABLES.get(item['type'], []))
 
     def export_odt(self):
         """ Export all contents to ODT file. """
@@ -546,6 +559,7 @@ class DialogCodeInAllFiles(QtWidgets.QDialog):
                     self.app.conn.commit()
                 except sqlite3.IntegrityError:
                     pass
+        self._emit_project_table_changes(self.CODED_TABLES.get(item['type'], []))
 
 
 class DialogCodedIds(QtWidgets.QDialog):

--- a/src/qualcoder/code_organiser.py
+++ b/src/qualcoder/code_organiser.py
@@ -14,9 +14,10 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 import csv  # codebook import
@@ -138,6 +139,12 @@ class CodeOrganiser(QDialog):
                   "Potential for unexpected errors could occur.\n"
                   "THERE IS NO UNDO OPTION AFTER APPLYING CHANGES WITH THE APPLY BUTTON.")
         Message(self.app, "Code organiser", text_).exec()
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def create_category(self):
         """ Create a new category, via push button. """
@@ -1705,7 +1712,7 @@ class CodeOrganiser(QDialog):
             tables = ['code_cat', 'code_name']
             if code_merges_present or code_deletes_present:
                 tables += ['code_text', 'code_image', 'code_av']
-            self.app.project_events.emit_table_changes(tables, source=self)
+            self._emit_project_table_changes(tables)
 
         # Wrap up
         self.app.delete_backup = False

--- a/src/qualcoder/code_pdf.py
+++ b/src/qualcoder/code_pdf.py
@@ -14,8 +14,10 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
+https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -2343,6 +2345,12 @@ class DialogCodePdf(QtWidgets.QWidget):
         if getattr(self.app, "project_events", None) is not None:
             self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def update_sizes(self):
         """
         Saves the splitter sizes to settings when the user drags them (parity with
@@ -2643,8 +2651,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         cur = self.app.conn.cursor()
         cur.execute("update source set memo=? where id=?", (memo, file_['id']))
         self.app.conn.commit()
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['source'], source=self)
+        self._emit_project_table_changes(['source'])
         self.app.delete_backup = False
         file_['tooltip'] = self._file_tooltip(file_)
         items = self.ui.listWidget.findItems(file_['name'], Qt.MatchFlag.MatchExactly)
@@ -3281,8 +3288,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                     (coded['cid'], coded['fid'], coded['seltext'], coded['pos0'], coded['pos1'],
                      coded['owner'], coded['memo'], coded['date'], coded['important']))
         self.app.conn.commit()
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['code_text'], source=self)
+        self._emit_project_table_changes(['code_text'])
         self.app.delete_backup = False
         self._update_recent_codes(cid)
         self.get_coded_text_update_eventfilter_tooltips()
@@ -3313,8 +3319,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                      item['cid'], item['memo'], item['date'], item['owner'],
                      item['important'], item['pdf_page']))
         self.app.conn.commit()
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['code_image'], source=self)
+        self._emit_project_table_changes(['code_image'])
         self.app.delete_backup = False
         self._update_recent_codes(cid)
         self.get_coded_text_update_eventfilter_tooltips()
@@ -3415,8 +3420,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         # Refresh and notify
         self.annotations = self.app.get_annotations()
         self.get_coded_text_update_eventfilter_tooltips()
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['annotation'], source=self)
+        self._emit_project_table_changes(['annotation'])
 
     def _edit_annotation(self, note):
         """        Edits or deletes an existing annotation with DialogMemo (empty memo =
@@ -3443,8 +3447,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.app.delete_backup = False
         self.annotations = self.app.get_annotations()
         self.get_coded_text_update_eventfilter_tooltips()
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['annotation'], source=self)
+        self._emit_project_table_changes(['annotation'])
 
     def _delete_annotation(self, note):
         """        Deletes an existing annotation without going through the dialog.
@@ -3458,8 +3461,7 @@ class DialogCodePdf(QtWidgets.QWidget):
         self.app.delete_backup = False
         self.annotations = self.app.get_annotations()
         self.get_coded_text_update_eventfilter_tooltips()
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['annotation'], source=self)
+        self._emit_project_table_changes(['annotation'])
 
     def coded_memo(self, texts_here=None, areas_here=None):
         """        Views or edits the memo of the coding(s) under the selection (text or area) with
@@ -3495,8 +3497,8 @@ class DialogCodePdf(QtWidgets.QWidget):
                     changed.add('code_image')
         self.app.conn.commit()
         self.get_coded_text_update_eventfilter_tooltips()
-        if changed and getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(sorted(changed), source=self)
+        if changed:
+            self._emit_project_table_changes(sorted(changed))
 
     def _update_recent_codes_menu(self):
         """        Shows a popup menu with the recently used codes and marks the selection with the chosen
@@ -3621,8 +3623,8 @@ class DialogCodePdf(QtWidgets.QWidget):
                 cur.execute("delete from code_image where imid=?", [entry['ref']['imid']])
                 changed.add('code_image')
         self.app.conn.commit()
-        if changed and getattr(self.app, "project_events", None):
-            self.app.project_events.emit_table_changes(sorted(changed), source=self)
+        if changed:
+            self._emit_project_table_changes(sorted(changed))
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
 
@@ -3651,8 +3653,8 @@ class DialogCodePdf(QtWidgets.QWidget):
                          item['owner'], item['important'], item['pdf_page']))
             changed.add('code_image')
         self.app.conn.commit()
-        if changed and getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(sorted(changed), source=self)
+        if changed:
+            self._emit_project_table_changes(sorted(changed))
         self.undo_deleted_codes = []
         self.undo_deleted_areas = []
         self.get_coded_text_update_eventfilter_tooltips()
@@ -3681,8 +3683,8 @@ class DialogCodePdf(QtWidgets.QWidget):
                 changed.add('code_image')
         self.app.conn.commit()
         self.get_coded_text_update_eventfilter_tooltips()
-        if changed and getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(sorted(changed), source=self)
+        if changed:
+            self._emit_project_table_changes(sorted(changed))
 
     def change_code_for_segment(self, text_item=None, area_item=None):
         """        Changes the code (cid) of ONE already-coded segment: text (by ctid) or image area
@@ -3731,8 +3733,8 @@ class DialogCodePdf(QtWidgets.QWidget):
                 return
             changed = 'code_text'
         self.app.delete_backup = False
-        if changed and getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes([changed], source=self)
+        if changed:
+            self._emit_project_table_changes([changed])
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
 
@@ -3793,8 +3795,7 @@ class DialogCodePdf(QtWidgets.QWidget):
     def _after_autocode_refresh(self):
         """Notify other dialogs and refresh this view after autocoding changes."""
 
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['code_text'], source=self)
+        self._emit_project_table_changes(['code_text'])
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
         self.update_file_tooltip()
@@ -5139,8 +5140,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             self.get_codes_and_categories()
             self.code_tree.fill_tree()
             self.get_coded_text_update_eventfilter_tooltips()
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(tables, source=self)
+        self._emit_project_table_changes(tables)
 
     def _on_project_data_changed(self, tables, source):
         """        Handles change events emitted by other dialogs.
@@ -6153,8 +6153,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             cur.execute("update code_text set pos0=?, pos1=?, seltext=? where ctid=?",
                         [code_item['pos0'], code_item['pos1'], seltext, code_item['ctid']])
             self.app.conn.commit()
-            if getattr(self.app, "project_events", None) is not None:
-                self.app.project_events.emit_table_changes(['code_text'], source=self)
+            self._emit_project_table_changes(['code_text'])
             self.app.delete_backup = False
         except sqlite3.IntegrityError:
             self.app.conn.rollback()
@@ -6244,8 +6243,7 @@ class DialogCodePdf(QtWidgets.QWidget):
             cur.execute("update code_image set x1=?, y1=?, width=?, height=? where imid=?",
                         (x, y, w, h, area['imid']))
             self.app.conn.commit()
-            if getattr(self.app, "project_events", None) is not None:
-                self.app.project_events.emit_table_changes(['code_image'], source=self)
+            self._emit_project_table_changes(['code_image'])
             self.app.delete_backup = False
         except sqlite3.IntegrityError:
             self.app.conn.rollback()
@@ -6447,9 +6445,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                     "warning").exec()
             return
         self.app.delete_backup = False
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(
-                ['source', 'code_text', 'annotation', 'case_text'], source=self)
+        self._emit_project_table_changes(['source', 'code_text', 'annotation', 'case_text'])
         # Report
         msg = _("File restructured to the new method.") + "\n"
         msg += _("Codings:") + f" {len(ct_rows)}, " + _("annotations:") + f" {len(an_rows)}, "
@@ -6528,8 +6524,7 @@ class DialogCodePdf(QtWidgets.QWidget):
                     Message(self.app, _("Journal"), _("Could not create the journal entry."), "warning").exec()
                     return
         self.app.delete_backup = False
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['journal'], source=self)
+        self._emit_project_table_changes(['journal'])
         self.parent_textEdit.append(_("Restructure report saved to journal: ") + intento)
         Message(self.app, _("Journal"), _("Report saved to journal:") + f"\n{intento}").exec()
 

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -16,8 +16,8 @@ If not, see <https://www.gnu.org/licenses/>.
 
 Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
-https://qualcoder-org.github.io
 https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -913,6 +913,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.fill_code_counts_in_tree()
         self.update_file_tooltip()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['code_text'])
 
     def _margin_coded_text_memo_ctid(self, code):  # <- L
         """ Add/edit memo for the exact coded segment (by ctid) clicked. """
@@ -934,6 +935,7 @@ class DialogCodeText(QtWidgets.QWidget):
         text_item['memo'] = memo
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def _margin_change_code_ctid(self, code):  # <- L
         """ Change the exact coded segment (by ctid) clicked to another code. """
@@ -952,13 +954,17 @@ class DialogCodeText(QtWidgets.QWidget):
         if not replacement_code:
             return
         cur = self.app.conn.cursor()
+        changed = False
         try:
             cur.execute("update code_text set cid=? where ctid=?", [replacement_code['cid'], code['ctid']])
             self.app.conn.commit()
+            changed = True
         except sqlite3.IntegrityError:
             pass
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        if changed:
+            self._emit_project_table_changes(['code_text'])
 
     def _margin_annotate_ctid(self, code):  # <- L
         """ Add/edit/remove an annotation over the EXACT range (pos0-pos1) of
@@ -1002,6 +1008,7 @@ class DialogCodeText(QtWidgets.QWidget):
                                             + str(item['pos0']) + "-" + str(item['pos1']) + _(" for: ")
                                             + self.file_['name'])
                 self.get_coded_text_update_eventfilter_tooltips()
+                self._emit_project_table_changes(['annotation'])
             return
 
         # Edit existing annotation
@@ -1017,6 +1024,7 @@ class DialogCodeText(QtWidgets.QWidget):
             self.app.delete_backup = False
             self.annotations = self.app.get_annotations()
             self.get_coded_text_update_eventfilter_tooltips()
+            self._emit_project_table_changes(['annotation'])
             return
 
         # Blank memo -> delete the annotation
@@ -1028,6 +1036,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.parent_textEdit.append(_("Annotation removed from position ")
                                     + str(item['pos0']) + _(" for: ") + self.file_['name'])
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['annotation'])
 
     def _margin_resize_ctid(self, code):
         """ Show resize handles bound to the EXACT coded segment (by ctid)
@@ -1765,6 +1774,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.app.delete_backup = False
         msg = _("All codes by ") + self.app.settings['codername'] + _(" deleted from ") + self.file_['name']
         self.parent_textEdit.append(msg)
+        self._emit_project_table_changes(['code_text'])
 
     # Search for text methods
     def search_for_text(self):
@@ -2280,13 +2290,17 @@ class DialogCodeText(QtWidgets.QWidget):
             return
         cur = self.app.conn.cursor()
         sql = "update code_text set cid=? where ctid=?"
+        changed = False
         try:
             cur.execute(sql, [replacement_code['cid'], text_item['ctid']])
             self.app.conn.commit()
+            changed = True
         except sqlite3.IntegrityError:
             pass
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        if changed:
+            self._emit_project_table_changes(['code_text'])
 
     def recursive_set_current_item(self, item, text_):
         """ Set matching item to be the current selected item.
@@ -2362,6 +2376,7 @@ class DialogCodeText(QtWidgets.QWidget):
             self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def active_file_memo(self):
         """ Send active file to file_memo method.
@@ -2397,6 +2412,7 @@ class DialogCodeText(QtWidgets.QWidget):
             new_tt = f"{tt[:memo_pos]} {_('Memo:')} {file_['memo']}"
             items[0].setToolTip(new_tt)
         self.app.delete_backup = False
+        self._emit_project_table_changes(['source'])
 
     def coded_text_memo(self, position:None|int=None):
         """ Add or edit a memo for this coded text.
@@ -2447,6 +2463,7 @@ class DialogCodeText(QtWidgets.QWidget):
                 i['memo'] = memo
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def shift_code_positions(self, position: int):
         """ After a text file is edited - text added or deleted, code positions may be inaccurate.
@@ -2503,6 +2520,7 @@ class DialogCodeText(QtWidgets.QWidget):
                 self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def copy_selected_text_to_clipboard(self, metadata: bool = False):
         """ Copy text to clipboard for external use.
@@ -3825,6 +3843,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def extend_right(self, code_):
         """ Shift right arrow.
@@ -3847,6 +3866,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def shrink_to_left(self, code_):
         """ Alt left arrow, shrinks code from the right end of the code.
@@ -3868,6 +3888,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def shrink_to_right(self, code_):
         """ Alt right arrow shrinks code from the left end of the code.
@@ -3889,6 +3910,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.app.conn.commit()
         self.app.delete_backup = False
         self.get_coded_text_update_eventfilter_tooltips()
+        self._emit_project_table_changes(['code_text'])
 
     def show_selected_code_in_text_next(self):
         """ Highlight only the selected code in the text. Move to next instance in text
@@ -4085,6 +4107,12 @@ class DialogCodeText(QtWidgets.QWidget):
                 item['name'] = new_name
                 break
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def update_dialog_codes_and_categories(self, tables: list[str]|None = None):
         """Refresh the local dialog after code/category changes and optionally notify other dialogs.
 
@@ -4099,8 +4127,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.highlight()
         self.get_coded_text_update_eventfilter_tooltips()
 
-        if self.app.project_events is not None:
-            self.app.project_events.emit_table_changes(tables, source=self)
+        self._emit_project_table_changes(tables)
 
     def _on_project_data_changed(self, tables, source):
         """Handle project change events from other dialogs.
@@ -5032,6 +5059,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.app.conn.commit()
 
         self.update_file_tooltip()  # Number of codes applied
+        self._emit_project_table_changes(['code_text'])
 
     def undo_last_unmarked_code(self):
         """ Restore the last deleted code(s).
@@ -5053,6 +5081,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.undo_deleted_codes = []
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
+        self._emit_project_table_changes(['code_text'])
 
     def unmark(self, location):
         """ Remove code marking by all visible coders from selected text in current file.
@@ -5095,6 +5124,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.fill_code_counts_in_tree()
         self.update_file_tooltip()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['code_text'])
 
     def annotate(self, cursor_pos=None):
         """ Add view, or remove an annotation for selected text.
@@ -5164,6 +5194,7 @@ class DialogCodeText(QtWidgets.QWidget):
                                             + str(item['pos0']) + "-" + str(item['pos1']) + _(" for: ") + self.file_[
                                                 'name'])
                 self.get_coded_text_update_eventfilter_tooltips()
+                self._emit_project_table_changes(['annotation'])
             return
 
         # Edit existing annotation
@@ -5180,6 +5211,7 @@ class DialogCodeText(QtWidgets.QWidget):
 
             self.annotations = self.app.get_annotations()
             self.get_coded_text_update_eventfilter_tooltips()
+            self._emit_project_table_changes(['annotation'])
             return
 
         # If blank delete the annotation
@@ -5191,6 +5223,7 @@ class DialogCodeText(QtWidgets.QWidget):
             self.annotations = self.app.get_annotations()
             self.parent_textEdit.append(_("Annotation removed from position ")
                                         + str(item['pos0']) + _(" for: ") + self.file_['name'])
+            self._emit_project_table_changes(['annotation'])
         self.get_coded_text_update_eventfilter_tooltips()
 
     def button_autocode_surround(self):
@@ -5304,6 +5337,8 @@ class DialogCodeText(QtWidgets.QWidget):
         self.parent_textEdit.append(msg)
         Message(self.app, "Autocode surround", msg).exec()
         self.app.delete_backup = False
+        if len(undo_list) > 0:
+            self._emit_project_table_changes(['code_text'])
 
     def undo_autocoding(self):
         """ Present a list of choices for the undo operation.
@@ -5485,6 +5520,8 @@ class DialogCodeText(QtWidgets.QWidget):
         # Update tooltip filter and code tree code counts
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
+        if len(undo_list) > 0:
+            self._emit_project_table_changes(['code_text'])
 
     def auto_code(self):
         """ Autocode text in one file or all files with currently selected code.
@@ -5660,6 +5697,8 @@ class DialogCodeText(QtWidgets.QWidget):
         self.parent_textEdit.append(msg)
         self.get_coded_text_update_eventfilter_tooltips()
         self.fill_code_counts_in_tree()
+        if len(undo_list) > 0:
+            self._emit_project_table_changes(['code_text'])
 
     # Methods for Editing mode
     def undo_edited_text(self):
@@ -5685,6 +5724,9 @@ class DialogCodeText(QtWidgets.QWidget):
         for ca in self.edit_original_case_assignment:
             cursor.execute("update case_text set pos0=?, pos1=? where caseid=?",
                            [ca[1], ca[2], ca[0]])
+        self.app.conn.commit()
+        self.app.delete_backup = False
+        self._emit_project_table_changes(['source', 'code_text', 'annotation', 'case_text'])
         self.clear_edit_variables()
         self.ui.plainTextEdit.installEventFilter(self.eventFilterTT)
         self.annotations = self.app.get_annotations()
@@ -5822,6 +5864,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ui.treeWidget.setEnabled(True)
         self.ui.widget_left.show()
         self.prev_text = ""
+        text_edited = self.edit_mode_has_changed
         if self.edit_mode_has_changed:
             self.text = self.ui.plainTextEdit.toPlainText()
             self.file_['fulltext'] = self.text
@@ -5862,10 +5905,9 @@ class DialogCodeText(QtWidgets.QWidget):
             self.coding_margin.update()
         # Notify the fulltext edit to the bus: an open DialogCodePdf with this file
         # must reload and re-verify the page mapping; without this it keeps stale
-        # text and positions in memory.
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(
-                ['source', 'code_text', 'annotation', 'case_text'], source=self)
+        # text and positions in memory. Only when something was actually edited.
+        if text_edited:
+            self._emit_project_table_changes(['source', 'code_text', 'annotation', 'case_text'])
 
     def edit_mode_find(self, direction:str="next"):
         """  Move forward or backward through the edit document.
@@ -6915,6 +6957,7 @@ class DialogCodeText(QtWidgets.QWidget):
             cur.execute(sql, [code_item['pos0'], code_item['pos1'], seltext, code_item['ctid']])
             self.app.conn.commit()
             self.app.delete_backup = False
+            self._emit_project_table_changes(['code_text'])
         except sqlite3.IntegrityError:
             self.app.conn.rollback()
             # Revert in-memory positions to undo temporary highlight

--- a/src/qualcoder/coder_names.py
+++ b/src/qualcoder/coder_names.py
@@ -14,9 +14,10 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -93,6 +94,12 @@ class DialogCoderNames(QtWidgets.QDialog):
         self.ui.buttonBox.accepted.connect(self.ok)
         self.ui.buttonBox.rejected.connect(self.cancel) 
         self.ui.buttonBox.helpRequested.connect(self.help)
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def read_coder_names(self):
         """
@@ -405,6 +412,10 @@ class DialogCoderNames(QtWidgets.QDialog):
         
         if self.do_commit and self.app.conn is not None:
             self.app.conn.commit()  # this writes all the changes finally to the database
+            if self.coder_names_changed:
+                # Renaming or merging a coder rewrites owner across the coded tables
+                self._emit_project_table_changes(
+                    ['coder_names', 'code_text', 'code_image', 'code_av', 'annotation'])
 
     def cancel(self):
         if self.app.conn is not None:

--- a/src/qualcoder/edit_textfile.py
+++ b/src/qualcoder/edit_textfile.py
@@ -605,11 +605,18 @@ class DialogEditTextFile(QtWidgets.QDialog):
             print(e_)
             self.app.conn.rollback()
             raise
+        self._emit_project_table_changes(['source', 'code_text', 'annotation', 'case_text'])
         # update doc in vectorstore
         if self.has_changed:
             if self.app.settings['ai_enable'] == 'True':
                 self.app.ai.sources_vectorstore.import_document(self.fid, self.name, self.text)
         super(DialogEditTextFile, self).accept()
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def update_casetext(self):
         """ Update linked case text positions. """

--- a/src/qualcoder/helpers.py
+++ b/src/qualcoder/helpers.py
@@ -548,6 +548,12 @@ class DialogCodeInText(QtWidgets.QDialog):
             tt = _("Resize coding\nAlt+Left Arrow, Alt+Right Arrow\nShift+LeftArrow, Shift+Right Arrow")
             self.te.setToolTip(tt)
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def draw_initial_coded_text(self):
         """ Can be called multiple times via keystrokes, so  initally set formatting to none. """
 
@@ -629,8 +635,7 @@ class DialogCodeInText(QtWidgets.QDialog):
         Notify the event bus that this coding was resized.
         """
 
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['code_text'], source=self)
+        self._emit_project_table_changes(['code_text'])
 
     def extend_left(self):
         """ Shift left arrow. """
@@ -1186,8 +1191,14 @@ class ImportPlainTextCodes:
             except sqlite3.IntegrityError:
                 self.text_edit.append(_("Duplicate code not imported: ") + code_name)
         # One event for the whole import, not one per row
-        if imported_tables and getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(sorted(imported_tables), source=None)
+        if imported_tables:
+            self._emit_project_table_changes(sorted(imported_tables))
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
 
 
 class MarkdownHighlighter(QtGui.QSyntaxHighlighter):

--- a/src/qualcoder/import_survey.py
+++ b/src/qualcoder/import_survey.py
@@ -14,9 +14,10 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -347,6 +348,12 @@ class DialogImportSurvey(QtWidgets.QDialog):
         self.insert_data()
         super(DialogImportSurvey, self).accept()
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def insert_data(self):
         """ Insert case, attributes, attribute values and qualitative text. """
 
@@ -532,6 +539,9 @@ class DialogImportSurvey(QtWidgets.QDialog):
 
         logger.info(_("Survey imported"))
         self.parent_textEdit.append(_("Survey imported."))
+        # One event for the whole survey, not one per row
+        self._emit_project_table_changes(['source', 'cases', 'case_text', 'attribute',
+                                          'attribute_type', 'code_name', 'code_text'])
         Message(self.app, _("Survey imported"), _("Survey imported")).exec()
         self.app.delete_backup = False
 

--- a/src/qualcoder/journals.py
+++ b/src/qualcoder/journals.py
@@ -131,6 +131,12 @@ class DialogJournals(QtWidgets.QDialog):
         self.ui.textEdit.hide()
         self.attribute_names = []  # For AddAttribute dialog
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def load_journals(self, order="name asc"):
         """ Load journals.
         Order by Name asc/desc date asc/desc.
@@ -239,6 +245,7 @@ class DialogJournals(QtWidgets.QDialog):
         self.load_journals()
         self.fill_table()
         self.parent_text_edit.append(f'{_("Attribute added to journals:")} {name}, {_("type")}: {value_type}')
+        self._emit_project_table_changes(['attribute_type', 'attribute'])
 
     def check_attribute_placeholders(self):
         """ Journals can be added after attributes are in the project.
@@ -246,6 +253,7 @@ class DialogJournals(QtWidgets.QDialog):
          Also,if a journal is deleted, check and remove any isolated attribute values. """
 
         cur = self.app.conn.cursor()
+        changed = False
         sql = "select jid from journal "
         cur.execute(sql)
         journal_jids_res = cur.fetchall()
@@ -262,6 +270,7 @@ class DialogJournals(QtWidgets.QDialog):
                     placeholders = [attribute[0], jid[0], datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                                     self.app.settings['codername']]
                     cur.execute(insert_sql, placeholders)
+                    changed = True
         self.app.conn.commit()
 
         # Check and delete attribute values where journal has been deleted
@@ -272,6 +281,9 @@ class DialogJournals(QtWidgets.QDialog):
         for r in res:
             cur.execute("delete from attribute where attr_type='journal' and id=?", [r[0], ])
             self.app.conn.commit()
+            changed = True
+        if changed:
+            self._emit_project_table_changes(['attribute'])
 
     def help(self):
         """ Open help for transcribe section in browser. """
@@ -627,6 +639,7 @@ class DialogJournals(QtWidgets.QDialog):
                     (self.journals[self.ui.tableWidget.currentRow()]['jentry'], now_date, self.jid))
         self.app.conn.commit()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['journal'])
 
     def text_changed(self):
         """ Used in combination with timer to update database entry. """
@@ -659,6 +672,7 @@ class DialogJournals(QtWidgets.QDialog):
         cur.execute("insert into journal(name,jentry,owner,date) values(?,?,?,?)",
                     (journal['name'], journal['jentry'], journal['owner'], journal['date']))
         self.app.conn.commit()
+        self._emit_project_table_changes(['journal'])
         cur.execute("select last_insert_rowid()")
         jid = cur.fetchone()[0]
         journal['jid'] = jid
@@ -721,6 +735,7 @@ class DialogJournals(QtWidgets.QDialog):
                     self.journals.remove(item)
             self.fill_table()
             self.parent_text_edit.append(_("Journal deleted: ") + journal_name)
+            self._emit_project_table_changes(['journal'])
         self.check_attribute_placeholders()
         self.app.delete_backup = False
 
@@ -784,6 +799,7 @@ class DialogJournals(QtWidgets.QDialog):
                     _("Journal name changed from: ") + f"{self.journals[row]['name']} -> {new_name}")
                 self.journals[row]['name'] = new_name
                 self.ui.label_jname.setText(_("Journal: ") + self.journals[row]['name'])
+                self._emit_project_table_changes(['journal'])
             else:  # Put the original text in the cell
                 self.ui.tableWidget.item(row, y).setText(self.journals[row]['name'])
 
@@ -811,6 +827,7 @@ class DialogJournals(QtWidgets.QDialog):
             cur.execute("update attribute set value=? where id=? and name=? and attr_type='journal'",
                         (value, self.journals[row]['jid'], attribute_name))
             self.app.conn.commit()
+            self._emit_project_table_changes(['attribute'])
 
             # Update self.journals[attributes]
             # Add list of attribute values to journals, order matches header columns
@@ -993,6 +1010,7 @@ class DialogJournals(QtWidgets.QDialog):
             except Exception as e:
                 logger.warning(_("Could not insert attribute: "), file_attr_name, str(e))
         self.app.conn.commit()
+        self._emit_project_table_changes(['source', 'attribute_type', 'attribute'])
 
         if self.app.settings['ai_enable'] == 'True' and getattr(self.app, 'ai', None) is not None:
             self.app.ai.sources_vectorstore.import_document(new_source_id, source_name, journal_text)

--- a/src/qualcoder/manage_files.py
+++ b/src/qualcoder/manage_files.py
@@ -14,7 +14,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
 https://qualcoder-org.github.io
@@ -1298,6 +1298,7 @@ class DialogManageFiles(QtWidgets.QDialog):
             self.load_file_data()
             self.app.delete_backup = False
             self.update_files_in_dialogs()
+            self._emit_project_table_changes(['source'])
 
     def extract_pdf_text_copy(self, row:int):
         """ Creates a new TEXT source with a copy of the PDF's fulltext (the one already
@@ -1351,6 +1352,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.fill_table()
         self.app.delete_backup = False
         self.update_files_in_dialogs()
+        self._emit_project_table_changes(['source', 'attribute'])
 
     def pdf_to_images(self, mediapath:str):
         """ Turn pdf pages into an image for each page.
@@ -1363,6 +1365,7 @@ class DialogManageFiles(QtWidgets.QDialog):
 
         filepath = ""
         filename = ""
+        pages_imported = 0
         if mediapath[:6] == '/docs/':
             filepath = Path(self.app.project_path) / "documents" / mediapath[6:]
             filename = mediapath[6:]
@@ -1399,7 +1402,9 @@ class DialogManageFiles(QtWidgets.QDialog):
                     # Other methods 'might' look for the forward slash. CC - ?
                     destination = Path(self.app.project_path) / "images" / image_filename
                     pymypdf_pixmap.save(destination)
-                    self.load_media_reference(f"/images/{image_filename}")
+                    # Silenced per page: one event after the whole page range
+                    self.load_media_reference(f"/images/{image_filename}", notify=False)
+                    pages_imported += 1
                     self.parent_text_edit.append(_("Image loaded from pdf: ") + image_filename)
             finally:
                 pymu_pdf.close()
@@ -1412,6 +1417,9 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.fill_table()
         self.app.delete_backup = False
         self.update_files_in_dialogs()
+        if pages_imported > 0:
+            # One event for the whole page range, not one per page
+            self._emit_project_table_changes(['source', 'attribute'])
 
     def view_original_text_file(self, mediapath: str):
         """ View original text file.
@@ -1470,6 +1478,7 @@ class DialogManageFiles(QtWidgets.QDialog):
                 cases_text = self.get_cases_by_filename(self.ui.tableWidget.item(row, self.NAME_COLUMN).text())
                 self.ui.tableWidget.item(row, self.CASE_COLUMN).setText(cases_text)
                 self.source[row]['case'] = cases_text
+        self._emit_project_table_changes(['case_text'])
         if self.file_filter_active():
             self.apply_file_filter()
 
@@ -1500,6 +1509,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.load_file_data()
         self.app.delete_backup = False
         self.update_files_in_dialogs()
+        self._emit_project_table_changes(['source'])
         # update doc in vectorstore
         id_ = int(self.ui.tableWidget.item(row, self.ID_COLUMN).text())
         if self.app.settings['ai_enable'] == 'True':
@@ -1537,6 +1547,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         if self.app.settings['ai_enable'] == 'True':
             self.app.ai.sources_vectorstore.update_vectorstore()
         self.files_renamed = [x for x in self.files_renamed if not (selection['fid'] == x.get('fid'))]
+        self._emit_project_table_changes(['source'])
         if len(self.files_renamed) == 0:
             self.ui.pushButton_undo.setEnabled(False)
 
@@ -1585,6 +1596,7 @@ class DialogManageFiles(QtWidgets.QDialog):
             entry = {'old_name': existing_name, 'name': new_name, 'fid': fid}
             self.files_renamed.append(entry)
         self.parent_text_edit.append(msg + err_msg)
+        self._emit_project_table_changes(['source'])
         # Updating vectorstore
         if self.app.settings['ai_enable'] == 'True':
             self.app.ai.sources_vectorstore.update_vectorstore()
@@ -1677,6 +1689,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.update_files_in_dialogs()
         self.load_file_data()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['source'])
 
     def button_import_linked_file(self):
         """ User presses button to import a linked file into the project folder.
@@ -1733,6 +1746,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.update_files_in_dialogs()
         self.load_file_data()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['source'])
 
     def mark_speakers(self):
         """ Mark the speakers in text files.
@@ -1809,6 +1823,8 @@ class DialogManageFiles(QtWidgets.QDialog):
         for r in res:
             cur.execute("delete from attribute where attr_type='file' and id=?", [r[0], ])
             self.app.conn.commit()
+        # No event here: the callers that reach this on a user action (delete,
+        # delete_button_multiple_files) already include 'attribute' in their payload.
 
     def export_attributes(self):
         """ Export attributes from table to an Excel file. """
@@ -1953,6 +1969,8 @@ class DialogManageFiles(QtWidgets.QDialog):
                 self.app.conn.commit()
                 self.parent_text_edit.append(_("Auto-renamed invalid file: ") + f"'{s['name']}' -> {new_name}")
                 s['name'] = new_name
+        # No event here: this runs on every refresh and sort, including refreshes
+        # triggered by the bus itself. The user actions that write source emit.
         self.header_labels = [_("Name"), _("Memo"), _("Date"), _("Id"), _("Case")]
         # Attributes
         sql = "select name from attribute_type where caseOrFile='file' order by upper(name)"
@@ -2186,6 +2204,7 @@ class DialogManageFiles(QtWidgets.QDialog):
             # Need to dynamically get the memo text in case it has been changed in a coding dialog
             cur.execute('select memo from source where id=?', [self.source[x]['id']])
             self.source[x]['memo'] = cur.fetchone()[0]
+            previous_memo = self.source[x]['memo']
             if name[-5:] == ".jpeg" or name[-4:] in ('.jpg', '.png', '.gif'):
                 ui = DialogMemo(self.app, _("Memo for file ") + self.source[x]['name'],
                                 self.source[x]['memo'], entity_type="file", entity_id=self.source[x]['id'])
@@ -2201,6 +2220,9 @@ class DialogManageFiles(QtWidgets.QDialog):
                 cur = self.app.conn.cursor()
                 cur.execute('update source set memo=? where id=?', (ui.memo, self.source[x]['id']))
                 self.app.conn.commit()
+            if self.source[x]['memo'] != previous_memo:
+                # Opening a memo to read it must not wake up the other dialogs
+                self._emit_project_table_changes(['source'])
             if self.source[x]['memo'] == "":
                 self.ui.tableWidget.setItem(x, self.MEMO_COLUMN, QtWidgets.QTableWidgetItem())
             else:
@@ -2295,7 +2317,7 @@ class DialogManageFiles(QtWidgets.QDialog):
                 self.extract_pdf_text_copy(x)
             return
         ui = DialogEditTextFile(self.app, self.source[x]['id'])
-        result = ui.exec()
+        ui.exec()
         # Get fulltext if changed (for metadata)
         cur = self.app.conn.cursor()
         cur.execute("select fulltext from source where id=?", [self.source[x]['id']])
@@ -2304,12 +2326,9 @@ class DialogManageFiles(QtWidgets.QDialog):
         if res is not None:
             fulltext = res[0]
         self.source[x]['fulltext'] = fulltext
-        # The editor saved changes: notify the bus so open coding dialogs
-        # (code_text, code_pdf) reload and do not keep stale positions.
-        if result == QtWidgets.QDialog.DialogCode.Accepted and \
-                getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(
-                ['source', 'code_text', 'annotation', 'case_text'], source=self)
+        # DialogEditTextFile.accept() notifies the bus itself, so open coding dialogs
+        # (code_text, code_pdf) reload and do not keep stale positions. Emitting again
+        # here would dispatch the same change twice.
 
     def view_av(self, x: int):
         """ View an audio or video file. Edit the memo. Edit the transcript file.
@@ -2552,6 +2571,7 @@ class DialogManageFiles(QtWidgets.QDialog):
             cur.execute('update source set memo=? where id=?', (self.source[x]['memo'],
                                                                 self.source[x]['id']))
             self.app.conn.commit()
+            self._emit_project_table_changes(['source'])
         if self.source[x]['memo'] == "":
             self.ui.tableWidget.setItem(x, self.MEMO_COLUMN, QtWidgets.QTableWidgetItem())
         else:
@@ -2614,6 +2634,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.source.append(item)
         self.fill_table()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['source', 'attribute'])
 
     def link_files(self):
         """ Trigger to link to file location. """
@@ -2919,7 +2940,7 @@ class DialogManageFiles(QtWidgets.QDialog):
             if suffix in ('.docx', '.odt', '.rtf', '.tex', '.txt', '.htm', '.html', '.epub', '.md'):
                 if suffix == '.tex':
                     try:
-                        imported_ok = self.load_file_text(import_path, f"docs:{import_path}")
+                        imported_ok = self.load_file_text(import_path, f"docs:{import_path}", notify=False)
                     except LatexImportError as err:
                         logger.warning(f"LaTeX import error: {filename} {err}")
                         Message(self.app, _("Cannot import LaTeX file"),
@@ -2935,7 +2956,7 @@ class DialogManageFiles(QtWidgets.QDialog):
                 if link_path == "":
                     try:
                         copyfile(import_path, destination)
-                        imported_ok = self.load_file_text(import_path)
+                        imported_ok = self.load_file_text(import_path, notify=False)
                     except PermissionError as e_:
                         msg = _("Cannot copy file: ") + f"{filename}\n" + _(
                             "Is the file open?\nIs there a permission restriction?") + f"\n{e_}"
@@ -2950,14 +2971,14 @@ class DialogManageFiles(QtWidgets.QDialog):
                             logger.warning(_("Removing failed import copy: ") + str(err))
                         continue
                 else:
-                    self.load_file_text(import_path, f"docs:{link_path}")
+                    self.load_file_text(import_path, f"docs:{link_path}", notify=False)
                 known_file_type = True
             if suffix == '.pdf':
                 destination += f"/documents/{filename}"
                 if link_path == "":
                     try:
                         copyfile(import_path, destination)
-                        imported_ok = self.load_file_text(import_path, "", progress)
+                        imported_ok = self.load_file_text(import_path, "", progress, notify=False)
                     except PermissionError as e_:
                         msg = _("Cannot copy file: ") + f"{filename}\n" + _(
                             "Is the file open?\nIs there a permission restriction?") + f"\n{e_}"
@@ -2973,7 +2994,7 @@ class DialogManageFiles(QtWidgets.QDialog):
                         continue
                 else:
                     # Progress also applies to linked PDFs (extraction takes just as long).
-                    self.load_file_text(import_path, f"docs:{link_path}", progress)
+                    self.load_file_text(import_path, f"docs:{link_path}", progress, notify=False)
                 known_file_type = True
             # Media files
             if Path(import_path).suffix.lower() in ('.jpg', '.jpeg', '.png'):
@@ -2981,42 +3002,42 @@ class DialogManageFiles(QtWidgets.QDialog):
                     destination += f"/images/{filename}"
                     try:
                         copyfile(import_path, destination)
-                        self.load_media_reference(f"/images/{filename}")
+                        self.load_media_reference(f"/images/{filename}", notify=False)
                     except PermissionError as e_:
                         msg = _("Cannot copy file: ") + f"{filename}\n" + _(
                             "Is the file open?\nIs there a permission restriction?") + f"\n{e_}"
                         Message(self.app, _("Copy file permission error"), msg).exec()
                         continue
                 else:
-                    self.load_media_reference(f"images:{link_path}")
+                    self.load_media_reference(f"images:{link_path}", notify=False)
                 known_file_type = True
             if Path(import_path).suffix.lower() in ('.flac', '.m4a', '.mp3',  '.ogg', '.wav'):
                 if link_path == "":
                     destination += f"/audio/{filename}"
                     try:
                         copyfile(import_path, destination)
-                        self.load_media_reference(f"/audio/{filename}")
+                        self.load_media_reference(f"/audio/{filename}", notify=False)
                     except PermissionError as e_:
                         msg = _("Cannot copy file: ") + f"{filename}\n" + _(
                             "Is the file open?\nIs there a permission restriction?") + f"\n{e_}"
                         Message(self.app, _("Copy file permission error"), msg).exec()
                         continue
                 else:
-                    self.load_media_reference(f"audio:{link_path}")
+                    self.load_media_reference(f"audio:{link_path}", notify=False)
                 known_file_type = True
             if Path(import_path).suffix.lower() in ('.mkv', '.mov', '.mp4', '.m4v', '.wmv', '.webm'):
                 if link_path == "":
                     destination += f"/video/{filename}"
                     try:
                         copyfile(import_path, destination)
-                        self.load_media_reference(f"/video/{filename}")
+                        self.load_media_reference(f"/video/{filename}", notify=False)
                     except PermissionError as e_:
                         msg = _("Cannot copy file: ") + f"{filename}\n" + _(
                             "Is the file open?\nIs there a permission restriction?") + f"\n{e_}"
                         Message(self.app, _("Copy file permission error"), msg).exec()
                         continue
                 else:
-                    self.load_media_reference(f"video:{link_path}")
+                    self.load_media_reference(f"video:{link_path}", notify=False)
                 known_file_type = True
             if not known_file_type:
                 Message(self.app, _('Not supported file type'),
@@ -3032,6 +3053,9 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.fill_table()
         self.app.delete_backup = False
         self.update_files_in_dialogs()
+        if file_number > 0:
+            # One event for the whole batch, not one per imported file
+            self._emit_project_table_changes(['source', 'attribute'])
 
     def update_files_in_dialogs(self):
         """ Update files list in any opened dialogs:
@@ -3091,7 +3115,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         except OSError as err:
             logger.warning(_("Deleting waveform error: ") + str(err))
 
-    def load_media_reference(self, mediapath:str):
+    def load_media_reference(self, mediapath:str, notify:bool=True):
         """ Load media reference information for all file types.
 
         Args:
@@ -3164,6 +3188,8 @@ class DialogManageFiles(QtWidgets.QDialog):
 
             self.parent_text_edit.append(entry['name'] + _(" created."))
             self.source.append(entry)
+        if notify:
+            self._emit_project_table_changes(['source', 'attribute'])
 
     def load_pseudonyms(self):
         """ Pseudonyms stored in pseudonyms.json in qda data folder.
@@ -3184,7 +3210,8 @@ class DialogManageFiles(QtWidgets.QDialog):
 
         return decode_text_with_best_encoding_helper(import_file)
 
-    def load_file_text(self, import_file:str, link_path:str="", progress_:QProgressDialog|None=None):
+    def load_file_text(self, import_file:str, link_path:str="", progress_:QProgressDialog|None=None,
+                       notify:bool=True):
         """ Import from file types of odt, docx, rtf, pdf, epub, txt, html, htm.
         Implement character detection for txt imports.
         Loading pdf text. I have removed additional line breaks. See commented sections below.
@@ -3359,6 +3386,8 @@ class DialogManageFiles(QtWidgets.QDialog):
             msg += _(" linked")
         self.parent_text_edit.append(msg)
         self.source.append(entry)
+        if notify:
+            self._emit_project_table_changes(['source', 'attribute'])
         # Offer (once per batch) to code highlight annotations; they are not
         # painted in the coding view (annots=False).
         if suffix == '.pdf':
@@ -3765,6 +3794,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.load_file_data()
         self.fill_table()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['source', 'code_text', 'code_image', 'code_av', 'annotation', 'case_text', 'attribute'])
 
     def delete(self):
         """ Delete files from database and update model and widget.
@@ -3871,6 +3901,7 @@ class DialogManageFiles(QtWidgets.QDialog):
         self.parent_text_edit.append(_("Deleted: ") + filenames)
         self.load_file_data()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['source', 'code_text', 'code_image', 'code_av', 'annotation', 'case_text', 'attribute'])
 
     def get_tooltip_values(self, attribute_name:str):
         """ Get values to display in tooltips for the value list column.

--- a/src/qualcoder/manage_links.py
+++ b/src/qualcoder/manage_links.py
@@ -72,6 +72,12 @@ class DialogManageLinks(QtWidgets.QDialog):
         self.ui.pushButton_search_folders.pressed.connect(self.find_filepaths)
         self.ui.pushButton_bulk.pressed.connect(self.bulk_path_rename)
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def bulk_path_rename(self):
         """ Update all the linked by changing the path.
         Typically occurs when moving to another computer. """
@@ -119,6 +125,7 @@ class DialogManageLinks(QtWidgets.QDialog):
                 self.app.conn.commit()
             if instances > 1:
                 multiples += 1
+        self._emit_project_table_changes(['source'])
         if multiples > 0:
             Message(self.app, _("Multiple occurrences"), _("Multiples of text in path. Some links not updated.") + f"\n{old_text}").exec()
         self.links = self.app.check_bad_file_links()
@@ -202,6 +209,7 @@ class DialogManageLinks(QtWidgets.QDialog):
         sql = "update source set mediapath=? where id=?"
         cur.execute(sql, [self.links[row]['mediapath'], self.links[row]['id']])
         self.app.conn.commit()
+        self._emit_project_table_changes(['source'])
         self.fill_table()
         # Update file in file list in any opened coding dialog
         contents = self.tab_coding.layout()

--- a/src/qualcoder/manage_references.py
+++ b/src/qualcoder/manage_references.py
@@ -14,7 +14,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
 https://qualcoder-org.github.io
@@ -129,6 +129,12 @@ class DialogReferenceManager(QtWidgets.QDialog):
         self.ui.splitter.setSizes([500, 200])
         self.table_files_rows_hidden = False
         self.table_refs_rows_hidden = False
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def get_data(self):
         """ Get data for files and references. """
@@ -392,8 +398,11 @@ class DialogReferenceManager(QtWidgets.QDialog):
             # print(best_match)
             ris_id = best_match[0]
             fid = file_['id']
-            self.link_reference_to_files(ris_id, fid)
+            # Silenced per call: one event covers the whole auto-link run
+            self.link_reference_to_files(ris_id, fid, notify=False)
             files_linked_count += 1
+        if files_linked_count > 0:
+            self._emit_project_table_changes(['source', 'attribute'])
         msg = _("Matches: ") + f"          {files_linked_count} / {len(files_unlinked)}          "
         Message(self.app, _("Files linked to references"), msg).exec()
 
@@ -823,7 +832,7 @@ class DialogReferenceManager(QtWidgets.QDialog):
         logger.debug(f"Attachment not found on disk: {value!r} (cleaned: {raw!r})")
         return None
 
-    def _import_attachment_file(self, file_path, progress=None):
+    def _import_attachment_file(self, file_path, progress=None, notify:bool=True):
         """
         Imports an attachment (PDF or EPUB) into the project: copy to documents/,
         extract its text and create the source row with attribute placeholders. Returns the
@@ -895,6 +904,8 @@ class DialogReferenceManager(QtWidgets.QDialog):
         # whole FAISS index, and a batch would queue one rebuild per attachment. Counted here only;
         # _update_ai_vectorstore does the single pass when the batch ends.
         self.attachments_imported += 1
+        if notify:
+            self._emit_project_table_changes(['source', 'attribute'])
         self.parent_text_edit.append(filename + _(" imported"))
         if ext == ".pdf":
             self._import_pdf_annotations(fid, file_path, text_, progress)
@@ -973,7 +984,7 @@ class DialogReferenceManager(QtWidgets.QDialog):
                 return True
         return False
 
-    def unlink_files(self, fid:int|None=None):
+    def unlink_files(self, fid:int|None=None, notify:bool=True):
         """ Remove linked reference from selected files.
         Called by:
             pushButton_unlink: Uses selected rows in files table. Does not use parameters.
@@ -1006,9 +1017,11 @@ class DialogReferenceManager(QtWidgets.QDialog):
             for attribute in attributes:
                 cur.execute(sql, [fid, attribute])
                 self.app.conn.commit()
+        if notify:
+            self._emit_project_table_changes(['source', 'attribute'])
         self.get_data()
 
-    def link_reference_to_files(self, ris_id:int|None=None, fid:int|None=None):
+    def link_reference_to_files(self, ris_id:int|None=None, fid:int|None=None, notify:bool=True):
         """ Link the selected files to the selected reference.
 
         Called by:
@@ -1084,6 +1097,8 @@ class DialogReferenceManager(QtWidgets.QDialog):
             for attribute in attr_values:
                 cur.execute(sql, [attr_values[attribute], fid, attribute])
                 self.app.conn.commit()
+        if notify:
+            self._emit_project_table_changes(['source', 'attribute'])
         self.get_data()
 
     def edit_reference(self):
@@ -1137,11 +1152,19 @@ class DialogReferenceManager(QtWidgets.QDialog):
                             [ui_re.tableWidget.item(row, 1).text(), ris_id, key])
                 self.app.conn.commit()
                 ref_edited = True
-        # Update Reference attributes
+        # Update Reference attributes. unlink_files and link_reference_to_files emit
+        # per call, so they are silenced here and one event covers the whole edit.
+        relinked = False
         for file_ in self.files:
             if file_['risid'] == ris_id:
-                self.unlink_files(file_['id'])
-                self.link_reference_to_files(ris_id, file_['id'])
+                self.unlink_files(file_['id'], notify=False)
+                self.link_reference_to_files(ris_id, file_['id'], notify=False)
+                relinked = True
+        if ref_edited or relinked:
+            tables = ['ris'] if ref_edited else []
+            if relinked:
+                tables += ['source', 'attribute']
+            self._emit_project_table_changes(tables)
         if ref_edited:
             self.parent_text_edit.append(_("Reference edited."))
         self.get_data()
@@ -1178,6 +1201,7 @@ class DialogReferenceManager(QtWidgets.QDialog):
             for attribute in attributes:
                 cur.execute(sql, [source[0], attribute])
                 self.app.conn.commit()
+        self._emit_project_table_changes(['ris', 'source', 'attribute'])
         self.get_data()
         self.fill_table_refs()
         self.fill_table_files()

--- a/src/qualcoder/manage_references_import_zotero.py
+++ b/src/qualcoder/manage_references_import_zotero.py
@@ -14,7 +14,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
 https://qualcoder-org.github.io
@@ -73,6 +73,12 @@ class ZoteroImport:
         self.refs_dialog = refs_dialog
 
     # local API
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def _get(self, path, want_json=True):
         """
@@ -258,6 +264,7 @@ class ZoteroImport:
                         [risid, tag, longtag, str(value)])
         if commit:
             self.app.conn.commit()
+        self._emit_project_table_changes(['ris'])
 
     def _ensure_ref_attributes(self):
         """
@@ -275,6 +282,7 @@ class ZoteroImport:
                             (key, now_date, self.app.settings['codername'], "", 'file', ref_vars[key]))
         self.app.conn.commit()
         self.app.delete_backup = False
+        self._emit_project_table_changes(['attribute_type'])
 
     # PDF attachments
 
@@ -523,11 +531,13 @@ class ZoteroImport:
                                 not_retrieved += 1
                                 continue
                             progress.setLabelText(os.path.basename(path_.replace("\\", "/")))
-                            fid = self.refs_dialog._import_attachment_file(path_, progress)
+                            fid = self.refs_dialog._import_attachment_file(path_, progress,
+                                                                           notify=False)
                             if fid is None:
                                 not_retrieved += 1
                                 continue
-                            self.refs_dialog.link_reference_to_files(risid, fid)
+                            # Silenced per attachment: one event after the batch
+                            self.refs_dialog.link_reference_to_files(risid, fid, notify=False)
                             linked += 1
                 finally:
                     # In a finally: a failure midway must leave neither the bar stuck
@@ -535,6 +545,9 @@ class ZoteroImport:
                     progress.close()
                     progress.deleteLater()
                     shutil.rmtree(tmp_dir, ignore_errors=True)
+                if linked > 0 and getattr(self.app, "project_events", None) is not None:
+                    # One event for the whole attachment batch, not one per file
+                    self.app.project_events.emit_table_changes(['source', 'attribute'], source=None)
         self.refs_dialog.get_data()
 
         msg = _("References imported: ") + f"{len(pairs)}"

--- a/src/qualcoder/merge_projects.py
+++ b/src/qualcoder/merge_projects.py
@@ -14,7 +14,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
 https://qualcoder-org.github.io
@@ -84,11 +84,21 @@ class MergeProjects:
             self.summary_msg += "\n" + _("Finished merging ") + f"{self.path_s}  --> {self.path_d}\n"
             self.summary_msg += _(
                 "Existing values in destination project are not over-written, apart from blank attribute values.") + "\n"
+            # One event for the whole merge, not one per inserted row
+            self._emit_project_table_changes(
+                ['source', 'code_name', 'code_cat', 'code_text', 'code_image', 'code_av',
+                 'cases', 'case_text', 'attribute', 'attribute_type', 'journal', 'annotation'])
             Message(self.app, _('Project merged'), _("Review the action log for details.")).exec()
             self.projects_merged = True
             self.app.delete_backup = False
         else:
             Message(self.app, _('Project not merged'), _("Project not merged")).exec()
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def insert_categories(self):
         """ Insert categories into destination code_cat table.

--- a/src/qualcoder/refi.py
+++ b/src/qualcoder/refi.py
@@ -14,7 +14,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
 https://qualcoder-org.github.io
@@ -110,6 +110,12 @@ class RefiImport:
                 return
             self.import_project()
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def import_codebook(self):
         """ Import REFI-QDA standard codebook into opened project.
         """
@@ -145,6 +151,9 @@ class RefiImport:
                     # Recursive search through each Code element
                     counter += self.sub_codes(el_, None)  # <(pre-existing: pass each Code, not the <Codes> container)
                 msg = str(counter) + _(" categories and codes imported from ") + self.file_path
+                if counter > 0:
+                    # Imported into an open project: one event for the whole codebook
+                    self._emit_project_table_changes(['code_name', 'code_cat'])
                 Message(self.app, _("Codebook imported"), msg).exec()
                 self.parent_textedit.append(msg)
                 return

--- a/src/qualcoder/report_attributes.py
+++ b/src/qualcoder/report_attributes.py
@@ -106,6 +106,12 @@ class DialogSelectAttributeParameters(QtWidgets.QDialog):
         self.ui.tableWidget.cellChanged.connect(self.cell_modified)
         self.ui.pushButton_clear.pressed.connect(self.clear_parameters)
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def filter_settings_delete(self):
         """ Delete saved filter settings. """
 
@@ -127,6 +133,7 @@ class DialogSelectAttributeParameters(QtWidgets.QDialog):
         selection = ui.get_selected()
         cur.execute("delete from files_filter where name=?", [selection['name']])
         self.app.conn.commit()
+        self._emit_project_table_changes(['files_filter'])
         Message(self.app, _("Filter deleted"), selection['name']).exec()
 
     def filter_settings_save(self):
@@ -151,6 +158,7 @@ class DialogSelectAttributeParameters(QtWidgets.QDialog):
             return
         cur.execute("insert into files_filter (name, filter, owner) values(?,?,?)", [filter_name, parameters_str, self.app.settings['codername']])
         self.app.conn.commit()
+        self._emit_project_table_changes(['files_filter'])
 
     def filter_settings_load(self):
         """ Load filter settings String.

--- a/src/qualcoder/report_codes.py
+++ b/src/qualcoder/report_codes.py
@@ -203,6 +203,12 @@ class DialogReportCodes(QtWidgets.QDialog):
         self.ui.textEdit.installEventFilter(self.eventFilterTT)
         self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def splitter_sizes(self):
         """ Detect size changes in splitter and store in app.settings variable. """
 
@@ -354,8 +360,7 @@ class DialogReportCodes(QtWidgets.QDialog):
         table = {'text': 'code_text', 'image': 'code_image', 'av': 'code_av'}.get(result_type)
         if table is None:
             return
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes([table], source=self)
+        self._emit_project_table_changes([table])
 
     def get_selected_files_and_cases(self):
         """ Fill file_ids and case_ids Strings used in the search.

--- a/src/qualcoder/report_cooccurrence.py
+++ b/src/qualcoder/report_cooccurrence.py
@@ -144,6 +144,12 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
         self.app.project_events.project_data_changed.connect(self._on_project_data_changed)
         self.process_data()
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def _rebuild_selected_code_strings(self):
         self.code_names_list = []
         self.code_names_str = ""
@@ -1086,6 +1092,7 @@ class DialogReportCooccurrence(QtWidgets.QDialog):
                 except Exception as e_:
                     print(e_)
                     logger.debug(e_)
+            self._emit_project_table_changes(['code_name', 'code_text', 'code_image'])
 
     def fill_table(self):
         """ Fill table using code names alphabetically (case insensitive), using self.data """

--- a/src/qualcoder/report_sql.py
+++ b/src/qualcoder/report_sql.py
@@ -29,6 +29,7 @@ import csv
 from datetime import datetime
 import logging
 import openpyxl
+import re
 import qtawesome as qta  # https://pictogrammers.com/library/mdi/
 import sqlite3
 
@@ -115,6 +116,30 @@ class DialogSQL(QtWidgets.QDialog):
             pass
         self.ui.splitter.splitterMoved.connect(self.update_sizes)
         self.ui.splitter_2.splitterMoved.connect(self.update_sizes)
+
+    # Tables a free-form query may write. Used when the target cannot be parsed out.
+    PROJECT_TABLES = ['source', 'code_name', 'code_cat', 'code_text', 'code_image', 'code_av',
+                      'cases', 'case_text', 'attribute', 'attribute_type', 'journal', 'annotation']
+
+    @staticmethod
+    def _tables_written_by(sql):
+        """Name the table a user DELETE or UPDATE targets, for the project change event.
+
+        Falls back to every project table when the target cannot be identified, so a
+        hand-written query never leaves open dialogs showing stale data.
+        """
+
+        match = re.search(r"(?:delete\s+from|update)\s+[\"\'`\[]?([a-zA-Z_][a-zA-Z0-9_]*)",
+                          sql, re.IGNORECASE)
+        if match and match.group(1).lower() in DialogSQL.PROJECT_TABLES:
+            return [match.group(1).lower()]
+        return list(DialogSQL.PROJECT_TABLES)
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def update_sizes(self):
         """ Called by splitter resized """
@@ -284,10 +309,12 @@ class DialogSQL(QtWidgets.QDialog):
                 self.ui.label.setText(str(cur.rowcount) + _(" rows deleted"))
                 self.app.delete_backup = False
                 self.app.conn.commit()
+                self._emit_project_table_changes(self._tables_written_by(self.sql))
             if self.sql[0:6].upper() == "UPDATE":
                 self.ui.label.setText(str(cur.rowcount) + _(" rows updated"))
                 self.app.delete_backup = False
                 self.app.conn.commit()
+                self._emit_project_table_changes(self._tables_written_by(self.sql))
             if selected_text != "":
                 text = self.ui.label.text() + "  " + _("Using selected text")
                 self.ui.label.setText(text)
@@ -402,6 +429,7 @@ class DialogSQL(QtWidgets.QDialog):
                 delete_sql = menu.addAction(_("Delete stored sql"))
         action = menu.exec(self.ui.treeWidget.mapToGlobal(position))
         if action is not None and action == delete_sql:
+            deleted = False
             for i in range(len(self.stored_sqls)):
                 if self.stored_sqls[i]['index'] == index:
                     title = self.ui.treeWidget.currentItem().text(0)
@@ -409,7 +437,10 @@ class DialogSQL(QtWidgets.QDialog):
                     cur.execute("delete from stored_sql where title=?", [title])
                     self.app.conn.commit()
                     del self.stored_sqls[i]
+                    deleted = True
                     break
+            if deleted:
+                self._emit_project_table_changes(['stored_sql'])
             self.get_schema_update_tree_widget()
 
     def keyPressEvent(self, event):
@@ -505,6 +536,7 @@ class DialogSQL(QtWidgets.QDialog):
         try:
             cur.execute(sql, [title, description, grouper, ssql])
             self.app.conn.commit()
+            self._emit_project_table_changes(['stored_sql'])
         except Exception as e:
             Message(self.app, _("Cannot save"), str(e)).exec()
         self.get_schema_update_tree_widget()

--- a/src/qualcoder/ris.py
+++ b/src/qualcoder/ris.py
@@ -347,6 +347,12 @@ class RisImport:
             self.create_file_placeholder_attributes()
             self.import_ris_file(file_path)
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def create_file_attributes(self):
         """ Creates the attributes for Ref_Authors, Ref_Title, Ref_Type, Ref_Year, Ref_Journal """
 
@@ -354,6 +360,7 @@ class RisImport:
         cur = self.app.conn.cursor()
         ref_vars = {'Ref_Authors': 'character', 'Ref_Title': 'character', 'Ref_Type': 'character',
                     'Ref_Year': 'numeric', 'Ref_Journal': 'character'}
+        created = False
         for key in ref_vars:
             cur.execute("select name from attribute_type where name=?", [key])
             res = cur.fetchone()
@@ -361,7 +368,10 @@ class RisImport:
                 cur.execute("insert into attribute_type (name,date,owner,memo,caseOrFile, valuetype) values(?,?,?,?,?,?)",
                         (key, now_date, self.app.settings['codername'], "", 'file', ref_vars[key]))
                 self.app.conn.commit()
+                created = True
         self.app.delete_backup = False
+        if created:
+            self._emit_project_table_changes(['attribute_type'])
 
     def create_file_placeholder_attributes(self):
         """ Creates empty placeholder attributes for each file.
@@ -376,6 +386,7 @@ class RisImport:
         attr_types = cur.fetchall()
         attr_types = ["Ref_Authors", "Ref_Title", "Ref_Type", "Ref_Year", "Ref_Journal"]
         insert_sql = "insert into attribute (name, attr_type, value, id, date, owner) values(?,'file','',?,?,?)"
+        created = False
         for source in sources:
             for att in attr_types:
                 sql = "select value from attribute where id=? and name=?"
@@ -386,6 +397,9 @@ class RisImport:
                                     self.app.settings['codername']]
                     cur.execute(insert_sql, placeholders)
                     self.app.conn.commit()
+                    created = True
+        if created:
+            self._emit_project_table_changes(['attribute'])
 
     def import_ris_file(self, filepath):
         """
@@ -516,6 +530,8 @@ class RisImport:
             pairs.append((max_risid, attach_paths))
             new_entries += 1
         self.app.conn.commit()
+        if new_entries > 0:
+            self._emit_project_table_changes(['ris'])
         if self.refs_dialog:
             self.refs_dialog.get_data()
 
@@ -537,17 +553,22 @@ class RisImport:
                             done += 1
                             progress.setValue(done)
                             progress.setLabelText(Path(path_.replace("\\", "/")).name)
-                            fid = self.refs_dialog._import_attachment_file(path_, progress)
+                            fid = self.refs_dialog._import_attachment_file(path_, progress,
+                                                                           notify=False)
                             if fid is None:
                                 failed += 1
                                 continue
-                            self.refs_dialog.link_reference_to_files(risid, fid)
+                            # Silenced per attachment: one event after the batch
+                            self.refs_dialog.link_reference_to_files(risid, fid, notify=False)
                             linked += 1
                 finally:
                     # No autoClose: close it, in a finally so a failure midway does not leave the
                     # bar stuck on screen.
                     progress.close()
                     progress.deleteLater()
+            if linked > 0 and getattr(self.app, "project_events", None) is not None:
+                # One event for the whole attachment batch, not one per file
+                self.app.project_events.emit_table_changes(['source', 'attribute'], source=None)
             self.refs_dialog.get_data()
 
         msg = _("Bibliography loaded from: ") + filepath + "\n"

--- a/src/qualcoder/settings.py
+++ b/src/qualcoder/settings.py
@@ -14,10 +14,11 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
+https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
-
 """
 
 import logging
@@ -861,6 +862,12 @@ class DialogSettings(QtWidgets.QDialog):
             self.ai_models, self.settings['ai_model_index'] = add_new_ai_model(self.ai_models, new_name)
             self.load_ai_profiles()
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def accept(self):
         restart_qualcoder = False
         if self.settings['codername'] == "":
@@ -963,6 +970,12 @@ class DialogSettings(QtWidgets.QDialog):
             self.coder_names_changes = True
         if self.app.conn is not None:
             self.app.conn.commit()
+            if self.coder_names_changes:
+                # DialogCoderNames runs here with do_commit=False, so the commit and the
+                # notification both belong to this dialog. Renaming or merging a coder
+                # rewrites owner across the coded tables.
+                self._emit_project_table_changes(
+                    ['coder_names', 'code_text', 'code_image', 'code_av', 'annotation'])
         self.save_settings()
         if restart_qualcoder:
             Message(self.app, _("Restart QualCoder"), _("Restart QualCoder to enact some changes")).exec()

--- a/src/qualcoder/speakers.py
+++ b/src/qualcoder/speakers.py
@@ -14,9 +14,10 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain (ccbogel)
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -338,6 +339,12 @@ class DialogSpeakers(QtWidgets.QDialog):
         # Help button top-right, icon-only, consistent with the other modules.
         self.ui.pushButton_help.setIcon(qta.icon('mdi6.help'))
         self.ui.pushButton_help.pressed.connect(self.help)
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def _setup_identifier_combo(self):
         """ 
@@ -1345,6 +1352,7 @@ class DialogSpeakers(QtWidgets.QDialog):
             if inserted_codings > 0:  # hubo codificaciones nuevas # new codings were written
                 self.app.delete_backup = False
             self.app.conn.commit()
+            self._emit_project_table_changes(['code_cat', 'code_name', 'code_text'])
         except Exception as e_:
             logger.exception(e_)  # antes print(); registra el traceback.  Was print(); logs the traceback
             self.app.conn.rollback()  # Revert all changes

--- a/src/qualcoder/special_functions.py
+++ b/src/qualcoder/special_functions.py
@@ -86,6 +86,12 @@ class DialogSpecialFunctions(QtWidgets.QDialog):
         # Text positions, is here in case it is needed, but hidden for users as dangerous, Key Tilde to activate
         self.ui.groupBox_text_positions.hide()
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def keyPressEvent(self, event):
         """ Tilde ~ to show the existing start and end text positions in coded text. """
 
@@ -215,6 +221,7 @@ class DialogSpecialFunctions(QtWidgets.QDialog):
                 pass
             cur.execute(update_sql, [new_pos0, seltext, r[2], r[3], r[0], r[1], r[4]])
             self.app.conn.commit()
+        self._emit_project_table_changes(['code_text'])
         self.parent_text_edit.append(
             _("All text codings by ") + self.app.settings['codername'] + _(" resized by ") + str(delta) + _(
                 " characters."))
@@ -261,6 +268,7 @@ class DialogSpecialFunctions(QtWidgets.QDialog):
                 pass
             cur.execute(update_sql, [new_pos1, seltext, r[2], r[3], r[0], r[1], r[4]])
             self.app.conn.commit()
+        self._emit_project_table_changes(['code_text'])
         self.parent_text_edit.append(
             _("All text codings by ") + self.app.settings['codername'] + _(" resized by ") + str(delta) + _(
                 " characters."))

--- a/src/qualcoder/text_file_replacement.py
+++ b/src/qualcoder/text_file_replacement.py
@@ -95,10 +95,17 @@ class ReplaceTextFile:
         errs = self.update_annotation_positions()
         errs += self.update_code_positions()
         errs += self.update_case_positions()
+        self._emit_project_table_changes(['source', 'code_text', 'annotation', 'case_text'])
         msg = _("Reload the other tabs.\nCheck accuracy of codings and annotations.\n")
         msg += _("Function works by identifying the first matching text segment for each coding and annotation.")
         msg += f"\n{errs}"
         Message(self.app, _("File replaced"), msg).exec()
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def update_case_positions(self):
         """ Update case if all file is assigned to case or portions assigned to case. """

--- a/src/qualcoder/view_av.py
+++ b/src/qualcoder/view_av.py
@@ -17,8 +17,8 @@ If not, see <https://www.gnu.org/licenses/>.
 Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
-https://qualcoder.org/
 https://qualcoder-org.github.io
+https://qualcoder.org/
 """
 
 from copy import copy
@@ -225,6 +225,7 @@ class DialogViewAV(QtWidgets.QDialog):
                 cur.execute("update source set av_text_id=? where id=?", [tr_id, self.file_['id']])
                 self.app.conn.commit()  # was a 'conmmit' typo silently swallowed; the
                 # av_text_id link could be lost, recreating duplicate .txt transcripts
+            self._emit_project_table_changes(['source'])
             cur.execute("select id, fulltext, name from source where id=?", [tr_id])
             self.transcription = cur.fetchone()
             if self.transcription is not None and self.transcription[1] is None:
@@ -729,6 +730,8 @@ class DialogViewAV(QtWidgets.QDialog):
         cur.execute("update source set fulltext=?, date=? where id=?", [text, now, self.transcription[0]])
         self.app.conn.commit()
         self.app.delete_backup = False
+        # Only source.fulltext is rewritten here; subscribers reload the file on 'source'
+        self._emit_project_table_changes(['source'])
         cur.execute("select id, fulltext, name from source where id=?", [self.transcription[0]])
         self.transcription = cur.fetchone()
         if self.transcription is not None and self.transcription[1] is None:
@@ -1987,6 +1990,13 @@ class DialogViewAV(QtWidgets.QDialog):
         self.text = current_text
         self.prev_text = copy(self.text)
         self.app.delete_backup = False
+        self._emit_project_table_changes(['source', 'code_text', 'annotation', 'case_text'])
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def update_positions(self):
         """ Update positions for code text, annotations and case text as each character changes

--- a/src/qualcoder/view_graph.py
+++ b/src/qualcoder/view_graph.py
@@ -16,8 +16,8 @@ If not, see <https://www.gnu.org/licenses/>.
 
 Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
-https://qualcoder-org.github.io
 https://qualcoder.wordpress.com/
+https://qualcoder-org.github.io
 https://qualcoder.org/
 """
 
@@ -6882,6 +6882,12 @@ class MemoGraphicsItem(QtWidgets.QGraphicsTextItem):
         self.setDefaultTextColor(safe_color("blue"))
         self._refresh_memo()
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     # Map source type -> (select SQL, update SQL, params)
     def _get_sql_and_params(self):
         type_map = {
@@ -6962,7 +6968,7 @@ class MemoGraphicsItem(QtWidgets.QGraphicsTextItem):
                 }
                 changed = table_map.get(self.memo_source_type)
                 if changed:
-                    self.app.project_events.emit_table_changes([changed], source=self)
+                    self._emit_project_table_changes([changed])
         self._refresh_memo()
 
     def mouseDoubleClickEvent(self, event):
@@ -8533,6 +8539,12 @@ class TextGraphicsItem(QtWidgets.QGraphicsTextItem):
         self.code_or_cat['memo'] = ""
         self.get_memo()
 
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
+
     def __repr__(self):
         txt = f"TextGraphicsItem CodeOrCat:{self.code_or_cat} Font:{self.font_size} Bold:{self.bold}\n"
         txt += f"Ellipse:{self.is_ellipse} Collapse:{self.is_collapsed}\n"
@@ -9098,6 +9110,7 @@ class TextGraphicsItem(QtWidgets.QGraphicsTextItem):
         """ Add or edit memos for codes and categories. """
 
         if self.code_or_cat['cid'] is not None:
+            previous_memo = self.code_or_cat['memo']
             ui = DialogMemo(self.app, _("Memo for Code ") + self.code_or_cat['name'], self.code_or_cat['memo'],
                             entity_type="code", entity_id=self.code_or_cat['cid'])
             ui.exec()
@@ -9105,7 +9118,10 @@ class TextGraphicsItem(QtWidgets.QGraphicsTextItem):
             cur = self.conn.cursor()
             cur.execute("update code_name set memo=? where cid=?", (self.code_or_cat['memo'], self.code_or_cat['cid']))
             self.conn.commit()
+            if self.code_or_cat['memo'] != previous_memo:
+                self._emit_project_table_changes(['code_name'])
         if self.code_or_cat['catid'] is not None and self.code_or_cat['cid'] is None:
+            previous_memo = self.code_or_cat['memo']
             ui = DialogMemo(self.app, _("Memo for Category ") + self.code_or_cat['name'], self.code_or_cat['memo'],
                             entity_type="category", entity_id=self.code_or_cat['catid'])
             ui.exec()
@@ -9114,6 +9130,8 @@ class TextGraphicsItem(QtWidgets.QGraphicsTextItem):
             cur.execute("update code_cat set memo=? where catid=?",
                         (self.code_or_cat['memo'], self.code_or_cat['catid']))
             self.conn.commit()
+            if self.code_or_cat['memo'] != previous_memo:
+                self._emit_project_table_changes(['code_cat'])
 
     def toggle_collapse(self):
         """ Oculta o muestra todos los nodos descendientes y actualiza las líneas.

--- a/src/qualcoder/view_image.py
+++ b/src/qualcoder/view_image.py
@@ -14,7 +14,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with QualCoder.
 If not, see <https://www.gnu.org/licenses/>.
 
-Author: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
+Authors: Colin Curtain C, Kai Dröge, Justin Missaghieh--Poncet, Lorenzo Salomón
 https://github.com/ccbogel/QualCoder
 https://qualcoder.wordpress.com/
 https://qualcoder-org.github.io
@@ -225,6 +225,12 @@ class DialogCodeImage(QtWidgets.QDialog):
         # These signals after the tree is filled the first time
         self.ui.treeWidget.itemCollapsed.connect(self.get_collapsed)
         self.ui.treeWidget.itemExpanded.connect(self.get_collapsed)
+
+    def _emit_project_table_changes(self, tables):
+        """Notify other open dialogs about changed project tables."""
+
+        if getattr(self.app, "project_events", None) is not None:
+            self.app.project_events.emit_table_changes(tables, source=self)
 
     def update_sizes(self):
         """ Called by changed splitter sizes """
@@ -678,6 +684,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         cur = self.app.conn.cursor()
         cur.execute("update source set memo=? where id=?", (memo, file_['id']))
         self.app.conn.commit()
+        self._emit_project_table_changes(['source'])
         self.get_files()
         self.ui.listWidget.clear()
         for f in self.files:
@@ -1030,8 +1037,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         self.get_coded_areas()
         self.draw_coded_areas()
 
-        if self.app.project_events is not None:
-            self.app.project_events.emit_table_changes(tables, source=self)
+        self._emit_project_table_changes(tables)
 
     def _on_project_data_changed(self, tables, source):
         """Handle project change events from other dialogs.
@@ -1922,8 +1928,7 @@ class DialogCodeImage(QtWidgets.QDialog):
         (e.g. the PDF coding viewer) refresh live.
         """
 
-        if getattr(self.app, "project_events", None) is not None:
-            self.app.project_events.emit_table_changes(['code_image'], source=self)
+        self._emit_project_table_changes(['code_image'])
 
     def find_coded_areas_for_pos(self, pos):
         """ Find any coded areas for this position AND for all visible coders.


### PR DESCRIPTION
- One _emit_project_table_changes across 33 classes, replacing the getattr guard in 35 places and two divergent bodies under the same name.
- The three purpose named wrappers delegate to the helper.
- Exceptions: ai_llm and ai_mcp_server (take project_events as a parameter), two module level functions in code_pdf (no self), and the batch events in RisImport and ZoteroImport.
- One event per action, not per row: the mirror helpers in code_av emitted inside loops (Mark speakers, one per speaker).
- Same for file import, PDF to images, bibliographic import and attribute placeholders.
- Fix: cases.cell_modified emitted ['attribute'] while writing to cases.
- Fix: code_text.undo_edited_text never called commit.
- Fix: edit_mode_off emitted with nothing edited.
- Fix: manage_files.view duplicated the editor's event.
- Fix: memos in cases, manage_files and view_graph emitted with no change.
- Fix: settings.py with do_commit=False did not notify coder renames.