### PR TITLE
Merged project Issues (for Test)

### DIFF
--- a/src/qualcoder/merge_projects.py
+++ b/src/qualcoder/merge_projects.py
@@ -24,12 +24,82 @@ https://qualcoder.org/
 import datetime
 import logging
 from pathlib import Path
+import re
 import shutil
 import sqlite3
+
+from PyQt6 import QtCore, QtWidgets
 
 from .helpers import Message
 
 logger = logging.getLogger(__name__)
+
+# Max item names listed per preview section. Counts are always complete
+MAX_LISTED_ITEMS = 200
+
+
+class DialogMergePreview(QtWidgets.QDialog):
+    """ Read only preview of what a merge would add, by section with counts and names.
+    Nothing is written yet, so Cancel leaves the project untouched.
+    """
+
+    def __init__(self, app, sections, path_s, parent=None):
+
+        super(DialogMergePreview, self).__init__(parent)
+        self.app = app
+        self.sections = sections
+        self.setWindowTitle(_("Merge preview"))
+        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowType.WindowContextHelpButtonHint)
+        self.resize(760, 580)
+        self.setStyleSheet(f'font: {app.settings["fontsize"]}pt "{app.settings["font"]}";')
+        layout = QtWidgets.QVBoxLayout(self)
+        header = QtWidgets.QLabel(_("Merging: ") + f"{path_s}\n" + _("Into: ") + f"{app.project_path}")
+        header.setWordWrap(True)
+        layout.addWidget(header)
+        self.tree = QtWidgets.QTreeWidget()
+        self.tree.setColumnCount(2)
+        self.tree.setHeaderLabels([_("Item"), _("Count")])
+        self.tree.setAlternatingRowColors(True)
+        self.tree.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.NoSelection)
+        layout.addWidget(self.tree)
+        self.fill_tree()
+        note = QtWidgets.QLabel(
+            _("Existing values in the destination project are not over-written, apart from blank attribute values."))
+        note.setWordWrap(True)
+        layout.addWidget(note)
+        self.checkbox_journal = QtWidgets.QCheckBox(_("Save this report to a journal"))
+        self.checkbox_journal.setToolTip(_("The report is stored as a journal entry, merged or cancelled"))
+        layout.addWidget(self.checkbox_journal)
+        button_box = QtWidgets.QDialogButtonBox()
+        merge_button = button_box.addButton(_("Merge"), QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
+        merge_button.setDefault(True)
+        button_box.addButton(_("Cancel"), QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def fill_tree(self):
+        """ One top level row per section, item names as children. """
+
+        # Expand a short report, otherwise open the warnings only
+        total_items = sum(len(s['items']) for s in self.sections)
+        expand_all = total_items <= 40
+        for section in self.sections:
+            top = QtWidgets.QTreeWidgetItem([section['title'], section['detail']])
+            if section['warning']:
+                for column in (0, 1):
+                    top.setForeground(column, QtCore.Qt.GlobalColor.red)
+            for item in section['items']:
+                top.addChild(QtWidgets.QTreeWidgetItem([item, ""]))
+            self.tree.addTopLevelItem(top)
+            if section['warning'] or (expand_all and section['items']):
+                top.setExpanded(True)
+        self.tree.resizeColumnToContents(0)
+
+    def save_to_journal(self):
+        """ True if the report should be stored as a journal entry. """
+
+        return self.checkbox_journal.isChecked()
 
 
 class MergeProjects:
@@ -44,10 +114,10 @@ class MergeProjects:
     Existing attribute values in destination are not over-written, unless already blank
      """
 
-    def __init__(self, app, path_s):
+    def __init__(self, app, path_s, show_preview=True):
         self.app = app
         self.path_s = path_s  # Path to source project folder
-        self.conn_s = sqlite3.connect(Path(self.path_s) / 'data.qda')  # Source project that is to be merged from
+        self.conn_s = None  # Source project that is to be merged from
         self.conn_d = self.app.conn  # Destination project - the currently opened project
         self.path_d = self.app.project_path  # Path to destination project folder
         self.summary_msg = _("Merging: ") + self.path_s + "\n" + _("Into: ") + self.app.project_path + "\n"
@@ -65,9 +135,34 @@ class MergeProjects:
         self.attributes_s = []  # values for Case and File attributes
         self.cases_s = []
         self.case_text_s = []  # case text and links to non-text files
-        self.copy_source_files_into_destination()
+        self.preview_sections = []  # Read only summary of what would be added
+        self.merge_cancelled = False
+        # Connecting to a missing file would create an empty database in the user folder
+        db_path_s = Path(self.path_s) / 'data.qda'
+        if not db_path_s.is_file():
+            self.summary_msg += _("No data.qda database found in the selected folder.") + "\n"
+            Message(self.app, _('Project not merged'), _("Not a QualCoder project")).exec()
+            return
+        self.conn_s = sqlite3.connect(db_path_s)
+        # Nothing is written until the preview is confirmed, so Cancel leaves the project untouched
         loaded = self.get_source_data()
+        save_journal = False
         if loaded:
+            self.preview_sections = self.build_preview()
+            if show_preview:
+                preview_dialog = DialogMergePreview(self.app, self.preview_sections, self.path_s)
+                proceed = preview_dialog.exec()
+                save_journal = preview_dialog.save_to_journal()
+                if not proceed:
+                    self.merge_cancelled = True
+                    self.summary_msg += "\n" + _("Merge cancelled. No changes were made.") + "\n"
+                    if save_journal:
+                        self.save_report_to_journal(merged=False)
+                    self.close_source_connection()
+                    Message(self.app, _('Project not merged'), _("Merge cancelled")).exec()
+                    return
+        if loaded:
+            self.copy_source_files_into_destination()
             msg, backup_name = self.app.save_backup("_Pre-merge")
             self.summary_msg += f"\n{msg}"
             self.insert_sources_get_new_file_ids()
@@ -88,17 +183,265 @@ class MergeProjects:
             self._emit_project_table_changes(
                 ['source', 'code_name', 'code_cat', 'code_text', 'code_image', 'code_av',
                  'cases', 'case_text', 'attribute', 'attribute_type', 'journal', 'annotation'])
-            Message(self.app, _('Project merged'), _("Review the action log for details.")).exec()
             self.projects_merged = True
             self.app.delete_backup = False
+            if save_journal:
+                self.save_report_to_journal(merged=True)
+            self.close_source_connection()
+            Message(self.app, _('Project merged'), _("Review the action log for details.")).exec()
         else:
+            self.close_source_connection()
             Message(self.app, _('Project not merged'), _("Project not merged")).exec()
+
+    def close_source_connection(self):
+        """ Release the source project database. """
+
+        if self.conn_s is not None:
+            try:
+                self.conn_s.close()
+            except sqlite3.Error as err:
+                logger.warning(f"Closing source project database: {err}")
+            self.conn_s = None
 
     def _emit_project_table_changes(self, tables):
         """Notify other open dialogs about changed project tables."""
 
         if getattr(self.app, "project_events", None) is not None:
             self.app.project_events.emit_table_changes(tables, source=self)
+
+    def build_preview(self):
+        """ Read only summary of what the merge would add. Runs after get_source_data and
+        before anything is written.
+        Return: [{'title': str, 'detail': str, 'items': [str], 'warning': bool}, ...]
+        """
+
+        cur_s = self.conn_s.cursor()
+        cur_d = self.conn_d.cursor()
+        sections = []
+
+        def add(title, detail, items=None, warning=False):
+            items = list(items or [])
+            # Cap the listed names, the section count still carries the full figure
+            if len(items) > MAX_LISTED_ITEMS:
+                remaining = len(items) - MAX_LISTED_ITEMS
+                items = items[:MAX_LISTED_ITEMS] + [_("and more, not listed: ") + str(remaining)]
+            sections.append({'title': title, 'detail': detail, 'items': items, 'warning': warning})
+
+        # Files
+        new_files = []
+        matched_files = []
+        length_warnings = []
+        for src in self.source_s:
+            cur_d.execute("select id, length(fulltext) from source where name=?", [src['name']])
+            res = cur_d.fetchone()
+            if res is None:
+                new_files.append(src['name'])
+                continue
+            matched_files.append(src['name'])
+            if src['fulltext'] is not None and len(src['fulltext']) != res[1]:
+                length_warnings.append(
+                    src['name'] + " " + _("source: ") + f"{len(src['fulltext'])} " +
+                    _("destination: ") + f"{res[1]}")
+        add(_("Files to add"), str(len(new_files)), new_files)
+        add(_("Files already in this project"), str(len(matched_files)), matched_files)
+        if length_warnings:
+            add(_("Warning: different text lengths for the same file name"),
+                str(len(length_warnings)), length_warnings, warning=True)
+
+        # Media files to copy into the project folders
+        files_to_copy = []
+        for folder_name in ("audio", "documents", "images", "video"):
+            source_dir = Path(self.path_s) / folder_name
+            if not source_dir.is_dir():
+                continue
+            for file_ in source_dir.iterdir():
+                if file_.is_file() and not (Path(self.app.project_path) / folder_name / file_.name).exists():
+                    files_to_copy.append(f"{folder_name}/{file_.name}")
+        add(_("Media files to copy"), str(len(files_to_copy)), files_to_copy)
+
+        # Categories. get_source_data already removed names present in the destination
+        cur_s.execute("select count(*) from code_cat")
+        total_cats = cur_s.fetchone()[0]
+        new_cat_names = [c['name'] for c in self.categories_s]
+        add(_("Code categories to add"), str(len(new_cat_names)), new_cat_names)
+        add(_("Code categories already in this project"), str(total_cats - len(new_cat_names)))
+
+        # Codes
+        cur_d.execute("select name from code_name")
+        dest_code_names = [r[0] for r in cur_d.fetchall()]
+        new_codes = [c['name'] for c in self.codes_s if c['name'] not in dest_code_names]
+        matched_codes = [c['name'] for c in self.codes_s if c['name'] in dest_code_names]
+        add(_("Codes to add"), str(len(new_codes)), new_codes)
+        add(_("Codes matched to existing codes"), str(len(matched_codes)), matched_codes)
+
+        # Codings. Counts are what will actually be added, so rows already in the destination
+        # and duplicates inside the source are excluded. New codes and files get placeholder keys
+        cur_d.execute("select name, id from source")
+        dest_file_ids = {r[0]: r[1] for r in cur_d.fetchall()}
+        cur_d.execute("select name, cid from code_name")
+        dest_code_ids = {r[0]: r[1] for r in cur_d.fetchall()}
+        source_code_names = {c['cid']: c['name'] for c in self.codes_s}
+        source_file_names = {s['id']: s['name'] for s in self.source_s}
+
+        def code_key(cid):
+            """ Destination cid, or a placeholder for a code not there yet. """
+
+            name = source_code_names.get(cid)
+            if name is None:
+                return None  # No code row in the source
+            return dest_code_ids.get(name, ('new_code', name))
+
+        def file_key(fid):
+            """ Destination file id, or a placeholder for a file not there yet. """
+
+            name = source_file_names.get(fid)
+            if name is None:
+                return None  # No file row in the source
+            return dest_file_ids.get(name, ('new_file', name))
+
+        def split_new(rows, dest_sql, key_builder):
+            """ Return (to_add, already_there, orphans) for the source rows. """
+
+            cur_d.execute(dest_sql)
+            seen = set(cur_d.fetchall())
+            to_add, already_there, orphans = 0, 0, 0
+            for row in rows:
+                key = key_builder(row)
+                if key is None:
+                    orphans += 1
+                    continue
+                if key in seen:
+                    already_there += 1
+                    continue
+                seen.add(key)
+                to_add += 1
+            return to_add, already_there, orphans
+
+        def text_key(c):
+            cid, fid = code_key(c['cid']), file_key(c['fid'])
+            return None if cid is None or fid is None else (cid, fid, c['pos0'], c['pos1'], c['owner'])
+
+        def image_key(c):
+            cid, fid = code_key(c['cid']), file_key(c['fid'])
+            if cid is None or fid is None:
+                return None
+            return cid, fid, c['x1'], c['y1'], c['width'], c['height'], c['owner'], c['pdf_page']
+
+        def av_key(c):
+            cid, fid = code_key(c['cid']), file_key(c['fid'])
+            return None if cid is None or fid is None else (cid, fid, c['pos0'], c['pos1'], c['owner'])
+
+        def annotation_key(a):
+            fid = file_key(a['fid'])
+            return None if fid is None else (fid, a['pos0'], a['pos1'], a['owner'])
+
+        orphan_total = 0
+        text_add, text_old, orphans = split_new(
+            self.code_text_s, "select cid, fid, pos0, pos1, owner from code_text", text_key)
+        orphan_total += orphans
+        pdf_rows = [c for c in self.code_image_s if c['pdf_page'] is not None]
+        image_rows = [c for c in self.code_image_s if c['pdf_page'] is None]
+        image_sql = "select cid, id, x1, y1, width, height, owner, pdf_page from code_image"
+        pdf_add, pdf_old, orphans = split_new(pdf_rows, image_sql, image_key)
+        orphan_total += orphans
+        image_add, image_old, orphans = split_new(image_rows, image_sql, image_key)
+        orphan_total += orphans
+        av_add, av_old, orphans = split_new(
+            self.code_av_s, "select cid, id, pos0, pos1, owner from code_av", av_key)
+        orphan_total += orphans
+        annot_add, annot_old, orphans = split_new(
+            self.annotations_s, "select fid, pos0, pos1, owner from annotation", annotation_key)
+        orphan_total += orphans
+        add(_("Coded text segments to add"), str(text_add))
+        add(_("Coded PDF areas to add"), str(pdf_add))
+        add(_("Coded image areas to add"), str(image_add))
+        add(_("Coded audio/video segments to add"), str(av_add))
+        add(_("Text annotations to add"), str(annot_add))
+        already_there = text_old + pdf_old + image_old + av_old + annot_old
+        if already_there > 0:
+            add(_("Codings already in this project, not duplicated"), str(already_there))
+        if orphan_total > 0:
+            add(_("Codings skipped, missing code or file in the source project"),
+                str(orphan_total), warning=True)
+
+        # Cases. A source case whose name is in the destination is skipped with its links
+        cur_d.execute("select name from cases")
+        dest_case_names = [r[0] for r in cur_d.fetchall()]
+        new_cases = [c for c in self.cases_s if c['name'] not in dest_case_names]
+        skipped_cases = [c['name'] for c in self.cases_s if c['name'] in dest_case_names]
+        new_case_ids = [c['caseid'] for c in new_cases]
+        # Inserted only when both case and file resolve
+        case_links = len([ct for ct in self.case_text_s
+                          if ct['caseid'] in new_case_ids and ct['fid'] in source_file_names])
+        add(_("Cases to add"), str(len(new_cases)), [c['name'] for c in new_cases])
+        add(_("Cases skipped, name already in this project"), str(len(skipped_cases)), skipped_cases)
+        add(_("Case file links to add"), str(case_links))
+
+        # Journals and stored queries
+        cur_d.execute("select name from journal")
+        dest_journal_names = [r[0] for r in cur_d.fetchall()]
+        new_journals = [j['name'] for j in self.journals_s if j['name'] not in dest_journal_names]
+        skipped_journals = [j['name'] for j in self.journals_s if j['name'] in dest_journal_names]
+        add(_("Journals to add"), str(len(new_journals)), new_journals)
+        add(_("Journals skipped, name already in this project"), str(len(skipped_journals)), skipped_journals)
+        cur_d.execute("select title from stored_sql")
+        dest_sql_titles = [r[0] for r in cur_d.fetchall()]
+        new_sql = [s['title'] for s in self.stored_sql_s if s['title'] not in dest_sql_titles]
+        add(_("Stored queries to add"), str(len(new_sql)), new_sql)
+
+        # Attributes. get_source_data already removed types present in the destination
+        add(_("Attribute types to add"), str(len(self.attribute_types_s)),
+            [f"{a['name']} ({a['caseOrFile']})" for a in self.attribute_types_s])
+        # Values carry over for files, and for cases being added
+        attribute_values = len([a for a in self.attributes_s
+                                if (a['attr_type'] == "file" and a['id'] in source_file_names)
+                                or (a['attr_type'] == "case" and a['id'] in new_case_ids)])
+        add(_("Attribute values"), str(attribute_values))
+        return sections
+
+    def report_text(self, merged):
+        """ Plain text preview for the journal entry. merged: False if cancelled. """
+
+        lines = [_("Merge preview"), "",
+                 _("Merging: ") + self.path_s,
+                 _("Into: ") + self.path_d,
+                 _("Date: ") + datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S"),
+                 _("Result: ") + (_("merged") if merged else _("cancelled, no changes were made")),
+                 ""]
+        for section in self.preview_sections:
+            lines.append(f"{section['title']}: {section['detail']}")
+            for item in section['items']:
+                lines.append(f"    {item}")
+        return "\n".join(lines)
+
+    def save_report_to_journal(self, merged):
+        """ Store the report as a journal entry. Journal names must be unique. """
+
+        now = datetime.datetime.now().astimezone()
+        date = now.strftime("%Y-%m-%d %H:%M:%S")
+        owner = self.app.settings['codername']
+        # Valid journal name: no dots or colons, and unique
+        name = re.sub(r"[^\w -]", "_", f"Merge preview {Path(self.path_s).stem} {now.strftime('%Y-%m-%d %H%M%S')}")
+        jentry = self.report_text(merged)
+        cur = self.conn_d.cursor()
+        attempt = name
+        suffix = 2
+        while True:
+            try:
+                cur.execute("insert into journal(name,jentry,owner,date) values(?,?,?,?)",
+                            (attempt, jentry, owner, date))
+                self.conn_d.commit()
+                break
+            except sqlite3.IntegrityError:
+                self.conn_d.rollback()
+                attempt = f"{name}_{suffix}"
+                suffix += 1
+                if suffix > 50:
+                    logger.warning("Could not create the merge preview journal entry")
+                    return
+        self.app.delete_backup = False
+        self.summary_msg += _("Merge report saved to journal: ") + attempt + "\n"
+        self._emit_project_table_changes(['journal'])
 
     def insert_categories(self):
         """ Insert categories into destination code_cat table.
@@ -140,7 +483,6 @@ class MergeProjects:
 
         if len(self.categories_s) > 0:
             self.summary_msg += str(len(self.categories_s)) + _(" categories not added") + "\n"
-            print("Categories NOT added:\n", self.categories_s)
             logger.debug("Categories NOT added:\n" + str(self.categories_s))
 
     def update_code_cid_and_insert_code(self):
@@ -230,35 +572,77 @@ class MergeProjects:
             cur_d.execute("insert or ignore into stored_sql (title, description, grouper, ssql) values(?,?,?,?)",
                           (s['title'], s['description'], s['grouper'], s['ssql']))
             self.conn_d.commit()
+        # A/V goes in before coded text, so code_text.avid can be remapped to the new avid.
+        # code_av and code_image have no unique constraint, so 'insert or ignore' would not stop
+        # duplicates: existing rows are matched by key set, which keeps a repeated merge idempotent
+        skipped_orphans = 0
+        avid_map = {}
+        cur_d.execute("select avid, cid, id, pos0, pos1, owner from code_av")
+        existing_av = {}
+        for row in cur_d.fetchall():
+            existing_av.setdefault(tuple(row[1:]), row[0])
+        for c in self.code_av_s:
+            if c['newcid'] == -1 or c['newfid'] == -1:
+                skipped_orphans += 1
+                continue
+            key = (c['newcid'], c['newfid'], c['pos0'], c['pos1'], c['owner'])
+            if key in existing_av:
+                c['newavid'] = existing_av[key]
+            else:
+                cur_d.execute(
+                    "insert into code_av (cid, id,pos0,pos1,memo,owner,date,important) values(?,?,?,?,?,?,?,?)",
+                    [c["newcid"], c["newfid"], c["pos0"], c["pos1"], c["memo"], c["owner"], c["date"],
+                     c["important"]])
+                self.conn_d.commit()
+                c['newavid'] = cur_d.lastrowid
+                existing_av[key] = c['newavid']
+            if c['avid'] is not None:
+                avid_map[c['avid']] = c['newavid']
+        if len(self.code_av_s) > 0:
+            self.summary_msg += _("Merging coded audio/video segments") + "\n"
         for c in self.code_text_s:
+            if c['newcid'] == -1 or c['newfid'] == -1:
+                skipped_orphans += 1
+                continue
+            c['newavid'] = avid_map.get(c['avid']) if c['avid'] is not None else None
             cur_d.execute("insert or ignore into code_text (cid,fid,seltext,pos0,pos1,owner,\
-                memo,date, important) values(?,?,?,?,?,?,?,?,?)", (c['newcid'], c['newfid'],
-                                                                   c['seltext'], c['pos0'], c['pos1'], c['owner'],
-                                                                   c['memo'], c['date'], c['important']))
+                memo,date, important, avid) values(?,?,?,?,?,?,?,?,?,?)", (c['newcid'], c['newfid'],
+                                                                           c['seltext'], c['pos0'], c['pos1'],
+                                                                           c['owner'], c['memo'], c['date'],
+                                                                           c['important'], c['newavid']))
             self.conn_d.commit()
         if len(self.code_text_s) > 0:
             self.summary_msg += _("Merging coded text") + "\n"
         for a in self.annotations_s:
+            if a['newfid'] == -1:
+                skipped_orphans += 1
+                continue
             cur_d.execute("insert or ignore into annotation (fid,pos0,pos1,memo,owner,date) values(?,?,?,?,?,?)",
                           [a["newfid"], a["pos0"], a["pos1"], a["memo"], a["owner"], a["date"]])
             self.conn_d.commit()
         if len(self.annotations_s) > 0:
             self.summary_msg += _("Merging annotations") + "\n"
+        cur_d.execute("select cid, id, x1, y1, width, height, owner, pdf_page from code_image")
+        existing_images = set(cur_d.fetchall())
         for c in self.code_image_s:
+            if c['newcid'] == -1 or c['newfid'] == -1:
+                skipped_orphans += 1
+                continue
+            key = (c['newcid'], c['newfid'], c['x1'], c['y1'], c['width'], c['height'], c['owner'], c['pdf_page'])
+            if key in existing_images:
+                continue
             cur_d.execute(
-                "insert or ignore into code_image (cid, id,x1,y1,width,height,memo,owner,date,important) values(?,?,?,?,?,?,?,?,?,?)",
+                "insert into code_image (cid, id,x1,y1,width,height,memo,owner,date,important,pdf_page) "
+                "values(?,?,?,?,?,?,?,?,?,?,?)",
                 [c["newcid"], c["newfid"], c["x1"], c["y1"], c["width"], c["height"], c["memo"], c["owner"], c["date"],
-                 c["important"]])
+                 c["important"], c["pdf_page"]])
             self.conn_d.commit()
+            existing_images.add(key)
         if len(self.code_image_s) > 0:
             self.summary_msg += _("Merging coded image areas") + "\n"
-        for c in self.code_av_s:
-            cur_d.execute(
-                "insert or ignore into code_av (cid, id,pos0,pos1,memo,owner,date,important) values(?,?,?,?,?,?,?,?)",
-                [c["newcid"], c["newfid"], c["pos0"], c["pos1"], c["memo"], c["owner"], c["date"], c["important"]])
-            self.conn_d.commit()
-        if len(self.code_av_s) > 0:
-            self.summary_msg += _("Merging coded audio/video segments") + "\n"
+        if skipped_orphans > 0:
+            # Source codings whose code or file row is missing
+            self.summary_msg += _("Codings skipped, missing code or file: ") + f"{skipped_orphans}\n"
 
     def insert_cases(self):
         """ Insert case data into destination.
@@ -302,20 +686,23 @@ class MergeProjects:
                 if case_s['caseid'] == case_text['caseid']:
                     case_text['newcaseid'] = case_s['newcaseid']
             for file_ in self.source_s:
-                if case_text['fid'] == file_['newid']:
+                # fid is a source id. Matching newid loses links or points them at the wrong file
+                if case_text['fid'] == file_['id']:
                     case_text['newfid'] = file_['newid']
         # Insert case text if newfileid is not -1 and newcaseid is not -1
         for c in self.case_text_s:
             if c['newcaseid'] > -1 and c['newfid'] > -1:
-                cur_d.execute("insert into case_text (caseid,fid,pos0,pos1) values(?,?,?,?)",
-                              [c['newcaseid'], c['newfid'], c['pos0'], c['pos1']])
+                cur_d.execute("insert into case_text (caseid,fid,pos0,pos1,owner,date,memo) values(?,?,?,?,?,?,?)",
+                              [c['newcaseid'], c['newfid'], c['pos0'], c['pos1'], c['owner'], c['date'], c['memo']])
                 self.app.conn.commit()
         # Create attribute placeholders for the destination case attributes
         now_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
         sql_attribute_types = 'select name from attribute_type where caseOrFile ="case"'
         cur_d.execute(sql_attribute_types)
         res_attr_types = cur_d.fetchall()
-        sql_attribute = "insert into attribute (name, attr_type, value, id, date, owner) values(?,'file','',?,?,?)"
+        # Placeholders for cases, so attr_type is case, not file
+        sql_attribute = "insert or ignore into attribute (name, attr_type, value, id, date, owner) " \
+                        "values(?,'case','',?,?,?)"
         for id_ in new_case_ids:
             for attribute_name in res_attr_types:
                 cur_d.execute(sql_attribute, [attribute_name[0], id_, now_date, self.app.settings['codername']])
@@ -400,16 +787,22 @@ class MergeProjects:
         folders = ["audio", "documents", "images", "video"]
         for folder_name in folders:
             source_dir = Path(self.path_s) / folder_name  # self.path_s + "/" + folder_name
-            for file_ in Path(source_dir).iterdir():
-                dest_path = Path(self.app.project_path) / folder_name / file_
-                if not dest_path.exists(): 
+            if not source_dir.is_dir():
+                continue
+            dest_dir = Path(self.app.project_path) / folder_name
+            for file_ in source_dir.iterdir():
+                if not file_.is_file():
+                    continue
+                # iterdir yields absolute paths. Joining one replaces the destination folder
+                dest_path = dest_dir / file_.name
+                if not dest_path.exists():
                     try:
-                        shutil.copyfile(Path(source_dir) / file_, dest_path)
-                        self.summary_msg += _("File copied: ") + f"{file_}\n"
+                        shutil.copyfile(file_, dest_path)
+                        self.summary_msg += _("File copied: ") + f"{file_.name}\n"
                     except shutil.SameFileError:
                         pass
                     except PermissionError:
-                        self.summary_msg += f"{file_} " + _("NOT copied. Permission error")
+                        self.summary_msg += f"{file_.name} " + _("NOT copied. Permission error")
 
     def insert_new_attribute_types(self):
         """ Insert new attribute types  for cases and files.
@@ -494,12 +887,21 @@ class MergeProjects:
         self.code_av_s = []
         self.cases_s = []
         self.case_text_s = []
+        self.source_s = []
         self.attribute_types_s = []
         self.attributes_s = []
         cur_s = self.conn_s.cursor()
         # Database version must be v5 or higher
-        cur_s.execute("select databaseversion from project")
-        version = cur_s.fetchone()
+        try:
+            cur_s.execute("select databaseversion from project")
+            version = cur_s.fetchone()
+        except sqlite3.DatabaseError as err:
+            logger.warning(f"Merge source project: {err}")
+            version = None
+        if version is None or version[0] is None:
+            self.summary_msg += _("Could not read the source project database.") + "\n"
+            self.summary_msg += _("Project not merged") + "\n"
+            return False
         if version[0] in ("v1", "v2", "v3", "v4"):
             self.summary_msg += _("Need to update the source project database.") + "\n"
             self.summary_msg += _("Please open the source project using QualCoder. Then close the project.") + "\n"
@@ -583,13 +985,13 @@ class MergeProjects:
                 res = cur_s.fetchone()
                 if res is not None:
                     code_s['supercodename'] = res[0]
-        # Code text data
-        sql_codetext = "select cid, fid, seltext, pos0, pos1, owner, date, memo, important from code_text"
+        # Code text data. avid links a transcript coding to its A/V segment, remapped on insert
+        sql_codetext = "select cid, fid, seltext, pos0, pos1, owner, date, memo, important, avid from code_text"
         cur_s.execute(sql_codetext)
         res_codetext = cur_s.fetchall()
         for i in res_codetext:
             ct = {"cid": i[0], "newcid": -1, "fid": i[1], "newfid": -1, "seltext": i[2], "pos0": i[3], "pos1": i[4],
-                  "owner": i[5], "date": i[6], "memo": i[7], "important": i[8]}
+                  "owner": i[5], "date": i[6], "memo": i[7], "important": i[8], "avid": i[9], "newavid": None}
             self.code_text_s.append(ct)
         # Text annotations data
         sql_annotations = "select fid, pos0, pos1, memo, owner, date from annotation"
@@ -598,21 +1000,27 @@ class MergeProjects:
         for i in res_annot:
             an = {"fid": i[0], "newfid": -1, "pos0": i[1], "pos1": i[2], "memo": i[3], "owner": i[4], "date": i[5]}
             self.annotations_s.append(an)
-        # Code image data
-        sql_code_img = "select cid, id, x1, y1, width, height, memo, date, owner, important from code_image"
+        # Code image data. pdf_page is the page of an area coded on a PDF.
+        # Databases older than v10 lack the column, so select a null placeholder
+        cur_s.execute("pragma table_info(code_image)")
+        code_image_columns = [r[1] for r in cur_s.fetchall()]
+        pdf_page_column = "pdf_page" if "pdf_page" in code_image_columns else "null"
+        sql_code_img = "select cid, id, x1, y1, width, height, memo, date, owner, important, " \
+                       f"{pdf_page_column} from code_image"
         cur_s.execute(sql_code_img)
         res_code_img = cur_s.fetchall()
         for i in res_code_img:
             cimg = {"cid": i[0], "newcid": -1, "fid": i[1], "newfid": -1, "x1": i[2], "y1": i[3],
-                    "width": i[4], "height": i[5], "memo": i[6], "date": i[7], "owner": i[8], "important": i[9]}
+                    "width": i[4], "height": i[5], "memo": i[6], "date": i[7], "owner": i[8], "important": i[9],
+                    "pdf_page": i[10]}
             self.code_image_s.append(cimg)
-        # Code AV data
-        sql_code_av = "select cid, id, pos0, pos1, owner, date, memo, important from code_av"
+        # Code AV data. avid is kept to remap code_text.avid
+        sql_code_av = "select cid, id, pos0, pos1, owner, date, memo, important, avid from code_av"
         cur_s.execute(sql_code_av)
         res_code_av = cur_s.fetchall()
         for i in res_code_av:
             c_av = {"cid": i[0], "newcid": -1, "fid": i[1], "newfid": -1, "pos0": i[2], "pos1": i[3],
-                    "owner": i[4], "date": i[5], "memo": i[6], "important": i[7]}
+                    "owner": i[4], "date": i[5], "memo": i[6], "important": i[7], "avid": i[8], "newavid": None}
             self.code_av_s.append(c_av)
         # Case data
         sql_cases = "select caseid, name, memo, owner, date from cases"
@@ -621,11 +1029,12 @@ class MergeProjects:
         for i in res_cases:
             c = {"caseid": i[0], "newcaseid": -1, "name": i[1], "memo": i[2], "owner": i[3], "date": i[4]}
             self.cases_s.append(c)
-        sql_case_text = "select caseid, fid, pos0, pos1 from case_text"
+        sql_case_text = "select caseid, fid, pos0, pos1, owner, date, memo from case_text"
         cur_s.execute(sql_case_text)
         res_case_text = cur_s.fetchall()
         for i in res_case_text:
-            c = {"caseid": i[0], "newcaseid": -1, "fid": i[1], "newfid": -1, "pos0": i[2], "pos1": i[3]}
+            c = {"caseid": i[0], "newcaseid": -1, "fid": i[1], "newfid": -1, "pos0": i[2], "pos1": i[3],
+                 "owner": i[4], "date": i[5], "memo": i[6]}
             self.case_text_s.append(c)
         # Attribute type data
         sql_attr_type = "select name, memo, date, owner, caseOrFile, valuetype from attribute_type"

--- a/src/qualcoder/merge_projects.py
+++ b/src/qualcoder/merge_projects.py
@@ -92,7 +92,12 @@ class MergeProgress:
             raise MergeCancelled()
 
     def hide(self):
+        """ reset() first: hide() alone leaves Qt's pending auto-show timer armed, and it
+        fires during the preview dialog's event loop, putting a modal dialog back on top.
+        """
+
         if self.dialog is not None:
+            self.dialog.reset()
             self.dialog.hide()
 
     def restart(self):

--- a/src/qualcoder/merge_projects.py
+++ b/src/qualcoder/merge_projects.py
@@ -38,6 +38,77 @@ logger = logging.getLogger(__name__)
 MAX_LISTED_ITEMS = 200
 
 
+class MergeCancelled(Exception):
+    """ Raised when the user cancels from the progress dialog. """
+
+
+class MergeProgress:
+    """ Progress dialog for the merge phases. Keeps the interface responsive and
+    raises MergeCancelled when the user cancels. No-op without a running application.
+    """
+
+    def __init__(self, app, parent=None):
+
+        self.dialog = None
+        if QtWidgets.QApplication.instance() is None:
+            return
+        self.dialog = QtWidgets.QProgressDialog("", _("Cancel"), 0, 100, parent)
+        self.dialog.setWindowTitle(_("Merge projects"))
+        self.dialog.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        self.dialog.setMinimumDuration(400)  # Do not flash on a small project
+        self.dialog.setAutoClose(False)
+        self.dialog.setAutoReset(False)
+        self.dialog.setStyleSheet(f'font: {app.settings["fontsize"]}pt "{app.settings["font"]}";')
+        self.dialog.setValue(0)
+
+    def phase(self, label, value, repaint=True):
+        """ Move to the next phase. repaint=False skips event processing, which is required
+        while the merge transaction is open: repainting lets timers in other dialogs run,
+        and they write to the shared connection.
+        """
+
+        if self.dialog is None:
+            return
+        self.dialog.setLabelText(label)
+        self.dialog.setValue(value)
+        if repaint:
+            self.check()
+
+    def tick(self, index, total, base, span, every=100):
+        """ Update from inside a long loop, at intervals. """
+
+        if self.dialog is None or index % every or not total:
+            return
+        self.dialog.setValue(base + int(span * index / total))
+        self.check()
+
+    def check(self):
+        """ Repaint and raise if the user pressed Cancel. """
+
+        if self.dialog is None:
+            return
+        QtWidgets.QApplication.processEvents()
+        if self.dialog.wasCanceled():
+            raise MergeCancelled()
+
+    def hide(self):
+        if self.dialog is not None:
+            self.dialog.hide()
+
+    def restart(self):
+        """ Re-arm after hide(), which otherwise stops the dialog re-appearing. """
+
+        if self.dialog is None:
+            return
+        self.dialog.reset()  # Also clears the cancel flag
+        self.dialog.setValue(0)
+
+    def close(self):
+        if self.dialog is not None:
+            self.dialog.close()
+            self.dialog = None
+
+
 class DialogMergePreview(QtWidgets.QDialog):
     """ Read only preview of what a merge would add, by section with counts and names.
     Nothing is written yet, so Cancel leaves the project untouched.
@@ -118,7 +189,9 @@ class MergeProjects:
         self.app = app
         self.path_s = path_s  # Path to source project folder
         self.conn_s = None  # Source project that is to be merged from
-        self.conn_d = self.app.conn  # Destination project - the currently opened project
+        # The merge runs in one transaction. Other open dialogs have timers that write and commit
+        # on app.conn, and progress repaints let them run, so use a connection of our own
+        self.conn_d = None  # Destination project - the currently opened project
         self.path_d = self.app.project_path  # Path to destination project folder
         self.summary_msg = _("Merging: ") + self.path_s + "\n" + _("Into: ") + self.app.project_path + "\n"
         self.projects_merged = False
@@ -137,34 +210,50 @@ class MergeProjects:
         self.case_text_s = []  # case text and links to non-text files
         self.preview_sections = []  # Read only summary of what would be added
         self.merge_cancelled = False
+        self.copied_files = []  # Removed again if the merge is cancelled
+        self.progress = MergeProgress(self.app)
         # Connecting to a missing file would create an empty database in the user folder
         db_path_s = Path(self.path_s) / 'data.qda'
         if not db_path_s.is_file():
             self.summary_msg += _("No data.qda database found in the selected folder.") + "\n"
+            self.progress.close()
             Message(self.app, _('Project not merged'), _("Not a QualCoder project")).exec()
             return
         self.conn_s = sqlite3.connect(db_path_s)
-        # Nothing is written until the preview is confirmed, so Cancel leaves the project untouched
-        loaded = self.get_source_data()
+        # timeout lets a write by another dialog finish rather than fail outright
+        self.conn_d = sqlite3.connect(Path(self.path_d) / 'data.qda', timeout=30)
         save_journal = False
-        if loaded:
-            self.preview_sections = self.build_preview()
-            if show_preview:
-                preview_dialog = DialogMergePreview(self.app, self.preview_sections, self.path_s)
-                proceed = preview_dialog.exec()
-                save_journal = preview_dialog.save_to_journal()
-                if not proceed:
-                    self.merge_cancelled = True
-                    self.summary_msg += "\n" + _("Merge cancelled. No changes were made.") + "\n"
-                    if save_journal:
-                        self.save_report_to_journal(merged=False)
-                    self.close_source_connection()
-                    Message(self.app, _('Project not merged'), _("Merge cancelled")).exec()
-                    return
-        if loaded:
+        try:
+            self.progress.phase(_("Reading the project to merge"), 2)
+            loaded = self.get_source_data()
+            if loaded:
+                self.progress.phase(_("Preparing the preview"), 10)
+                self.preview_sections = self.build_preview()
+        except MergeCancelled:
+            self.cancel_merge(save_journal=False)
+            return
+        if not loaded:
+            self.close_connections()
+            Message(self.app, _('Project not merged'), _("Project not merged")).exec()
+            return
+        self.progress.hide()
+        if show_preview:
+            preview_dialog = DialogMergePreview(self.app, self.preview_sections, self.path_s)
+            proceed = preview_dialog.exec()
+            save_journal = preview_dialog.save_to_journal()
+            if not proceed:
+                self.cancel_merge(save_journal)
+                return
+        # Everything below is one transaction, so a cancel or an error rolls the project back
+        try:
+            self.progress.restart()
+            self.progress.phase(_("Copying files"), 15)
             self.copy_source_files_into_destination()
             msg, backup_name = self.app.save_backup("_Pre-merge")
             self.summary_msg += f"\n{msg}"
+            # From here the transaction is open, so no more event processing and no cancel.
+            # The database phase runs well under a second even on a very large project
+            self.progress.phase(_("Merging"), 40, repaint=False)
             self.insert_sources_get_new_file_ids()
             self.update_coding_file_ids()
             self.insert_categories()
@@ -173,35 +262,78 @@ class MergeProjects:
             self.insert_cases()
             self.insert_new_attribute_types()
             self.insert_attributes()
+            self.conn_d.commit()  # One transaction for the whole merge
+        except MergeCancelled:
+            self.conn_d.rollback()
+            self.cancel_merge(save_journal)
+            return
+        except Exception as err:
+            # Broad on purpose: an escaping error would leave an open transaction and a modal
+            # progress dialog on screen
+            self.conn_d.rollback()
+            self.remove_copied_files()
+            logger.exception("Merge projects failed")
+            self.summary_msg += "\n" + _("Merge failed, no changes were made. ") + f"{err}\n"
+            self.close_connections()
+            Message(self.app, _('Project not merged'), _("Merge failed") + f"\n{err}").exec()
+            return
+        try:
+            self.progress.phase(_("Finishing"), 95, repaint=False)
             # Update vectorstore
             if self.app.settings['ai_enable'] == 'True':
                 self.app.ai.sources_vectorstore.update_vectorstore()
-            self.summary_msg += "\n" + _("Finished merging ") + f"{self.path_s}  --> {self.path_d}\n"
-            self.summary_msg += _(
-                "Existing values in destination project are not over-written, apart from blank attribute values.") + "\n"
-            # One event for the whole merge, not one per inserted row
-            self._emit_project_table_changes(
-                ['source', 'code_name', 'code_cat', 'code_text', 'code_image', 'code_av',
-                 'cases', 'case_text', 'attribute', 'attribute_type', 'journal', 'annotation'])
-            self.projects_merged = True
-            self.app.delete_backup = False
-            if save_journal:
-                self.save_report_to_journal(merged=True)
-            self.close_source_connection()
-            Message(self.app, _('Project merged'), _("Review the action log for details.")).exec()
-        else:
-            self.close_source_connection()
-            Message(self.app, _('Project not merged'), _("Project not merged")).exec()
+        except Exception as err:
+            # The merge itself is committed, so report and carry on
+            logger.exception("Vectorstore update after merge failed")
+            self.summary_msg += _("Could not update the AI vectorstore: ") + f"{err}\n"
+        self.summary_msg += "\n" + _("Finished merging ") + f"{self.path_s}  --> {self.path_d}\n"
+        self.summary_msg += _(
+            "Existing values in destination project are not over-written, apart from blank attribute values.") + "\n"
+        # One event for the whole merge, not one per inserted row
+        self._emit_project_table_changes(
+            ['source', 'code_name', 'code_cat', 'code_text', 'code_image', 'code_av',
+             'cases', 'case_text', 'attribute', 'attribute_type', 'journal', 'annotation'])
+        self.projects_merged = True
+        self.app.delete_backup = False
+        if save_journal:
+            self.save_report_to_journal(merged=True)
+        self.close_connections()
+        Message(self.app, _('Project merged'), _("Review the action log for details.")).exec()
 
-    def close_source_connection(self):
-        """ Release the source project database. """
+    def cancel_merge(self, save_journal):
+        """ Undo anything copied, report and release the source project. """
 
-        if self.conn_s is not None:
+        self.merge_cancelled = True
+        self.remove_copied_files()
+        self.summary_msg += "\n" + _("Merge cancelled. No changes were made.") + "\n"
+        if save_journal and self.preview_sections:
+            self.save_report_to_journal(merged=False)
+        self.close_connections()
+        Message(self.app, _('Project not merged'), _("Merge cancelled")).exec()
+
+    def remove_copied_files(self):
+        """ Delete media files copied during a merge that did not complete. """
+
+        for file_path in self.copied_files:
             try:
-                self.conn_s.close()
+                Path(file_path).unlink(missing_ok=True)
+            except OSError as err:
+                logger.warning(f"Could not remove {file_path}: {err}")
+        self.copied_files = []
+
+    def close_connections(self):
+        """ Close the progress dialog and release both project databases. """
+
+        self.progress.close()
+        for name in ('conn_s', 'conn_d'):
+            conn = getattr(self, name)
+            if conn is None:
+                continue
+            try:
+                conn.close()
             except sqlite3.Error as err:
-                logger.warning(f"Closing source project database: {err}")
-            self.conn_s = None
+                logger.warning(f"Closing {name}: {err}")
+            setattr(self, name, None)
 
     def _emit_project_table_changes(self, tables):
         """Notify other open dialogs about changed project tables."""
@@ -238,9 +370,9 @@ class MergeProjects:
                 new_files.append(src['name'])
                 continue
             matched_files.append(src['name'])
-            if src['fulltext'] is not None and len(src['fulltext']) != res[1]:
+            if src['fulltext_len'] is not None and src['fulltext_len'] != res[1]:
                 length_warnings.append(
-                    src['name'] + " " + _("source: ") + f"{len(src['fulltext'])} " +
+                    src['name'] + " " + _("source: ") + f"{src['fulltext_len']} " +
                     _("destination: ") + f"{res[1]}")
         add(_("Files to add"), str(len(new_files)), new_files)
         add(_("Files already in this project"), str(len(matched_files)), matched_files)
@@ -457,7 +589,6 @@ class MergeProjects:
                 self.summary_msg += _("Adding top level category: ") + c['name'] + "\n"
                 cur_d.execute("insert into code_cat (name,memo,owner,date,supercatid) values(?,?,?,?,?)",
                               (c['name'], c['memo'], c['owner'], c['date'], c['supercatid']))
-                self.conn_d.commit()
                 remove_list.append(c)
         for item in remove_list:
             self.categories_s.remove(item)
@@ -475,7 +606,6 @@ class MergeProjects:
                     remove_list.append(c)
                     sql = "insert into code_cat (name, memo, owner, date, supercatid) values (?,?,?,?,?)"
                     cur_d.execute(sql, [c['name'], c['memo'], c['owner'], c['date'], res_category[0]])
-                    self.conn_d.commit()
                     self.summary_msg += _("Adding sub-category: ") + f"{c['name']} --> {c['supercatname']}\n"
             for item in remove_list:
                 self.categories_s.remove(item)
@@ -512,7 +642,6 @@ class MergeProjects:
                 cur_d.execute("insert into code_name (name,memo,owner,date,catid,color) values(?,?,?,?,?,?)",
                               (code_s['name'], code_s['memo'], code_s['owner'], code_s['date'], code_s['catid'],
                                code_s['color']))
-                self.conn_d.commit()
                 cur_d.execute("select last_insert_rowid()")
                 cid = cur_d.fetchone()[0]
                 code_s['newcid'] = cid
@@ -534,19 +663,12 @@ class MergeProjects:
                 if parent_newcid is not None and parent_newcid != code_s['newcid']:
                     cur_d.execute("update code_name set supercid=?, catid=null where cid=?",
                                   [parent_newcid, code_s['newcid']])
-        self.conn_d.commit()
 
         # Update code_text, code_image, code_av cids to destination values
-        for code_s in self.codes_s:
-            for coding_text in self.code_text_s:
-                if coding_text['cid'] == code_s['cid']:
-                    coding_text['newcid'] = code_s['newcid']
-            for coding_image in self.code_image_s:
-                if coding_image['cid'] == code_s['cid']:
-                    coding_image['newcid'] = code_s['newcid']
-            for coding_av in self.code_av_s:
-                if coding_av['cid'] == code_s['cid']:
-                    coding_av['newcid'] = code_s['newcid']
+        new_cids = {code_s['cid']: code_s['newcid'] for code_s in self.codes_s}
+        for rows in (self.code_text_s, self.code_image_s, self.code_av_s):
+            for row in rows:
+                row['newcid'] = new_cids.get(row['cid'], -1)
 
     def insert_coding_and_journal_data(self):
         """ Coding fid and cid have been updated, annotation fid has been updated.
@@ -566,12 +688,10 @@ class MergeProjects:
                 cur_d.execute("insert into journal (name, jentry, date, owner) values(?,?,?,?)",
                               (j['name'], j['jentry'], j['date'], j['owner']))
                 self.summary_msg += _("Adding journal: ") + j['name'] + "\n"
-                self.conn_d.commit()
         for s in self.stored_sql_s:
             # Cannot have two identical stored_sql titles, using 'or ignore'
             cur_d.execute("insert or ignore into stored_sql (title, description, grouper, ssql) values(?,?,?,?)",
                           (s['title'], s['description'], s['grouper'], s['ssql']))
-            self.conn_d.commit()
         # A/V goes in before coded text, so code_text.avid can be remapped to the new avid.
         # code_av and code_image have no unique constraint, so 'insert or ignore' would not stop
         # duplicates: existing rows are matched by key set, which keeps a repeated merge idempotent
@@ -581,6 +701,7 @@ class MergeProjects:
         existing_av = {}
         for row in cur_d.fetchall():
             existing_av.setdefault(tuple(row[1:]), row[0])
+        self.progress.phase(_("Merging audio/video codings"), 40, repaint=False)
         for c in self.code_av_s:
             if c['newcid'] == -1 or c['newfid'] == -1:
                 skipped_orphans += 1
@@ -593,13 +714,13 @@ class MergeProjects:
                     "insert into code_av (cid, id,pos0,pos1,memo,owner,date,important) values(?,?,?,?,?,?,?,?)",
                     [c["newcid"], c["newfid"], c["pos0"], c["pos1"], c["memo"], c["owner"], c["date"],
                      c["important"]])
-                self.conn_d.commit()
                 c['newavid'] = cur_d.lastrowid
                 existing_av[key] = c['newavid']
             if c['avid'] is not None:
                 avid_map[c['avid']] = c['newavid']
         if len(self.code_av_s) > 0:
             self.summary_msg += _("Merging coded audio/video segments") + "\n"
+        self.progress.phase(_("Merging coded text"), 55, repaint=False)
         for c in self.code_text_s:
             if c['newcid'] == -1 or c['newfid'] == -1:
                 skipped_orphans += 1
@@ -610,7 +731,6 @@ class MergeProjects:
                                                                            c['seltext'], c['pos0'], c['pos1'],
                                                                            c['owner'], c['memo'], c['date'],
                                                                            c['important'], c['newavid']))
-            self.conn_d.commit()
         if len(self.code_text_s) > 0:
             self.summary_msg += _("Merging coded text") + "\n"
         for a in self.annotations_s:
@@ -619,11 +739,11 @@ class MergeProjects:
                 continue
             cur_d.execute("insert or ignore into annotation (fid,pos0,pos1,memo,owner,date) values(?,?,?,?,?,?)",
                           [a["newfid"], a["pos0"], a["pos1"], a["memo"], a["owner"], a["date"]])
-            self.conn_d.commit()
         if len(self.annotations_s) > 0:
             self.summary_msg += _("Merging annotations") + "\n"
         cur_d.execute("select cid, id, x1, y1, width, height, owner, pdf_page from code_image")
         existing_images = set(cur_d.fetchall())
+        self.progress.phase(_("Merging coded image and PDF areas"), 75, repaint=False)
         for c in self.code_image_s:
             if c['newcid'] == -1 or c['newfid'] == -1:
                 skipped_orphans += 1
@@ -636,7 +756,6 @@ class MergeProjects:
                 "values(?,?,?,?,?,?,?,?,?,?,?)",
                 [c["newcid"], c["newfid"], c["x1"], c["y1"], c["width"], c["height"], c["memo"], c["owner"], c["date"],
                  c["important"], c["pdf_page"]])
-            self.conn_d.commit()
             existing_images.add(key)
         if len(self.code_image_s) > 0:
             self.summary_msg += _("Merging coded image areas") + "\n"
@@ -649,7 +768,7 @@ class MergeProjects:
         First remove all existing matching case names and the associated case text data.
         """
 
-        cur_d = self.app.conn.cursor()
+        cur_d = self.conn_d.cursor()
         # Remove all duplicate cases and case text lists from source data
         cur_d.execute("select name from cases")
         res_cases_dest = cur_d.fetchall()
@@ -674,7 +793,6 @@ class MergeProjects:
         for case_s in self.cases_s:
             cur_d.execute("insert into cases (name, memo, owner, date) values (?,?,?,?)",
                           [case_s['name'], case_s['memo'], case_s['owner'], case_s['date']])
-            self.app.conn.commit()
             cur_d.execute("select last_insert_rowid()")
             case_id = cur_d.fetchone()[0]
             case_s['newcaseid'] = case_id
@@ -694,7 +812,6 @@ class MergeProjects:
             if c['newcaseid'] > -1 and c['newfid'] > -1:
                 cur_d.execute("insert into case_text (caseid,fid,pos0,pos1,owner,date,memo) values(?,?,?,?,?,?,?)",
                               [c['newcaseid'], c['newfid'], c['pos0'], c['pos1'], c['owner'], c['date'], c['memo']])
-                self.app.conn.commit()
         # Create attribute placeholders for the destination case attributes
         now_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
         sql_attribute_types = 'select name from attribute_type where caseOrFile ="case"'
@@ -706,7 +823,6 @@ class MergeProjects:
         for id_ in new_case_ids:
             for attribute_name in res_attr_types:
                 cur_d.execute(sql_attribute, [attribute_name[0], id_, now_date, self.app.settings['codername']])
-                self.app.conn.commit()
 
     def insert_sources_get_new_file_ids(self):
         """ Insert Source.source into Destination.source, unless source file name is already present.
@@ -725,18 +841,20 @@ class MergeProjects:
                 # Warn user if the source and destination fulltexts are different lengths
                 # Occurs if one of the texts was edited or replaced
                 # Check fulltext for not None, as might be image, audio, video
-                if src['fulltext'] is not None and len(src['fulltext']) != res[1]:
+                if src['fulltext_len'] is not None and src['fulltext_len'] != res[1]:
                     msg = _("Warning! Inaccurate coding positions. Text lengths different for same text file: ")
                     msg += src['name'] + "\n"
-                    msg += _("Import project file text length: ") + f"{len(src['fulltext'])}  "
+                    msg += _("Import project file text length: ") + f"{src['fulltext_len']}  "
                     msg += _("Destination project file text length: ") + str(res[1]) + "\n"
                     self.summary_msg += msg
             else:
                 # To update the av_text_id after all new ids have been generated
+                cur_s = self.conn_s.cursor()
+                cur_s.execute("select fulltext from source where id=?", [src['id']])
+                fulltext = cur_s.fetchone()[0]
                 cur_d.execute(
                     "insert into source(name,fulltext,mediapath,memo,owner,date, av_text_id) values(?,?,?,?,?,?,?)",
-                    (src['name'], src['fulltext'], src['mediapath'], src['memo'], src['owner'], src['date'], None))
-                self.conn_d.commit()
+                    (src['name'], fulltext, src['mediapath'], src['memo'], src['owner'], src['date'], None))
                 cur_d.execute("select last_insert_rowid()")
                 id_ = cur_d.fetchone()[0]
                 src['newid'] = id_
@@ -749,7 +867,6 @@ class MergeProjects:
                 res = cur_d.fetchone()
                 if res is not None:
                     cur_d.execute("update source set av_text_id=? where id=?", [res[0], src['newid']])
-                    self.conn_d.commit()
 
         # Create attribute placeholders for the destination file attributes
         now_date = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
@@ -760,24 +877,14 @@ class MergeProjects:
         for id_ in new_source_file_ids:
             for attribute_name in res_attr_types:
                 cur_d.execute(sql_attribute, [attribute_name[0], id_, now_date, self.app.settings['codername']])
-                self.app.conn.commit()
 
     def update_coding_file_ids(self):
         """ Update the file ids in the codings and annotations data. """
 
-        for src in self.source_s:
-            for c_text in self.code_text_s:
-                if c_text['fid'] == src['id']:
-                    c_text['newfid'] = src['newid']
-            for an in self.annotations_s:
-                if an['fid'] == src['id']:
-                    an['newfid'] = src['newid']
-            for c_img in self.code_image_s:
-                if c_img['fid'] == src['id']:
-                    c_img['newfid'] = src['newid']
-            for c_av in self.code_av_s:
-                if c_av['fid'] == src['id']:
-                    c_av['newfid'] = src['newid']
+        new_ids = {src['id']: src['newid'] for src in self.source_s}
+        for rows in (self.code_text_s, self.annotations_s, self.code_image_s, self.code_av_s):
+            for row in rows:
+                row['newfid'] = new_ids.get(row['fid'], -1)
 
     def copy_source_files_into_destination(self):
         """ Copy source files into destination project.
@@ -785,24 +892,46 @@ class MergeProjects:
         """
 
         folders = ["audio", "documents", "images", "video"]
+        to_copy = []
         for folder_name in folders:
             source_dir = Path(self.path_s) / folder_name  # self.path_s + "/" + folder_name
             if not source_dir.is_dir():
                 continue
             dest_dir = Path(self.app.project_path) / folder_name
             for file_ in source_dir.iterdir():
-                if not file_.is_file():
-                    continue
                 # iterdir yields absolute paths. Joining one replaces the destination folder
-                dest_path = dest_dir / file_.name
-                if not dest_path.exists():
-                    try:
-                        shutil.copyfile(file_, dest_path)
-                        self.summary_msg += _("File copied: ") + f"{file_.name}\n"
-                    except shutil.SameFileError:
-                        pass
-                    except PermissionError:
-                        self.summary_msg += f"{file_.name} " + _("NOT copied. Permission error")
+                if file_.is_file() and not (dest_dir / file_.name).exists():
+                    to_copy.append((file_, dest_dir / file_.name))
+        for index, (source_file, dest_path) in enumerate(to_copy):
+            # Media can be large, so cancel is checked on every file and inside each one
+            self.progress.tick(index, len(to_copy), 15, 20, every=1)
+            try:
+                self.copy_one_file(source_file, dest_path)
+                self.copied_files.append(dest_path)
+                self.summary_msg += _("File copied: ") + f"{source_file.name}\n"
+            except shutil.SameFileError:
+                pass
+            except PermissionError:
+                self.summary_msg += f"{source_file.name} " + _("NOT copied. Permission error")
+
+    def copy_one_file(self, source_file, dest_path):
+        """ Copy in chunks, so Cancel responds part way through a large video.
+        A cancel removes the partial file before raising.
+        """
+
+        chunk = 8 * 1024 * 1024
+        try:
+            with open(source_file, 'rb') as f_in, open(dest_path, 'wb') as f_out:
+                while True:
+                    buffer = f_in.read(chunk)
+                    if not buffer:
+                        break
+                    f_out.write(buffer)
+                    self.progress.check()
+        except MergeCancelled:
+            Path(dest_path).unlink(missing_ok=True)
+            raise
+        shutil.copystat(source_file, dest_path)
 
     def insert_new_attribute_types(self):
         """ Insert new attribute types  for cases and files.
@@ -810,7 +939,7 @@ class MergeProjects:
         To be performed after Cases and files have been inserted.
         """
 
-        cur_d = self.app.conn.cursor()
+        cur_d = self.conn_d.cursor()
         cur_d.execute("select id from source")
         res_file_ids = cur_d.fetchall()
         cur_d.execute("select caseid from cases")
@@ -819,19 +948,16 @@ class MergeProjects:
         for a in self.attribute_types_s:
             cur_d.execute("insert into attribute_type (name,date,owner,memo,caseOrFile, valuetype) values(?,?,?,?,?,?)",
                           (a['name'], a['date'], a['owner'], a['memo'], a['caseOrFile'], a['valuetype']))
-            self.app.conn.commit()
             self.summary_msg += _("Adding attribute (") + a['caseOrFile'] + "): " + a['name'] + "\n"
             # Create attribute placeholders for new attributes, does NOT create for existing destination attributes
             if a['caseOrFile'] == "file":
                 for id_ in res_file_ids:
                     sql = "insert into attribute (name, value, id, attr_type, date, owner) values (?,?,?,?,?,?)"
                     cur_d.execute(sql, (a['name'], "", id_[0], "file", a['date'], a['owner']))
-                    self.app.conn.commit()
             if a['caseOrFile'] == "case":
                 for id_ in res_case_ids:
                     sql = "insert into attribute (name, value, id, attr_type, date, owner) values (?,?,?,?,?,?)"
                     cur_d.execute(sql, (a['name'], "", id_[0], "case", a['date'], a['owner']))
-                    self.app.conn.commit()
 
     def insert_attributes(self):
         """ Insert new attribute values for files and cases.
@@ -845,7 +971,7 @@ class MergeProjects:
         # Insert if a placeholder is missing
         sql_insert = "insert into attribute (name,id,attr_type,value,date,owner) values (?,?,?,?,?,?)"
         attribute_count = 0
-        cur_d = self.app.conn.cursor()
+        cur_d = self.conn_d.cursor()
         for a in self.attributes_s:
             if a['attr_type'] == "file":
                 source_dict = next((item for item in self.source_s if item["id"] == a['id']), {'newid': -1})
@@ -862,11 +988,9 @@ class MergeProjects:
                 if not res:
                     cur_d.execute(sql_insert,
                                   (a['name'], a['newid'], a['attr_type'], a['value'], a['date'], a['owner']))
-                    self.app.conn.commit()
                     attribute_count += 1
                 else:
                     cur_d.execute(sql_update, (a['value'], a['name'], a['newid'], a['attr_type']))
-                    self.app.conn.commit()
                     attribute_count += 1
         if attribute_count > 0:
             self.summary_msg += _("Added attribute values for cases and files: n=") + str(attribute_count) + "\n"
@@ -923,12 +1047,14 @@ class MergeProjects:
             src = {"title": i[0], "description": i[1], "grouper": i[2], "ssql": i[3]}
             self.stored_sql_s.append(src)
         # Source data
-        sql_source = "select id, name, fulltext,mediapath,memo,owner,date,av_text_id from source"
+        # length(fulltext) only. Holding every document's text would cost as much memory as
+        # the project itself. The text is fetched per file when it is inserted
+        sql_source = "select id, name, length(fulltext),mediapath,memo,owner,date,av_text_id from source"
         cur_s.execute(sql_source)
         res_source = cur_s.fetchall()
         # Later update av_text_id
         for i in res_source:
-            src = {"id": i[0], "newid": -1, "name": i[1], "fulltext": i[2], "mediapath": i[3], "memo": i[4],
+            src = {"id": i[0], "newid": -1, "name": i[1], "fulltext_len": i[2], "mediapath": i[3], "memo": i[4],
                    "owner": i[5], "date": i[6], "av_text_id": i[7], "av_text_filename": ""}
             self.source_s.append(src)
         # The av_text_id is not enough to recreate linkages. Need the referenced text file name.
@@ -947,7 +1073,7 @@ class MergeProjects:
                     "name": i[2], "memo": i[3], "owner": i[4], "date": i[5], }
             self.categories_s.append(ccat)
         # Remove categories from the source list, that are already present in the destination database
-        cur_d = self.app.conn.cursor()
+        cur_d = self.conn_d.cursor()
         cur_d.execute("select name from code_cat")
         res_dest_catnames = cur_d.fetchall()
         dest_cat_names_list = [r[0] for r in res_dest_catnames]
@@ -1045,7 +1171,7 @@ class MergeProjects:
         for row in res_attr_type_s:
             temp_attribute_types_s.append(dict(zip(keys, row)))
         # Remove matching attribute type names
-        cur_d = self.app.conn.cursor()
+        cur_d = self.conn_d.cursor()
         cur_d.execute("select name from attribute_type")
         res_attr_name_dest = cur_d.fetchall()
         attribute_names_dest = [r[0] for r in res_attr_name_dest]

--- a/src/qualcoder/special_functions.py
+++ b/src/qualcoder/special_functions.py
@@ -134,7 +134,8 @@ class DialogSpecialFunctions(QtWidgets.QDialog):
         # Sticky: a later cancelled merge must not undo the refresh owed to an earlier one
         if mp.projects_merged:
             self.projects_merged = True
-        if mp.merge_cancelled:
+        else:
+            # Cancelled or failed, so allow another attempt
             self.ui.pushButton_merge.setEnabled(True)
 
     # Functions to update a text file but attempt to keep original codings

--- a/src/qualcoder/special_functions.py
+++ b/src/qualcoder/special_functions.py
@@ -131,7 +131,11 @@ class DialogSpecialFunctions(QtWidgets.QDialog):
 
         mp = MergeProjects(self.app, self.merge_project_path)
         self.parent_text_edit.append(mp.summary_msg)
-        self.projects_merged = mp.projects_merged
+        # Sticky: a later cancelled merge must not undo the refresh owed to an earlier one
+        if mp.projects_merged:
+            self.projects_merged = True
+        if mp.merge_cancelled:
+            self.ui.pushButton_merge.setEnabled(True)
 
     # Functions to update a text file but attempt to keep original codings
     def select_original_text_file(self):

--- a/tests/test_merge_projects.py
+++ b/tests/test_merge_projects.py
@@ -957,6 +957,28 @@ def e2_preview_dialog_builds():
 
 
 
+
+# C7. hide() must also stop Qt's pending auto-show timer, or the modal progress dialog
+# pops back on top of the preview and the application looks frozen
+def c7_hidden_progress_stays_hidden():
+    from PyQt6 import QtCore
+    stub_app = types.SimpleNamespace(settings={"fontsize": 10, "font": "Noto Sans"})
+    prog = merge_projects.MergeProgress(stub_app)
+    prog.phase("reading", 2)  # Faster than minimumDuration, so the show timer is left armed
+    prog.phase("preview", 10)
+    prog.hide()
+    loop = QtCore.QEventLoop()  # Stands in for the preview dialog's event loop
+    QtCore.QTimer.singleShot(900, loop.quit)
+    loop.exec()
+    check("C7 hidden progress does not pop back over the preview", not prog.dialog.isVisible())
+    prog.restart()
+    prog.phase("copying", 15)
+    APP.processEvents()
+    check("C7 restart still re-arms the dialog", prog.dialog is not None)
+    prog.close()
+
+
+
 MERGE_HOLDER = [None]
 
 
@@ -985,6 +1007,7 @@ if __name__ == "__main__":
     c4_unexpected_error()
     c5_vectorstore_failure()
     c6_not_a_project_releases()
+    c7_hidden_progress_stays_hidden()
     d1_text_not_held_in_memory()
     d2_cancel_inside_large_file()
     e1_journal_report()

--- a/tests/test_merge_projects.py
+++ b/tests/test_merge_projects.py
@@ -1,0 +1,997 @@
+"""
+Regression and safety suite for qualcoder/merge_projects.py.
+Every check prints PASS or FAIL. The exit code is 1 if anything failed.
+"""
+import builtins
+import logging
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+builtins._ = lambda s: s  # merge_projects expects gettext to be installed
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def _find_source_root():
+    """Locate the qualcoder package: argv, then env, then the usual repo layout."""
+
+    candidates = []
+    if len(sys.argv) > 1:
+        candidates.append(Path(sys.argv[1]))
+    if os.environ.get("QUALCODER_SRC"):
+        candidates.append(Path(os.environ["QUALCODER_SRC"]))
+    here = Path(__file__).resolve().parent
+    candidates += [here, here / "src", here.parent, here.parent / "src"]
+    for candidate in candidates:
+        if (candidate / "qualcoder" / "merge_projects.py").is_file():
+            return candidate
+    sys.exit("Could not find qualcoder/merge_projects.py. Pass the src path as an argument.")
+
+
+sys.path.insert(0, str(_find_source_root()))
+
+from PyQt6 import QtWidgets  # noqa: E402
+from qualcoder import merge_projects  # noqa: E402
+
+# Silence the modal message boxes
+merge_projects.Message = lambda *a, **k: types.SimpleNamespace(exec=lambda: None)
+APP = QtWidgets.QApplication.instance() or QtWidgets.QApplication(sys.argv[:1])
+TMP = Path(tempfile.mkdtemp(prefix="qc_merge_tests_"))
+RESULTS = []
+
+
+@contextmanager
+def expected_error():
+    """Silence the traceback merge_projects logs on purpose during the failure tests."""
+
+    logging.disable(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        logging.disable(logging.NOTSET)
+
+
+SCHEMA = [
+    "CREATE TABLE project (databaseversion text, date text, memo text,about text, bookmarkfile integer, "
+    "bookmarkpos integer, codername text, recently_used_codes text, avbookmarkfile integer, "
+    "avbookmarkmsec integer, avbookmarktextpos integer)",
+    "CREATE TABLE source (id integer primary key, name text, fulltext text, mediapath text, memo text, "
+    "owner text, date text, av_text_id integer, risid integer, unique(name))",
+    "CREATE TABLE code_image (imid integer primary key,id integer,x1 integer, y1 integer, width integer, "
+    "height integer, cid integer, memo text, date text, owner text, important integer, pdf_page integer)",
+    "CREATE TABLE code_av (avid integer primary key,id integer,pos0 integer, pos1 integer, cid integer, "
+    "memo text, date text, owner text, important integer)",
+    "CREATE TABLE annotation (anid integer primary key, fid integer,pos0 integer, pos1 integer, memo text, "
+    "owner text, date text, unique(fid,pos0,pos1,owner))",
+    "CREATE TABLE attribute_type (name text primary key, date text, owner text, memo text, caseOrFile text, "
+    "valuetype text)",
+    "CREATE TABLE attribute (attrid integer primary key, name text, attr_type text, value text, id integer, "
+    "date text, owner text, unique(name,attr_type,id))",
+    "CREATE TABLE case_text (id integer primary key, caseid integer, fid integer, pos0 integer, pos1 integer, "
+    "owner text, date text, memo text)",
+    "CREATE TABLE cases (caseid integer primary key, name text, memo text, owner text,date text, "
+    "constraint ucm unique(name))",
+    "CREATE TABLE code_cat (catid integer primary key, name text, owner text, date text, memo text, "
+    "supercatid integer, unique(name))",
+    "CREATE TABLE code_text (ctid integer primary key, cid integer, fid integer,seltext text, pos0 integer, "
+    "pos1 integer, owner text, date text, memo text, avid integer, important integer, "
+    "unique(cid,fid,pos0,pos1, owner))",
+    "CREATE TABLE code_name (cid integer primary key, name text, memo text, catid integer, owner text,"
+    "date text, color text, supercid integer, unique(name))",
+    "CREATE TABLE journal (jid integer primary key, name text, jentry text, date text, owner text, unique(name))",
+    "CREATE TABLE stored_sql (title text, description text, grouper text, ssql text, unique(title))",
+]
+
+
+class StubApp:
+    def __init__(self, path):
+        self.project_path = str(path)
+        self.conn = sqlite3.connect(Path(path) / "data.qda")
+        self.settings = {"codername": "tester", "ai_enable": "False",
+                         "fontsize": 10, "font": "Noto Sans"}
+        self.project_events = None
+        self.delete_backup = True
+
+    def save_backup(self, suffix):
+        return f"backup{suffix}", "backup"
+
+
+def check(name, condition, detail=""):
+    RESULTS.append((name, bool(condition), detail))
+    print(("PASS  " if condition else "FAIL  ") + name + (f"   {detail}" if detail else ""))
+
+
+def make(folder, rows, media=(), schema=None, project_row=True):
+    folder = Path(folder)
+    for sub in ("audio", "documents", "images", "video"):
+        (folder / sub).mkdir(parents=True, exist_ok=True)
+    for sub, fname, content in media:
+        (folder / sub / fname).write_bytes(content)
+    conn = sqlite3.connect(folder / "data.qda")
+    cur = conn.cursor()
+    for stmt in (schema or SCHEMA):
+        cur.execute(stmt)
+    if project_row:
+        cur.execute("insert into project values(?,?,?,?,?,?,?,?,null,null,null)",
+                    ("v17", "2026-08-24", "", "t", 0, 0, "tester", ""))
+    for sql in rows:
+        cur.execute(sql)
+    conn.commit()
+    conn.close()
+
+
+def fresh(name):
+    path = TMP / name
+    if path.exists():
+        shutil.rmtree(path)
+    return path
+
+
+def counts(conn):
+    cur = conn.cursor()
+    out = {}
+    for table in ("source", "code_name", "code_cat", "code_text", "code_image", "code_av",
+                  "annotation", "cases", "case_text", "journal", "stored_sql", "attribute_type"):
+        cur.execute(f"select count(*) from {table}")
+        out[table] = cur.fetchone()[0]
+    return out
+
+
+def sections_map(mp):
+    return {s['title']: s['detail'] for s in mp.preview_sections}
+
+
+# A rich source project used by several tests
+RICH_SOURCE = [
+    "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+    "values(1,'E01_Rosa.txt','texto de rosa aqui','/docs/E01_Rosa.txt','','t','d',null)",
+    "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+    "values(4,'E02_Marta.pdf','texto del pdf','/docs/E02_Marta.pdf','','t','d',null)",
+    "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+    "values(6,'foto.jpg',null,'/images/foto.jpg','','t','d',null)",
+    "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+    "values(7,'sesion.mp3',null,'/audio/sesion.mp3','','t','d',1)",
+    "insert into code_cat (catid,name,owner,date,memo,supercatid) values(2,'Cuidado','t','d','',null)",
+    "insert into code_cat (catid,name,owner,date,memo,supercatid) values(3,'Apoyos','t','d','',2)",
+    "insert into code_name (cid,name,memo,catid,owner,date,color,supercid) "
+    "values(1,'Sobrecarga','',2,'t','d','#F44336',null)",
+    "insert into code_name (cid,name,memo,catid,owner,date,color,supercid) "
+    "values(2,'Red familiar','',3,'t','d','#2196F3',null)",
+    "insert into code_name (cid,name,memo,catid,owner,date,color,supercid) "
+    "values(3,'Hermana','',null,'t','d','#4CAF50',2)",
+    "insert into code_text (ctid,cid,fid,seltext,pos0,pos1,owner,date,memo,avid,important) "
+    "values(1,1,1,'texto',0,5,'t','d','',null,0)",
+    "insert into code_text (ctid,cid,fid,seltext,pos0,pos1,owner,date,memo,avid,important) "
+    "values(2,3,1,'de rosa',6,13,'t','d','',null,0)",
+    "insert into code_av (avid,id,pos0,pos1,cid,memo,date,owner,important) values(9,7,1000,5000,1,'','d','t',0)",
+    "insert into code_text (ctid,cid,fid,seltext,pos0,pos1,owner,date,memo,avid,important) "
+    "values(3,1,1,'aqui',14,18,'t','d','',9,0)",
+    "insert into code_image (imid,id,x1,y1,width,height,cid,memo,date,owner,important,pdf_page) "
+    "values(1,4,10,10,50,50,1,'','d','t',0,0)",
+    "insert into code_image (imid,id,x1,y1,width,height,cid,memo,date,owner,important,pdf_page) "
+    "values(2,4,20,20,50,50,2,'','d','t',0,3)",
+    "insert into code_image (imid,id,x1,y1,width,height,cid,memo,date,owner,important,pdf_page) "
+    "values(3,6,5,5,30,30,2,'','d','t',0,null)",
+    "insert into annotation (anid,fid,pos0,pos1,memo,owner,date) values(1,1,0,4,'nota','t','d')",
+    "insert into cases (caseid,name,memo,owner,date) values(1,'Rosa','memo caso','t','d')",
+    "insert into case_text (caseid,fid,pos0,pos1,owner,date,memo) values(1,1,0,18,'t','d','link memo')",
+    "insert into journal (jid,name,jentry,date,owner) values(1,'Diario de campo','texto','d','t')",
+    "insert into stored_sql (title,description,grouper,ssql) values('Consulta A','d','g','select 1')",
+    "insert into attribute_type (name,date,owner,memo,caseOrFile,valuetype) "
+    "values('Edad','d','t','','case','numeric')",
+    "insert into attribute (attrid,name,attr_type,value,id,date,owner) values(1,'Edad','case','58',1,'d','t')",
+]
+RICH_MEDIA = [("documents", "E02_Marta.pdf", b"%PDF fake"),
+              ("images", "foto.jpg", b"jpg"),
+              ("audio", "sesion.mp3", b"mp3")]
+
+
+# A1. The preview counts must equal what the merge actually inserts
+def a1_preview_matches_reality():
+    base = fresh("a1")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [
+        # Destination shares one file and one code name, and holds one identical coding already
+        "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+        "values(1,'E01_Rosa.txt','texto de rosa aqui','/docs/E01_Rosa.txt','','t','d',null)",
+        "insert into code_name (cid,name,memo,catid,owner,date,color,supercid) "
+        "values(1,'Sobrecarga','',null,'t','d','#F44336',null)",
+        "insert into code_text (ctid,cid,fid,seltext,pos0,pos1,owner,date,memo,avid,important) "
+        "values(1,1,1,'texto',0,5,'t','d','',null,0)",
+    ])
+    app = StubApp(base / "dst.qda")
+    before = counts(app.conn)
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    after = counts(app.conn)
+    sec = sections_map(mp)
+    expected = {
+        "source": "Files to add",
+        "code_name": "Codes to add",
+        "code_cat": "Code categories to add",
+        "code_text": "Coded text segments to add",
+        "code_av": "Coded audio/video segments to add",
+        "annotation": "Text annotations to add",
+        "cases": "Cases to add",
+        "case_text": "Case file links to add",
+        "journal": "Journals to add",
+        "stored_sql": "Stored queries to add",
+        "attribute_type": "Attribute types to add",
+    }
+    for table, title in expected.items():
+        delta = after[table] - before[table]
+        check(f"A1 preview matches inserted rows: {table}", delta == int(sec[title]),
+              f"real {delta}, preview {sec[title]} ({title})")
+    image_delta = after["code_image"] - before["code_image"]
+    preview_images = int(sec["Coded PDF areas to add"]) + int(sec["Coded image areas to add"])
+    check("A1 preview matches inserted rows: code_image", image_delta == preview_images,
+          f"real {image_delta}, preview {preview_images}")
+    check("A1 preview reports the coding already present",
+          sec.get("Codings already in this project, not duplicated") == "1",
+          f"got {sec.get('Codings already in this project, not duplicated')}")
+
+
+# A2. Merging the same project twice must add nothing the second time
+def a2_idempotent():
+    base = fresh("a2")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    before = counts(app.conn)
+    mp2 = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    after = counts(app.conn)
+    changed = {t: (before[t], after[t]) for t in before if before[t] != after[t]}
+    check("A2 second merge inserts nothing", not changed, f"{changed}")
+    sec = sections_map(mp2)
+    zeros = [t for t in ("Coded text segments to add", "Coded PDF areas to add", "Coded image areas to add",
+                         "Coded audio/video segments to add", "Text annotations to add", "Files to add",
+                         "Codes to add", "Cases to add") if sec[t] != "0"]
+    check("A2 second preview shows nothing to add", not zeros, f"non zero: {zeros}")
+
+
+# A3. Codings whose code or file is missing must not land as cid or fid -1
+def a3_orphans():
+    base = fresh("a3")
+    make(base / "src.qda", [
+        "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+        "values(1,'ok.txt','texto valido','/docs/ok.txt','','t','d',null)",
+        "insert into code_name (cid,name,memo,catid,owner,date,color,supercid) "
+        "values(1,'Bueno','',null,'t','d','#111',null)",
+        # Coding on a code that does not exist
+        "insert into code_text (ctid,cid,fid,seltext,pos0,pos1,owner,date,memo,avid,important) "
+        "values(1,99,1,'texto',0,5,'t','d','',null,0)",
+        # Coding on a file that does not exist
+        "insert into code_text (ctid,cid,fid,seltext,pos0,pos1,owner,date,memo,avid,important) "
+        "values(2,1,99,'texto',0,5,'t','d','',null,0)",
+        "insert into code_image (imid,id,x1,y1,width,height,cid,memo,date,owner,important,pdf_page) "
+        "values(1,99,0,0,10,10,1,'','d','t',0,2)",
+        "insert into code_av (avid,id,pos0,pos1,cid,memo,date,owner,important) values(1,99,0,10,1,'','d','t',0)",
+        "insert into annotation (anid,fid,pos0,pos1,memo,owner,date) values(1,99,0,4,'n','t','d')",
+        # One good coding
+        "insert into code_text (ctid,cid,fid,seltext,pos0,pos1,owner,date,memo,avid,important) "
+        "values(3,1,1,'valido',6,12,'t','d','',null,0)",
+    ])
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    cur = app.conn.cursor()
+    bad = 0
+    for table, cid_col, fid_col in (("code_text", "cid", "fid"), ("code_image", "cid", "id"),
+                                    ("code_av", "cid", "id")):
+        cur.execute(f"select count(*) from {table} where {cid_col}=-1 or {fid_col}=-1")
+        bad += cur.fetchone()[0]
+    cur.execute("select count(*) from annotation where fid=-1")
+    bad += cur.fetchone()[0]
+    check("A3 no coding rows with cid or fid -1", bad == 0, f"{bad} bad rows")
+    cur.execute("select count(*) from code_text")
+    check("A3 the valid coding is still merged", cur.fetchone()[0] == 1)
+    check("A3 orphans reported in the summary", "Codings skipped" in mp.summary_msg)
+    check("A3 orphans flagged in the preview",
+          sections_map(mp).get("Codings skipped, missing code or file in the source project") == "5",
+          str(sections_map(mp).get("Codings skipped, missing code or file in the source project")))
+
+
+# A4. A folder without data.qda must not crash and must not create a database there
+def a4_not_a_project():
+    base = fresh("a4")
+    (base / "src.qda").mkdir(parents=True)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    check("A4 no crash on a folder without a project", mp.projects_merged is False)
+    check("A4 no database created in the source folder", not (base / "src.qda" / "data.qda").exists())
+
+
+# A5. An unreadable or empty project database must be refused
+def a5_empty_project_table():
+    base = fresh("a5")
+    make(base / "src.qda", [], project_row=False)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    before = counts(app.conn)
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    check("A5 empty project table refused", mp.projects_merged is False)
+    check("A5 nothing written", counts(app.conn) == before)
+    check("A5 reason in the summary", "Could not read" in mp.summary_msg)
+
+
+# A6. Old database versions must still be refused with the upgrade message
+def a6_old_version():
+    base = fresh("a6")
+    make(base / "src.qda", [], project_row=False)
+    conn = sqlite3.connect(base / "src.qda" / "data.qda")
+    conn.execute("insert into project values(?,?,?,?,?,?,?,?,null,null,null)",
+                 ("v4", "2026-08-24", "", "t", 0, 0, "tester", ""))
+    conn.commit()
+    conn.close()
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    check("A6 pre v5 project refused", mp.projects_merged is False)
+    check("A6 upgrade message shown", "update the source project" in mp.summary_msg)
+
+
+# A7. Case data carried across, and case attribute placeholders typed as case
+def a7_case_data():
+    base = fresh("a7")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [
+        # Destination already has a case attribute type, which triggers the placeholder path
+        "insert into attribute_type (name,date,owner,memo,caseOrFile,valuetype) "
+        "values('Zona','d','t','','case','character')",
+    ])
+    app = StubApp(base / "dst.qda")
+    merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    cur = app.conn.cursor()
+    cur.execute("select owner, date, memo from case_text")
+    row = cur.fetchone()
+    check("A7 case link keeps owner, date and memo", row == ('t', 'd', 'link memo'), str(row))
+    cur.execute("select attr_type from attribute where name='Zona'")
+    types_ = [r[0] for r in cur.fetchall()]
+    check("A7 case attribute placeholder typed as case", types_ == ['case'], str(types_))
+    cur.execute("select value from attribute where name='Edad' and attr_type='case'")
+    val = cur.fetchone()
+    check("A7 case attribute value carried across", val is not None and val[0] == '58', str(val))
+
+
+# A8. Sub-codes, categories and the transcript link survive the merge
+def a8_structure():
+    base = fresh("a8")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    cur = app.conn.cursor()
+    cur.execute("select cid from code_name where name='Red familiar'")
+    parent = cur.fetchone()[0]
+    cur.execute("select supercid from code_name where name='Hermana'")
+    check("A8 sub-code keeps its parent", cur.fetchone()[0] == parent)
+    cur.execute("select catid from code_cat where name='Cuidado'")
+    parent_cat = cur.fetchone()[0]
+    cur.execute("select supercatid from code_cat where name='Apoyos'")
+    check("A8 sub-category keeps its parent", cur.fetchone()[0] == parent_cat)
+    cur.execute("select id from source where name='E01_Rosa.txt'")
+    transcript = cur.fetchone()[0]
+    cur.execute("select av_text_id from source where name='sesion.mp3'")
+    check("A8 A/V transcript link rebuilt", cur.fetchone()[0] == transcript)
+    cur.execute("select avid from code_av")
+    av = cur.fetchone()[0]
+    cur.execute("select avid from code_text where pos0=14")
+    check("A8 transcript coding still points at its A/V segment", cur.fetchone()[0] == av)
+    cur.execute("select pdf_page from code_image where pdf_page is not null order by pdf_page")
+    check("A8 PDF pages preserved", [r[0] for r in cur.fetchall()] == [0, 3])
+
+
+# A9. Existing media files are never overwritten, and the source db is closed
+def a9_files_and_handles():
+    base = fresh("a9")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [], media=[("documents", "E02_Marta.pdf", b"ORIGINAL DEL DESTINO")])
+    app = StubApp(base / "dst.qda")
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    kept = (base / "dst.qda" / "documents" / "E02_Marta.pdf").read_bytes()
+    check("A9 existing file not overwritten", kept == b"ORIGINAL DEL DESTINO", str(kept))
+    check("A9 other files copied", (base / "dst.qda" / "images" / "foto.jpg").exists())
+    check("A9 source database closed after merge", mp.conn_s is None)
+    check("A9 source project files untouched",
+          (base / "src.qda" / "documents" / "E02_Marta.pdf").read_bytes() == b"%PDF fake")
+
+
+# A10. Names with quotes and accents must survive
+def a10_unicode_and_quotes():
+    base = fresh("a10")
+    make(base / "src.qda", [
+        "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+        "values(1,'Entrevista ''Doña Rosa''.txt','texto','/docs/x.txt','','t','d',null)",
+        "insert into code_name (cid,name,memo,catid,owner,date,color,supercid) "
+        "values(1,'Acompañamiento ''cercano''','',null,'t','d','#111',null)",
+        "insert into code_text (ctid,cid,fid,seltext,pos0,pos1,owner,date,memo,avid,important) "
+        "values(1,1,1,'texto',0,5,'t','d','',null,0)",
+    ])
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    cur = app.conn.cursor()
+    cur.execute("select name from code_name")
+    check("A10 code name with accents and quotes merged",
+          cur.fetchone()[0] == "Acompañamiento 'cercano'")
+    cur.execute("select count(*) from code_text")
+    check("A10 its coding merged", cur.fetchone()[0] == 1)
+    check("A10 preview lists the name",
+          "Acompañamiento 'cercano'" in [i for s in mp.preview_sections for i in s['items']])
+
+
+# A11. Attribute values do not overwrite existing non blank values
+def a11_attribute_values():
+    base = fresh("a11")
+    make(base / "src.qda", [
+        "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+        "values(1,'comun.txt','texto','/docs/comun.txt','','t','d',null)",
+        "insert into attribute_type (name,date,owner,memo,caseOrFile,valuetype) "
+        "values('Sitio','d','t','','file','character')",
+        "insert into attribute (attrid,name,attr_type,value,id,date,owner) values(1,'Sitio','file','Mazatlan',1,'d','t')",
+    ])
+    make(base / "dst.qda", [
+        "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+        "values(1,'comun.txt','texto','/docs/comun.txt','','t','d',null)",
+        "insert into attribute_type (name,date,owner,memo,caseOrFile,valuetype) "
+        "values('Sitio','d','t','','file','character')",
+        "insert into attribute (attrid,name,attr_type,value,id,date,owner) values(1,'Sitio','file','Culiacan',1,'d','t')",
+    ])
+    app = StubApp(base / "dst.qda")
+    merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    cur = app.conn.cursor()
+    cur.execute("select value from attribute where name='Sitio'")
+    check("A11 existing attribute value not overwritten", cur.fetchone()[0] == 'Culiacan')
+
+
+# A12. Cancelling from the dialog closes the source database and writes nothing
+def a12_cancel_releases():
+    base = fresh("a12")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+
+    class CancelDialog:
+        def __init__(self, app_, sections, path_s_, parent=None):
+            pass
+
+        def exec(self):
+            return 0
+
+        def save_to_journal(self):
+            return False
+
+    original = merge_projects.DialogMergePreview
+    merge_projects.DialogMergePreview = CancelDialog
+    before = counts(app.conn)
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"))
+    merge_projects.DialogMergePreview = original
+    check("A12 cancel writes nothing", counts(app.conn) == before)
+    check("A12 cancel closes the source database", mp.conn_s is None)
+    check("A12 cancel copies no files", not (base / "dst.qda" / "images" / "foto.jpg").exists())
+
+
+
+# A13. Very large lists are capped in the tree and the journal entry, counts stay complete
+def a13_large_lists():
+    base = fresh("a13")
+    rows = []
+    for i in range(1, 461):
+        rows.append(f"insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+                    f"values({i},'f{i:04}.txt','texto','/docs/f{i:04}.txt','','t','d',null)")
+    make(base / "src.qda", rows)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    app.settings.update({"fontsize": 10, "font": "Noto Sans"})
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    files_section = next(s for s in mp.preview_sections if s['title'] == "Files to add")
+    check("A13 count is complete", files_section['detail'] == "460", files_section['detail'])
+    check("A13 listed names are capped", len(files_section['items']) == 201,
+          f"{len(files_section['items'])} rows listed")
+    check("A13 cap line states the remainder", "260" in files_section['items'][-1],
+          files_section['items'][-1])
+    dlg = merge_projects.DialogMergePreview(app, mp.preview_sections, str(base / "src.qda"))
+    check("A13 dialog builds with the capped list", dlg.tree.topLevelItemCount() == len(mp.preview_sections))
+    dlg.close()
+
+
+
+
+def _progress_stub(fail_at, phase_label=None):
+    """Progress that raises MergeCancelled at the nth tick, or on a named phase."""
+
+    state = {'ticks': 0}
+
+    class Stub:
+        def __init__(self, app_, parent=None):
+            pass
+
+        def phase(self, label, value, repaint=True):
+            if phase_label is not None and label == phase_label:
+                raise merge_projects.MergeCancelled()
+
+        def tick(self, index, total, base, span, every=100):
+            state['ticks'] += 1
+            if fail_at is not None and state['ticks'] >= fail_at:
+                raise merge_projects.MergeCancelled()
+
+        def check(self):
+            pass
+
+        def hide(self):
+            pass
+
+        def restart(self):
+            pass
+
+        def close(self):
+            pass
+
+    return Stub, state
+
+
+# B1. Cancelling while files are copied leaves nothing behind
+def b1_cancel_during_copy():
+    base = fresh("b1")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    before = counts(app.conn)
+    stub, _state = _progress_stub(fail_at=2)
+    original = merge_projects.MergeProgress
+    merge_projects.MergeProgress = stub
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    merge_projects.MergeProgress = original
+    check("B1 cancel during copy writes nothing", counts(app.conn) == before)
+    left = [p.name for p in (base / "dst.qda").rglob("*") if p.is_file() and p.name != "data.qda"]
+    check("B1 copied files removed again", not left, f"left behind: {left}")
+    check("B1 flagged as cancelled", mp.merge_cancelled is True)
+    check("B1 source database closed", mp.conn_s is None)
+
+
+# B2. Cancelling mid insert rolls the whole merge back
+def b2_cancel_during_insert():
+    base = fresh("b2")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    before = counts(app.conn)
+    stub, _state = _progress_stub(fail_at=None, phase_label="Merging coded text")
+    original = merge_projects.MergeProgress
+    merge_projects.MergeProgress = stub
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    merge_projects.MergeProgress = original
+    after = counts(app.conn)
+    changed = {t: (before[t], after[t]) for t in before if before[t] != after[t]}
+    check("B2 cancel mid merge rolls everything back", not changed, f"{changed}")
+    left = [p.name for p in (base / "dst.qda").rglob("*") if p.is_file() and p.name != "data.qda"]
+    check("B2 copied files removed again", not left, f"left behind: {left}")
+    check("B2 flagged as cancelled", mp.merge_cancelled is True)
+    check("B2 not reported as merged", mp.projects_merged is False)
+
+
+# B3. A database error rolls back instead of leaving a half merged project
+def b3_error_rolls_back():
+    base = fresh("b3")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    before = counts(app.conn)
+    original = merge_projects.MergeProjects.insert_cases
+
+    def boom(self):
+        raise sqlite3.OperationalError("simulated failure")
+
+    merge_projects.MergeProjects.insert_cases = boom
+    with expected_error():
+        mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    merge_projects.MergeProjects.insert_cases = original
+    check("B3 error rolls everything back", counts(app.conn) == before,
+          str({t: (before[t], counts(app.conn)[t]) for t in before if before[t] != counts(app.conn)[t]}))
+    check("B3 not reported as merged", mp.projects_merged is False)
+    check("B3 failure reported", "Merge failed" in mp.summary_msg)
+
+
+# B4. The whole merge is one transaction, invisible to other readers until it commits
+def b4_single_transaction():
+    base = fresh("b4")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    observed = {}
+    reader = sqlite3.connect(base / "dst.qda" / "data.qda", timeout=0.2)
+
+    class Watcher:
+        def __init__(self, app_, parent=None):
+            pass
+
+        def phase(self, label, value, repaint=True):
+            if label == "Merging coded image and PDF areas":
+                try:
+                    cur = reader.cursor()
+                    cur.execute("select count(*) from code_text")
+                    observed['code_text'] = cur.fetchone()[0]
+                except sqlite3.Error as err:
+                    observed['error'] = str(err)
+
+        def tick(self, *a, **k):
+            pass
+
+        def check(self):
+            pass
+
+        def hide(self):
+            pass
+
+        def restart(self):
+            pass
+
+        def close(self):
+            pass
+
+    original = merge_projects.MergeProgress
+    merge_projects.MergeProgress = Watcher
+    merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    merge_projects.MergeProgress = original
+    check("B4 uncommitted work is not visible to another reader",
+          observed.get('code_text') == 0 or 'error' in observed, str(observed))
+    reader.close()
+    cur = app.conn.cursor()
+    cur.execute("select count(*) from code_text")
+    check("B4 committed after the merge", cur.fetchone()[0] == 3)
+
+
+# B5. The progress helper is inert when there is no application
+def b5_progress_headless():
+    prog = merge_projects.MergeProgress.__new__(merge_projects.MergeProgress)
+    prog.dialog = None
+    prog.phase("x", 1)
+    prog.tick(0, 10, 0, 10)
+    prog.check()
+    prog.hide()
+    prog.restart()
+    prog.close()
+    check("B5 progress helper is inert without a dialog", True)
+
+
+
+
+# C1. The progress dialog must come back after being hidden for the preview
+def c1_progress_returns_after_hide():
+    import time
+    stub_app = types.SimpleNamespace(settings={"fontsize": 10, "font": "Noto Sans"})
+    prog = merge_projects.MergeProgress(stub_app)
+    prog.phase("reading", 2)
+    time.sleep(0.6)
+    prog.phase("preview", 10)
+    check("C1 dialog shows during a slow read", prog.dialog.isVisible())
+    prog.hide()
+    prog.restart()
+    time.sleep(0.6)
+    prog.phase("copying", 15)
+    time.sleep(0.6)
+    prog.phase("merging", 40)
+    APP.processEvents()
+    check("C1 dialog returns for the merge phase", prog.dialog.isVisible())
+    check("C1 cancel flag cleared by restart", not prog.dialog.wasCanceled())
+    prog.close()
+
+
+# C2. The merge must not run on the shared app connection
+def c2_own_connection():
+    base = fresh("c2")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    seen = {}
+
+    class Watcher:
+        def __init__(self, app_, parent=None):
+            pass
+
+        def phase(self, label, value, repaint=True):
+            if label == "Merging coded text":
+                seen['conn_is_shared'] = MERGE_HOLDER[0].conn_d is app.conn
+
+        def tick(self, *a, **k):
+            pass
+
+        def check(self):
+            pass
+
+        def hide(self):
+            pass
+
+        def restart(self):
+            pass
+
+        def close(self):
+            pass
+
+    original = merge_projects.MergeProgress
+    merge_projects.MergeProgress = Watcher
+    MERGE_HOLDER[0] = merge_projects.MergeProjects.__new__(merge_projects.MergeProjects)
+    mp = MERGE_HOLDER[0]
+    mp.__init__(app, str(base / "src.qda"), show_preview=False)
+    merge_projects.MergeProgress = original
+    check("C2 merge uses its own connection", seen.get('conn_is_shared') is False, str(seen))
+    check("C2 connections released", mp.conn_d is None and mp.conn_s is None)
+    cur = app.conn.cursor()
+    cur.execute("select count(*) from code_text")
+    check("C2 shared connection sees the committed merge", cur.fetchone()[0] == 3)
+
+
+# C3. A pending write on the shared connection survives a cancelled merge
+def c3_other_writes_survive_rollback():
+    base = fresh("c3")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    # Another dialog writes and commits on the shared connection before the merge starts
+    cur = app.conn.cursor()
+    cur.execute("insert into journal (name,jentry,date,owner) values('otro diario','texto','d','t')")
+    app.conn.commit()
+    stub, _state = _progress_stub(fail_at=None, phase_label="Merging coded text")
+    original = merge_projects.MergeProgress
+    merge_projects.MergeProgress = stub
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    merge_projects.MergeProgress = original
+    cur.execute("select name from journal")
+    names = [r[0] for r in cur.fetchall()]
+    check("C3 the other dialog's row survives the rollback", names == ['otro diario'], str(names))
+    check("C3 merge rolled back", mp.merge_cancelled is True)
+
+
+# C4. Any unexpected error rolls back and releases everything
+def c4_unexpected_error():
+    base = fresh("c4")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    before = counts(app.conn)
+    original = merge_projects.MergeProjects.insert_categories
+
+    def boom(self):
+        raise ValueError("not a database error")
+
+    merge_projects.MergeProjects.insert_categories = boom
+    with expected_error():
+        mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    merge_projects.MergeProjects.insert_categories = original
+    check("C4 non database error rolls back", counts(app.conn) == before)
+    check("C4 connections released", mp.conn_d is None and mp.conn_s is None)
+    check("C4 progress dialog closed", mp.progress.dialog is None)
+    check("C4 failure reported", "Merge failed" in mp.summary_msg)
+    left = [q.name for q in (base / "dst.qda").rglob("*") if q.is_file() and q.name != "data.qda"]
+    check("C4 copied files removed", not left, str(left))
+
+
+# C5. A failing vectorstore update must not lose a committed merge
+def c5_vectorstore_failure():
+    base = fresh("c5")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    app.settings["ai_enable"] = "True"
+
+    class BadAi:
+        @property
+        def sources_vectorstore(self):
+            raise RuntimeError("vectorstore unavailable")
+
+    app.ai = BadAi()
+    with expected_error():
+        mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    check("C5 merge still reported as merged", mp.projects_merged is True)
+    cur = app.conn.cursor()
+    cur.execute("select count(*) from code_text")
+    check("C5 merge data committed", cur.fetchone()[0] == 3)
+    check("C5 vectorstore problem reported", "vectorstore" in mp.summary_msg)
+    check("C5 progress dialog closed", mp.progress.dialog is None)
+
+
+# C6. A folder that is not a project must release the dialog too
+def c6_not_a_project_releases():
+    base = fresh("c6")
+    (base / "src.qda").mkdir(parents=True)
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    check("C6 progress dialog closed", mp.progress.dialog is None)
+    check("C6 attributes present for the caller",
+          mp.projects_merged is False and mp.merge_cancelled is False and mp.copied_files == [])
+
+
+
+
+# D1. Document text is fetched at insert time, not held for every file
+def d1_text_not_held_in_memory():
+    base = fresh("d1")
+    texto = "Rosa dijo que el cuidado la desborda. " * 50
+    make(base / "src.qda", [
+        "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+        f"values(1,'larga.txt','{texto}','/docs/larga.txt','','t','d',null)",
+        "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+        "values(2,'video.mp4',null,'/video/video.mp4','','t','d',null)",
+    ])
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    check("D1 source rows carry the length, not the text",
+          all('fulltext' not in src and 'fulltext_len' in src for src in mp.source_s))
+    check("D1 length recorded for the text file",
+          mp.source_s[0]['fulltext_len'] == len(texto), str(mp.source_s[0]['fulltext_len']))
+    check("D1 media file has no length", mp.source_s[1]['fulltext_len'] is None)
+    cur = app.conn.cursor()
+    cur.execute("select fulltext from source where name='larga.txt'")
+    check("D1 the full text is still merged intact", cur.fetchone()[0] == texto)
+    cur.execute("select fulltext from source where name='video.mp4'")
+    check("D1 media file keeps a null text", cur.fetchone()[0] is None)
+
+
+# D2. Cancelling inside a large file leaves no partial copy
+def d2_cancel_inside_large_file():
+    base = fresh("d2")
+    big = b"0" * (30 * 1024 * 1024)  # 30 MB, several chunks
+    make(base / "src.qda", [
+        "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+        "values(1,'grande.mp4',null,'/video/grande.mp4','','t','d',null)",
+    ], media=[("video", "grande.mp4", big)])
+    make(base / "dst.qda", [])
+    app = StubApp(base / "dst.qda")
+    state = {'checks': 0}
+
+    class ChunkCanceller:
+        def __init__(self, app_, parent=None):
+            pass
+
+        def phase(self, label, value, repaint=True):
+            pass
+
+        def tick(self, *a, **k):
+            pass
+
+        def check(self):
+            state['checks'] += 1
+            if state['checks'] >= 2:  # Part way through the file
+                raise merge_projects.MergeCancelled()
+
+        def hide(self):
+            pass
+
+        def restart(self):
+            pass
+
+        def close(self):
+            pass
+
+    original = merge_projects.MergeProgress
+    merge_projects.MergeProgress = ChunkCanceller
+    before = counts(app.conn)
+    mp = merge_projects.MergeProjects(app, str(base / "src.qda"), show_preview=False)
+    merge_projects.MergeProgress = original
+    check("D2 cancel fires inside the file, not only between files", state['checks'] >= 2)
+    check("D2 no partial file left behind",
+          not (base / "dst.qda" / "video" / "grande.mp4").exists())
+    check("D2 nothing written to the database", counts(app.conn) == before)
+    check("D2 flagged as cancelled", mp.merge_cancelled is True)
+    check("D2 source file untouched",
+          (base / "src.qda" / "video" / "grande.mp4").stat().st_size == len(big))
+
+
+
+
+# E1. The preview report can be stored as a journal entry, merged or cancelled
+def e1_journal_report():
+    for merged_run in (True, False):
+        base = fresh("e1_merged" if merged_run else "e1_cancelled")
+        make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+        make(base / "dst.qda", [])
+        app = StubApp(base / "dst.qda")
+
+        class Dialog:
+            def __init__(self, app_, sections, path_s_, parent=None):
+                pass
+
+            def exec(self):
+                return 1 if merged_run else 0
+
+            def save_to_journal(self):
+                return True
+
+        original = merge_projects.DialogMergePreview
+        merge_projects.DialogMergePreview = Dialog
+        mp = merge_projects.MergeProjects(app, str(base / "src.qda"))
+        merge_projects.DialogMergePreview = original
+        label = "merged" if merged_run else "cancelled"
+        cur = app.conn.cursor()
+        cur.execute("select name, jentry from journal where name like 'Merge preview%'")
+        rows = cur.fetchall()
+        check(f"E1 report saved to a journal ({label})", len(rows) == 1, str([r[0] for r in rows]))
+        if rows:
+            check(f"E1 entry states the outcome ({label})",
+                  ("Result: merged" if merged_run else "cancelled") in rows[0][1])
+            check(f"E1 entry carries the counts ({label})", "Coded PDF areas to add" in rows[0][1])
+        check(f"E1 merge flag correct ({label})", mp.projects_merged is merged_run)
+
+
+# E2. The preview dialog itself builds and lists what it was given
+def e2_preview_dialog_builds():
+    base = fresh("e2")
+    make(base / "src.qda", RICH_SOURCE, media=RICH_MEDIA)
+    make(base / "dst.qda", [
+        "insert into source (id,name,fulltext,mediapath,memo,owner,date,av_text_id) "
+        "values(1,'E01_Rosa.txt','corto','/docs/E01_Rosa.txt','','t','d',null)",
+    ])
+    app = StubApp(base / "dst.qda")
+    captured = {}
+    original = merge_projects.DialogMergePreview
+
+    class Capture:
+        def __init__(self, app_, sections, path_s_, parent=None):
+            captured['sections'] = sections
+
+        def exec(self):
+            return 0
+
+        def save_to_journal(self):
+            return False
+
+    merge_projects.DialogMergePreview = Capture
+    merge_projects.MergeProjects(app, str(base / "src.qda"))
+    merge_projects.DialogMergePreview = original
+    dialog = original(app, captured['sections'], str(base / "src.qda"))
+    check("E2 dialog renders one row per section",
+          dialog.tree.topLevelItemCount() == len(captured['sections']))
+    warnings = [s for s in captured['sections'] if s['warning']]
+    check("E2 different text lengths raised as a warning", len(warnings) == 1,
+          str([s['title'] for s in warnings]))
+    check("E2 journal checkbox defaults to off", dialog.save_to_journal() is False)
+    dialog.close()
+
+
+
+MERGE_HOLDER = [None]
+
+
+if __name__ == "__main__":
+    a1_preview_matches_reality()
+    a2_idempotent()
+    a3_orphans()
+    a4_not_a_project()
+    a5_empty_project_table()
+    a6_old_version()
+    a7_case_data()
+    a8_structure()
+    a9_files_and_handles()
+    a10_unicode_and_quotes()
+    a11_attribute_values()
+    a12_cancel_releases()
+    a13_large_lists()
+    b1_cancel_during_copy()
+    b2_cancel_during_insert()
+    b3_error_rolls_back()
+    b4_single_transaction()
+    b5_progress_headless()
+    c1_progress_returns_after_hide()
+    c2_own_connection()
+    c3_other_writes_survive_rollback()
+    c4_unexpected_error()
+    c5_vectorstore_failure()
+    c6_not_a_project_releases()
+    d1_text_not_held_in_memory()
+    d2_cancel_inside_large_file()
+    e1_journal_report()
+    e2_preview_dialog_builds()
+    failed = [r for r in RESULTS if not r[1]]
+    shutil.rmtree(TMP, ignore_errors=True)
+    print(f"\n{len(RESULTS) - len(failed)}/{len(RESULTS)} checks passed")
+    for name, _ok, detail in failed:
+        print(f"FAILED: {name}   {detail}")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
merge_projects.py

- bug fixes: pdf_page was not carried over: PDF coded areas arrived as NULL and piled up on page 1.
- bug fixes: copy_source_files_into_destination: absolute path join, so no file was ever copied.
- bug fixes: case_text: remapped against newid instead of id, losing case-file links or pointing them at the wrong file.
- bug fixes: code_text.avid was not carried over: transcript codings lost their A/V segment.
- bug fixes: code_image and code_av not deduplicated: merging twice duplicated areas and segments.
- bug fixes: Orphan codings were inserted with cid = -1 or fid = -1.
- bug fixes: A .qda folder without a project: an empty data.qda was created in the user's folder, then a crash.
- bug fixes: Empty project table: TypeError when reading the database version.
- bug fixes: Source connection was never closed.
- bug fixes: Case attribute placeholders written with attr_type 'file' instead of 'case'.
- bug fixes: case_text inserted without owner, date or memo.
- bug fixes: Only sqlite3.Error was caught: any other failure left an open transaction and a modal dialog on screen, freezing the application.
- bug fixes: A failing AI vectorstore update, which runs after the commit, propagated and left the same modal stuck.
- bug fixes: Debug print in insert_categories.

Updates:
- robustness and performance
- The whole merge now runs in one transaction on its own connection: cancel or failure rolls back cleanly, and timers in other dialogs can no longer commit it half way.
- One commit() per row removed. The database phase went from 3.69 s to 0.02 s with 8300 codings, and stays at 0.34 s with 100 000.
- Document text is no longer held in memory for every file. Peak extra memory on a 342 MB project dropped from 400 MB to 132 MB.
- Id remapping moved from nested loops to dictionary lookups.
- Media copied in 8 MB chunks, so Cancel responds inside a large video and no partial file is left.

- DialogMergePreview: preview of what will be incorporated, with counts that match what actually gets inserted, warnings in red, and an option to save the report to journals.
- MergeProgress: progress dialog with Cancel during reading, preview and file copying.


special_functions.py

- projects_merged was overwritten: cancelling a second merge undid the tab refresh owed to the first.
- The Merge button was only re-enabled on cancel, not on failure.

tests file:

test_merge_projects.py: 

- 103 headless checks covering all of the above, verified on Windows with Python 3.14.