### PR TITLE
Update ui_dialog_settings.ui

### DIFF
--- a/src/GUI_UIs/ui_dialog_settings.ui
+++ b/src/GUI_UIs/ui_dialog_settings.ui
@@ -814,7 +814,7 @@ langauge = it</string>
                 <bool>true</bool>
                </property>
                <property name="textInteractionFlags">
-                <set>Qt::NoTextInteraction</set>
+                <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
In Settings → AI, each AI profile shows an "access info" link below the profile
selector — for Blablador the API-access guide
https://sdlaml.pages.jsc.fz-juelich.de/ai/guides/blablador_api_access/, for OpenAI
https://platform.openai.com/api-keys, etc.

This restores interaction on that links, make it clickable and copyable. Tested on my machine.