### PR TITLE
Update ui_dialog_settings.py

### DIFF
--- a/src/qualcoder/GUI/ui_dialog_settings.py
+++ b/src/qualcoder/GUI/ui_dialog_settings.py
@@ -331,7 +331,7 @@ class Ui_Dialog_settings(object):
         self.label_ai_access_info_url = QtWidgets.QLabel(parent=self.widget_ai_provider)
         self.label_ai_access_info_url.setText("")
         self.label_ai_access_info_url.setOpenExternalLinks(True)
-        self.label_ai_access_info_url.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.NoTextInteraction)
+        self.label_ai_access_info_url.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.LinksAccessibleByKeyboard|QtCore.Qt.TextInteractionFlag.LinksAccessibleByMouse|QtCore.Qt.TextInteractionFlag.TextBrowserInteraction|QtCore.Qt.TextInteractionFlag.TextSelectableByKeyboard|QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
         self.label_ai_access_info_url.setObjectName("label_ai_access_info_url")
         self.gridLayout_6.addWidget(self.label_ai_access_info_url, 4, 2, 1, 1)
         self.label_2 = QtWidgets.QLabel(parent=self.widget_ai_provider)


### PR DESCRIPTION
In Settings → AI, each AI profile shows an "access info" link below the profile
selector — for Blablador the API-access guide
https://sdlaml.pages.jsc.fz-juelich.de/ai/guides/blablador_api_access/, for OpenAI
https://platform.openai.com/api-keys, etc.

This restores interaction on that links, make it clickable and copyable. Tested on my machine.