### PR TITLE
Update settings.py

### DIFF
--- a/src/qualcoder/settings.py
+++ b/src/qualcoder/settings.py
@@ -854,7 +854,8 @@ class DialogSettings(QtWidgets.QDialog):
             # ensure the new name is unique
             existing_names = {model['name'] for model in self.ai_models}
             if new_name in existing_names:
-                Message(_('New AI profile'), _('An AI profile with this name already exists: ') + new_name, 'critical')
+                Message(self.app, _('New AI profile'),
+                        _('An AI profile with this name already exists: ') + new_name, 'critical').exec()
                 return
             
             self.ai_models, self.settings['ai_model_index'] = add_new_ai_model(self.ai_models, new_name)


### PR DESCRIPTION
Fixes a crash that occurs when creating a new AI profile with a name that already exists. The duplicate-name guard raised AttributeError instead of showing its warning message.