### PR TITLE
Update manage_files.py

### DIFF
--- a/src/qualcoder/manage_files.py
+++ b/src/qualcoder/manage_files.py
@@ -2621,7 +2621,6 @@ class DialogManageFiles(QtWidgets.QDialog):
         id_ = cur.fetchone()[0]
         item['id'] = id_
         ui = DialogEditTextFile(self.app, id_)
-        ui.ui.textEdit.setAcceptRichText(False)
         ui.exec()
         icon, metadata, err_ = self.get_icon_and_metadata(id_)
         item['icon'] = icon


### PR DESCRIPTION
Fix: When creating a new file, the code tried to disable rich text on a text box that no longer exists in that dialog (it is now a plain-text-only field, which never accepts formatting). That leftover line was removed.