### PR TITLE
Issues: AI Assistance (for review)

### DIFF
--- a/src/qualcoder/ai_chat.py
+++ b/src/qualcoder/ai_chat.py
@@ -562,6 +562,7 @@ class DialogAIChat(QtWidgets.QDialog):
     current_streaming_chat_idx = -1
     chat_msg_list = [] 
     is_updating_chat_window = False
+    _chat_ai_model_snapshots = {}
     ai_semantic_search_chunks = []
     last_export_dir = ''
     # filenames = []

--- a/src/qualcoder/ai_chat.py
+++ b/src/qualcoder/ai_chat.py
@@ -2285,8 +2285,9 @@ class DialogAIChat(QtWidgets.QDialog):
             return heading
         safe_model = html_lib.escape(model_line)
         model_size = max(1, self.app.settings['fontsize'] - 1)
+        # plain label, matches the API field name and needs no translation
         heading += (f'<div style="font-size: {model_size}pt; opacity: 0.75;">'
-                    f'{_("model")}: {safe_model}</div>')
+                    f'model: {safe_model}</div>')
         return heading
 
     def _ai_agent_heading_html(self, author: str = '', chat_idx: Optional[int] = None,

--- a/src/qualcoder/ai_chat.py
+++ b/src/qualcoder/ai_chat.py
@@ -676,6 +676,7 @@ class DialogAIChat(QtWidgets.QDialog):
         self.ai_text_text = ''
         self.ai_text_start_pos = -1
         self._chat_ai_profile_snapshots: Dict[int, str] = {}
+        self._chat_ai_model_snapshots: Dict[int, str] = {}
         self.ai_output_autoscroll = True
         self._chat_window_refresh_pending = False
         self._chat_window_refresh_timer = QtCore.QTimer(self)
@@ -1702,6 +1703,7 @@ class DialogAIChat(QtWidgets.QDialog):
                                 msg_type TEXT,
                                 msg_author TEXT,
                                 msg_content TEXT,
+                                msg_model TEXT,
                                 FOREIGN KEY (chat_id) REFERENCES chats(id))''')
         
         cursor.execute('''CREATE TABLE IF NOT EXISTS topic_chat_embeddings (
@@ -1715,6 +1717,10 @@ class DialogAIChat(QtWidgets.QDialog):
         chat_columns = {str(row[1]).strip() for row in cursor.fetchall() if isinstance(row, tuple) and len(row) > 1}
         if 'compaction_frontier_msg_id' not in chat_columns:
             cursor.execute("ALTER TABLE chats ADD COLUMN compaction_frontier_msg_id INTEGER DEFAULT 0")
+        cursor.execute("PRAGMA table_info(chat_messages)")
+        msg_columns = {str(row[1]).strip() for row in cursor.fetchall() if isinstance(row, tuple) and len(row) > 1}
+        if 'msg_model' not in msg_columns:
+            cursor.execute("ALTER TABLE chat_messages ADD COLUMN msg_model TEXT")
         self.chat_history_conn.commit()
         self.current_chat_idx = -1
         self.fill_chat_list()
@@ -1760,6 +1766,7 @@ class DialogAIChat(QtWidgets.QDialog):
         self.ai_text_text = ''
         self.ai_text_start_pos = -1
         self._chat_ai_profile_snapshots.clear()
+        self._chat_ai_model_snapshots.clear()
         self._multi_chat_selection_active = False
 
         selection_model = self.ui.treeView_chat_list.selectionModel()
@@ -2204,6 +2211,13 @@ class DialogAIChat(QtWidgets.QDialog):
             author = ''
         return author or 'unknown'
 
+    def _current_ai_model_id(self) -> str:
+        """Model id actually used for requests, not the profile label."""
+        try:
+            return str(self.app.ai.get_active_model_id()).strip()
+        except Exception:
+            return ''
+
     def _normalize_ai_profile_author(self, author: str = '', chat_idx: Optional[int] = None,
                                      fallback_to_current: bool = False) -> str:
         """Resolve display/storage author names for AI messages."""
@@ -2231,7 +2245,26 @@ class DialogAIChat(QtWidgets.QDialog):
         author = self._current_ai_profile_name()
         if chat_idx is not None and chat_idx >= 0:
             self._chat_ai_profile_snapshots[int(chat_idx)] = author
+            self._chat_ai_model_snapshots[int(chat_idx)] = self._current_ai_model_id()
         return author
+
+    def _resolve_message_model_id(self, model_id: str = '', chat_idx: Optional[int] = None,
+                                  fallback_to_current: bool = False) -> str:
+        """Model id for one message: stored value, chat snapshot, then current."""
+
+        stored = str(model_id if model_id is not None else '').strip()
+        if stored != '':
+            return stored
+        if not fallback_to_current:
+            # Stored messages without a model stay blank, they predate this field.
+            return ''
+        if chat_idx is None:
+            chat_idx = self.current_chat_idx
+        if chat_idx is not None and chat_idx >= 0:
+            snapshot = str(self._chat_ai_model_snapshots.get(int(chat_idx), '')).strip()
+            if snapshot != '':
+                return snapshot
+        return self._current_ai_model_id()
 
     def _clear_chat_ai_profile_snapshot(self, chat_idx: Optional[int] = None) -> None:
         """Remove a previously frozen AI profile snapshot for one chat."""
@@ -2241,20 +2274,34 @@ class DialogAIChat(QtWidgets.QDialog):
         if chat_idx is None or chat_idx < 0:
             return
         self._chat_ai_profile_snapshots.pop(int(chat_idx), None)
+        self._chat_ai_model_snapshots.pop(int(chat_idx), None)
 
-    def _message_heading_html(self, heading_text: str) -> str:
+    def _message_heading_html(self, heading_text: str, model_id: str = '') -> str:
         safe_heading = html_lib.escape(str(heading_text if heading_text is not None else ""))
         heading_size = self.app.settings['fontsize'] + 1
-        return f'<div style="margin-top: 6px; font-size: {heading_size}pt;">⦿ <b>{safe_heading}</b></div>'
+        heading = f'<div style="margin-top: 6px; font-size: {heading_size}pt;">⦿ <b>{safe_heading}</b></div>'
+        model_line = str(model_id if model_id is not None else '').strip()
+        if model_line == '':
+            return heading
+        safe_model = html_lib.escape(model_line)
+        model_size = max(1, self.app.settings['fontsize'] - 1)
+        heading += (f'<div style="font-size: {model_size}pt; opacity: 0.75;">'
+                    f'{_("model")}: {safe_model}</div>')
+        return heading
 
     def _ai_agent_heading_html(self, author: str = '', chat_idx: Optional[int] = None,
-                               fallback_to_current: bool = False) -> str:
+                               fallback_to_current: bool = False, model_id: str = '') -> str:
         display_author = self._normalize_ai_profile_author(
             author,
             chat_idx=chat_idx,
             fallback_to_current=fallback_to_current,
         )
-        return self._message_heading_html(f'{_("AI Agent")} ({display_author}):')
+        display_model = self._resolve_message_model_id(
+            model_id,
+            chat_idx=chat_idx,
+            fallback_to_current=fallback_to_current,
+        )
+        return self._message_heading_html(f'{_("AI Agent")} ({display_author}):', model_id=display_model)
             
     def fill_chat_list(self):
         self.chat_list_model.clear()
@@ -5751,21 +5798,25 @@ data collected. This information will accompany every prompt sent to the AI, res
                 # Show chat messages:
                 agent_status_lines = []
                 agent_status_author = ''
+                agent_status_model = ''
                 markdown_hr_width = max(
                     1,
                     max(self.ui.ai_output.width(), self.ui.scrollArea_ai_output.viewport().width()) - 24
                 )
 
                 def flush_agent_status_block():
-                    nonlocal agent_status_lines, agent_status_author
+                    nonlocal agent_status_lines, agent_status_author, agent_status_model
                     if len(agent_status_lines) == 0:
                         return
                     # body = '<br />'.join(agent_status_lines)
                     body = "".join(agent_status_lines)
-                    block = f'{self._ai_agent_heading_html(agent_status_author, chat_idx=self.current_chat_idx)}<ul>{body}</ul>'
+                    heading = self._ai_agent_heading_html(agent_status_author, chat_idx=self.current_chat_idx,
+                                                          model_id=agent_status_model)
+                    block = f'{heading}<ul>{body}</ul>'
                     html_parts.append(f'<p style={self.ai_status_style}>{block}</p>')
                     agent_status_lines = []
                     agent_status_author = ''
+                    agent_status_model = ''
 
                 for msg in self.chat_msg_list:
                     msg_type = str(msg[2])
@@ -5794,6 +5845,7 @@ data collected. This information will accompany every prompt sent to the AI, res
                             flush_agent_status_block()
                         if agent_status_author == '':
                             agent_status_author = status_author
+                            agent_status_model = str(msg[5] if len(msg) > 5 and msg[5] is not None else '')
                         agent_status_lines.append(status_line)
                         continue
 
@@ -5821,7 +5873,8 @@ data collected. This information will accompany every prompt sent to the AI, res
                             style_role="ai",
                         )
                         author = msg[3]
-                        txt = f'{self._ai_agent_heading_html(author, chat_idx=self.current_chat_idx)}{txt}'
+                        msg_model = msg[5] if len(msg) > 5 else ''
+                        txt = f'{self._ai_agent_heading_html(author, chat_idx=self.current_chat_idx, model_id=msg_model)}{txt}'
                         html_parts.append(f'<p style={self.ai_response_style}>{txt}</p>')
                     elif msg_type == 'info':
                         txt = self._message_heading_html(_("Info:"))
@@ -6609,9 +6662,13 @@ data collected. This information will accompany every prompt sent to the AI, res
             if db_conn is None:
                 db_conn = self.chat_history_conn
             cursor = db_conn.cursor()
+            msg_model = ''
+            if msg_type in ('ai', 'agent_status', 'tool_call', 'single_instruct'):
+                msg_model = self._resolve_message_model_id(
+                    chat_idx=chat_idx, fallback_to_current=True)
             # Insert new message
-            cursor.execute('INSERT INTO chat_messages (chat_id, msg_type, msg_author, msg_content)'
-                           ' VALUES (?, ?, ?, ?)', (curr_chat_id, msg_type, msg_author, msg_content))
+            cursor.execute('INSERT INTO chat_messages (chat_id, msg_type, msg_author, msg_content, msg_model)'
+                           ' VALUES (?, ?, ?, ?, ?)', (curr_chat_id, msg_type, msg_author, msg_content, msg_model))
             if commit:
                 db_conn.commit()
             if refresh:
@@ -6643,8 +6700,10 @@ data collected. This information will accompany every prompt sent to the AI, res
             if prev_author == str(msg_author) and prev_content == status_line:
                 return
 
-        cursor.execute('INSERT INTO chat_messages (chat_id, msg_type, msg_author, msg_content)'
-                       ' VALUES (?, ?, ?, ?)', (curr_chat_id, 'agent_status', msg_author, status_line))
+        cursor.execute('INSERT INTO chat_messages (chat_id, msg_type, msg_author, msg_content, msg_model)'
+                       ' VALUES (?, ?, ?, ?, ?)', (curr_chat_id, 'agent_status', msg_author, status_line,
+                                                   self._resolve_message_model_id(
+                                                       chat_idx=chat_idx, fallback_to_current=True)))
         self.chat_history_conn.commit()
 
     def _chat_user_message_count(self, chat_id: int, db_conn=None) -> int:

--- a/src/qualcoder/ai_llm.py
+++ b/src/qualcoder/ai_llm.py
@@ -894,6 +894,26 @@ class AiLLM():
             return str(self.app.ai_models[model_idx].get('name', '')).strip()
         return 'unknown'
 
+    def get_active_model_id(self, model_kind: str = 'large') -> str:
+        """Return the model id sent to the API, not the user's profile label."""
+
+        normalized_kind = 'fast' if str(model_kind).strip().lower() == 'fast' else 'large'
+        params = self._fast_llm_params if normalized_kind == 'fast' else self._large_llm_params
+        if isinstance(params, dict):
+            for key in ('model', 'azure_deployment', 'deployment_name'):
+                value = str(params.get(key, '') or '').strip()
+                if value != '':
+                    return value
+        # Not initialized yet: fall back to the configured profile.
+        try:
+            model_idx = int(self.app.settings.get('ai_model_index', '-1'))
+            if 0 <= model_idx < len(self.app.ai_models):
+                key = 'fast_model' if normalized_kind == 'fast' else 'large_model'
+                return str(self.app.ai_models[model_idx].get(key, '')).strip()
+        except Exception:
+            pass
+        return ''
+
     def _llm_provider_name(self, factory) -> str:
         if factory is AzureChatOpenAI:
             return 'azure'

--- a/src/qualcoder/ai_mcp_server.py
+++ b/src/qualcoder/ai_mcp_server.py
@@ -217,31 +217,36 @@ class AiMcpServer:
         return ""
 
     def _strip_ai_provenance(self, text: str) -> str:
-        """Remove a provenance block added by an earlier call."""
+        """Remove a provenance block added by an earlier call, in any language."""
 
-        marker = "\n\n**Coded by:**"
-        idx = text.find(marker)
-        if idx >= 0:
-            text = text[:idx]
-        label = "**AI interpretation:** "
-        if text.startswith(label):
-            text = text[len(label):]
-        return text.rstrip()
+        label_line = re.compile(r"^\*\*[^*\n]+:\*\* .*$")
+        parts = text.rsplit("\n\n", 1)
+        if len(parts) != 2:
+            return text.rstrip()
+        tail = [line for line in parts[1].splitlines() if line.strip() != ""]
+        if len(tail) == 0 or not all(label_line.match(line) for line in tail):
+            return text.rstrip()
+        body = parts[0]
+        # only now, the leading label is ours too
+        leading = re.match(r"^\*\*[^*\n]+:\*\* ", body)
+        if leading is not None:
+            body = body[leading.end():]
+        return body.rstrip()
 
     def _stamp_ai_model(self, memo: Any) -> str:
         """Rewrite a memo written by the AI Agent with its provenance block."""
 
         text = self._strip_ai_provenance("" if memo is None else str(memo))
-        block = f"**Coded by:** {self.AI_AGENT_OWNER}"
+        block = f'**{_("Coded by")}:** {self.AI_AGENT_OWNER}'
         profile = self._active_profile_name()
         if profile != "":
-            block += f"\n**AI profile:** {profile}"
+            block += f'\n**{_("AI profile")}:** {profile}'
         model_id = self._active_model_id()
         if model_id != "":
-            block += f"\n**AI model:** {model_id}"
+            block += f'\n**{_("AI model")}:** {model_id}'
         if text.strip() == "":
             return block
-        return f"**AI interpretation:** {text}\n\n{block}"
+        return f'**{_("AI interpretation")}:** {text}\n\n{block}'
 
     def _stamp_ai_model_if_ai_owned(self, memo: Any, owner: Any) -> str:
         """Stamp only entities the AI Agent owns, never a human memo."""

--- a/src/qualcoder/ai_mcp_server.py
+++ b/src/qualcoder/ai_mcp_server.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 """
 Internal MCP server for QualCoder.
@@ -198,6 +198,27 @@ class AiMcpServer:
         """Normalize one AI-provided memo update to public text only."""
 
         return self._memo_public_text(memo)
+
+    def _active_model_id(self) -> str:
+        """Model id used by the agent, not the profile label."""
+        try:
+            return str(self.app.ai.get_active_model_id()).strip()
+        except Exception:
+            return ""
+
+    def _stamp_ai_model(self, memo: Any) -> str:
+        """Append the model id to a memo written by the AI Agent."""
+
+        text = "" if memo is None else str(memo)
+        model_id = self._active_model_id()
+        if model_id == "":
+            return text
+        stamp = f"{self.AI_AGENT_OWNER}, model: {model_id}"
+        if stamp in text:
+            return text
+        if text.strip() == "":
+            return stamp
+        return f"{text}\n\n{stamp}"
 
     def _merge_public_memo(self, existing_memo: Any, memo: Any) -> str:
         """Replace only the AI-visible memo text and preserve any private suffix."""
@@ -1522,7 +1543,7 @@ class AiMcpServer:
             cur.execute(
                 "INSERT INTO code_name (name, memo, catid, owner, date, color, supercid) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (name, memo, catid, self.AI_AGENT_OWNER, now, color, supercid),
+                (name, self._stamp_ai_model(memo), catid, self.AI_AGENT_OWNER, now, color, supercid),
             )
             cid = int(cur.lastrowid)
             conn.commit()
@@ -1620,7 +1641,7 @@ class AiMcpServer:
 
             cur.execute(
                 "INSERT INTO code_text (cid, fid, seltext, pos0, pos1, owner, date, memo) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (cid, fid, seltext, pos0, pos1, self.AI_AGENT_OWNER, now, memo),
+                (cid, fid, seltext, pos0, pos1, self.AI_AGENT_OWNER, now, self._stamp_ai_model(memo)),
             )
             ctid = int(cur.lastrowid)
             conn.commit()

--- a/src/qualcoder/ai_mcp_server.py
+++ b/src/qualcoder/ai_mcp_server.py
@@ -206,19 +206,42 @@ class AiMcpServer:
         except Exception:
             return ""
 
-    def _stamp_ai_model(self, memo: Any) -> str:
-        """Append the model id to a memo written by the AI Agent."""
+    def _active_profile_name(self) -> str:
+        """Profile label the user gave the API entry."""
+        try:
+            model_idx = int(self.app.settings.get("ai_model_index", "-1"))
+            if 0 <= model_idx < len(self.app.ai_models):
+                return str(self.app.ai_models[model_idx].get("name", "")).strip()
+        except Exception:
+            pass
+        return ""
 
-        text = "" if memo is None else str(memo)
+    def _strip_ai_provenance(self, text: str) -> str:
+        """Remove a provenance block added by an earlier call."""
+
+        marker = "\n\n**Coded by:**"
+        idx = text.find(marker)
+        if idx >= 0:
+            text = text[:idx]
+        label = "**AI interpretation:** "
+        if text.startswith(label):
+            text = text[len(label):]
+        return text.rstrip()
+
+    def _stamp_ai_model(self, memo: Any) -> str:
+        """Rewrite a memo written by the AI Agent with its provenance block."""
+
+        text = self._strip_ai_provenance("" if memo is None else str(memo))
+        block = f"**Coded by:** {self.AI_AGENT_OWNER}"
+        profile = self._active_profile_name()
+        if profile != "":
+            block += f"\n**AI profile:** {profile}"
         model_id = self._active_model_id()
-        if model_id == "":
-            return text
-        stamp = f"{self.AI_AGENT_OWNER}, model: {model_id}"
-        if stamp in text:
-            return text
+        if model_id != "":
+            block += f"\n**AI model:** {model_id}"
         if text.strip() == "":
-            return stamp
-        return f"{text}\n\n{stamp}"
+            return block
+        return f"**AI interpretation:** {text}\n\n{block}"
 
     def _stamp_ai_model_if_ai_owned(self, memo: Any, owner: Any) -> str:
         """Stamp only entities the AI Agent owns, never a human memo."""

--- a/src/qualcoder/ai_mcp_server.py
+++ b/src/qualcoder/ai_mcp_server.py
@@ -1547,10 +1547,11 @@ class AiMcpServer:
                     },
                 }
 
+            memo = self._stamp_ai_model(memo)
             cur.execute(
                 "INSERT INTO code_name (name, memo, catid, owner, date, color, supercid) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (name, self._stamp_ai_model(memo), catid, self.AI_AGENT_OWNER, now, color, supercid),
+                (name, memo, catid, self.AI_AGENT_OWNER, now, color, supercid),
             )
             cid = int(cur.lastrowid)
             conn.commit()
@@ -1646,9 +1647,10 @@ class AiMcpServer:
                     },
                 }
 
+            memo = self._stamp_ai_model(memo)
             cur.execute(
                 "INSERT INTO code_text (cid, fid, seltext, pos0, pos1, owner, date, memo) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (cid, fid, seltext, pos0, pos1, self.AI_AGENT_OWNER, now, self._stamp_ai_model(memo)),
+                (cid, fid, seltext, pos0, pos1, self.AI_AGENT_OWNER, now, memo),
             )
             ctid = int(cur.lastrowid)
             conn.commit()

--- a/src/qualcoder/ai_mcp_server.py
+++ b/src/qualcoder/ai_mcp_server.py
@@ -220,6 +220,13 @@ class AiMcpServer:
             return stamp
         return f"{text}\n\n{stamp}"
 
+    def _stamp_ai_model_if_ai_owned(self, memo: Any, owner: Any) -> str:
+        """Stamp only entities the AI Agent owns, never a human memo."""
+
+        if str(owner if owner is not None else "").strip() != self.AI_AGENT_OWNER:
+            return "" if memo is None else str(memo)
+        return self._stamp_ai_model(memo)
+
     def _merge_public_memo(self, existing_memo: Any, memo: Any) -> str:
         """Replace only the AI-visible memo text and preserve any private suffix."""
 
@@ -1851,7 +1858,8 @@ class AiMcpServer:
             old_name = str(code.get("name", ""))
             old_memo = str(code.get("memo", ""))
             new_name = old_name if not has_name else " ".join(str(arguments.get("name", "")).split()).strip()
-            new_memo = old_memo if not has_memo else self._merge_public_memo(old_memo, arguments.get("memo", ""))
+            new_memo = old_memo if not has_memo else self._merge_public_memo(
+                old_memo, self._stamp_ai_model_if_ai_owned(arguments.get("memo", ""), code.get("owner")))
             if new_name == "":
                 raise ValueError("name must not be empty.")
             if new_name.casefold() != old_name.casefold():
@@ -1921,7 +1929,8 @@ class AiMcpServer:
                 raise ValueError(f"Text coding id {ctid} not found.")
 
             old_memo = str(coding.get("memo", ""))
-            new_memo = self._merge_public_memo(old_memo, arguments.get("memo", ""))
+            new_memo = self._merge_public_memo(
+                old_memo, self._stamp_ai_model_if_ai_owned(arguments.get("memo", ""), coding.get("owner")))
             if new_memo == old_memo:
                 return {
                     "tool": "codes/update_text_coding",

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -76,6 +76,8 @@ class DialogCodeText(QtWidgets.QWidget):
     Trialled using setHtml for documents, but on marking text Html formatting was replaced, also
     on unmarking text, the unmark was not immediately cleared (needed to reload the file). """
 
+    ai_search_message_shown = False  # text view holds a search message, not file text
+
     def __init__(self, app, parent_textedit, tab_reports):
 
         super(DialogCodeText, self).__init__()
@@ -494,7 +496,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ai_search_found = False
         self.ai_search_analysis_counter = 0
         self.ai_search_session_id = 0
-        self.ai_search_message_shown = False  # text view holds a search message, not file text
+        self.ai_search_message_shown = False
         self.ui.pushButton_ai_search.pressed.connect(self.ai_search_clicked)
         self.ui.listWidget_ai.selectionModel().selectionChanged.connect(self.ai_search_selection_changed)
         self.ai_search_listview_action_label = None

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -4631,6 +4631,13 @@ class DialogCodeText(QtWidgets.QWidget):
             if 'color' not in item:
                 item['color'] = '#cccccc'
             self.code_text.append(item)
+        if self.ai_search_message_shown:
+            # a search message is on screen: no tooltips, no highlighting
+            self.eventFilterTT.set_codes_and_annotations(self.app, [], self.codes, [], self.file_)
+            if getattr(self, 'coding_margin', None) is not None:
+                self.coding_margin.update()
+            return
+
         # Update filter for tooltip and redo formatting
         if self.important:
             imp_coded = []
@@ -4780,7 +4787,7 @@ class DialogCodeText(QtWidgets.QWidget):
         For defined colours in color_selector, make text light on dark, and conversely dark on light
         """
 
-        if self.file_ is None or self.ui.plainTextEdit.toPlainText() == "":
+        if self.file_ is None or self.ai_search_message_shown or self.ui.plainTextEdit.toPlainText() == "":
             # still refresh the side margin so it clears properly <- L
             if hasattr(self, 'coding_margin') and self.coding_margin is not None:
                 self.coding_margin.update()

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -37,7 +37,7 @@ import sqlite3
 import unicodedata
 import webbrowser
 
-from PyQt6 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets, sip
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QBrush, QColor
 # Required for the _export_odt_clean method which generates native ODF files with ranged annotations using odfpy
@@ -489,10 +489,12 @@ class DialogCodeText(QtWidgets.QWidget):
         self.ai_search_current_result_index = None
         self.ai_search_prompt = None
         self.ai_search_ai_model = None
+        self.ai_search_ai_model_id = ''
         self.ai_include_coded_segments = None
         self.ai_search_found = False
         self.ai_search_analysis_counter = 0
         self.ai_search_session_id = 0
+        self.ai_search_message_shown = False  # text view holds a search message, not file text
         self.ui.pushButton_ai_search.pressed.connect(self.ai_search_clicked)
         self.ui.listWidget_ai.selectionModel().selectionChanged.connect(self.ai_search_selection_changed)
         self.ai_search_listview_action_label = None
@@ -595,6 +597,32 @@ class DialogCodeText(QtWidgets.QWidget):
         except Exception as err:
             logger.warning(err)
             return False
+
+    def _show_ai_search_message(self, message=''):
+        """Show a temporary search message instead of the file text."""
+
+        self.ai_search_message_shown = True
+        self.ui.plainTextEdit.setPlainText(message)
+        if getattr(self, 'eventFilterTT', None) is not None and self.file_ is not None:
+            # no code tooltips over a search message
+            self.eventFilterTT.set_codes_and_annotations(self.app, [], self.codes, [], self.file_)
+        if getattr(self, 'coding_margin', None) is not None:
+            self.coding_margin.update()
+
+    def _ai_search_ui_alive(self) -> bool:
+        """False when the coding window was closed while a search was running."""
+
+        try:
+            ui = self.ui
+        except RuntimeError:
+            return False
+        if ui is None:
+            return False
+        for widget_name in ('listWidget_ai', 'plainTextEdit'):
+            widget = getattr(ui, widget_name, None)
+            if widget is None or sip.isdeleted(widget):
+                return False
+        return True
 
     def _ai_search_scope_status(self) -> str:
         ai = getattr(self.app, 'ai', None)
@@ -4530,6 +4558,7 @@ class DialogCodeText(QtWidgets.QWidget):
         if self.text.endswith('\n'):
             self.text = self.text[:-1]
         self.detect_text_direction()
+        self.ai_search_message_shown = False
         self.ui.plainTextEdit.setPlainText(self.text)
 
         # margin visibility handled via layout container; sync with preference <- L
@@ -4914,7 +4943,9 @@ class DialogCodeText(QtWidgets.QWidget):
             if ai_search_result is not None:
                 memo = _("AI interpretation: ") + ai_search_result["interpretation"]
                 memo += _("\n\nAI search prompt: ") + prompt_name_and_scope(self.ai_search_prompt)
-                memo += _("\nAI model: ") + self.ai_search_ai_model
+                memo += _("\nAI profile: ") + self.ai_search_ai_model
+                if str(self.ai_search_ai_model_id).strip() != '':
+                    memo += _("\nAI model: ") + str(self.ai_search_ai_model_id).strip()
 
                 msg = '<p style="font-size: ' + str(self.app.settings['fontsize']) + 'pt">'
                 msg += _("Do you want to store the AI interpretation in a memo together with the coding?<br/><br/>")
@@ -5742,6 +5773,7 @@ class DialogCodeText(QtWidgets.QWidget):
         self.file_['start'] = 0
         self.file_['end'] = len(file_result['fulltext'])
         self.text = file_result['fulltext']
+        self.ai_search_message_shown = False
         self.ui.plainTextEdit.setPlainText(self.text)
         self.prev_text = copy(self.text)
         self.ui.plainTextEdit.removeEventFilter(self.eventFilterTT)
@@ -6292,6 +6324,8 @@ class DialogCodeText(QtWidgets.QWidget):
             self.ai_search_results = []
             self.ai_search_prompt = ui.current_prompt
             self.ai_search_ai_model = self.app.ai_models[int(self.app.settings['ai_model_index'])]['name']
+            # store the model id actually used, not only the profile label
+            self.ai_search_ai_model_id = self.app.ai.get_active_model_id()
 
             # Prepare the UI
             self.ai_search_running = True
@@ -6300,7 +6334,7 @@ class DialogCodeText(QtWidgets.QWidget):
             self.ui.listWidget_ai.clear()
             self.ai_search_current_result_index = None
             self.ai_search_spinner_timer.start(500)
-            self.ui.plainTextEdit.setPlainText(_('Searching for related data, please wait...'))
+            self._show_ai_search_message(_('Searching for related data, please wait...'))
 
             # Phase 1: find similar chunks of data from the vectorstore
             self.ai_search_session_id += 1
@@ -6327,10 +6361,10 @@ class DialogCodeText(QtWidgets.QWidget):
             return
         if self._ai_search_scope_status() == 'canceled':
             self.ai_search_running = False
-            self.ui.plainTextEdit.setPlainText('')
+            self._show_ai_search_message()
             return
         if chunks is None or len(chunks) == 0:
-            self.ui.plainTextEdit.setPlainText('')
+            self._show_ai_search_message()
             msg = _('AI: No related data found for "') + self.ai_search_code_name + '".'
             Message(self.app, _('AI Search'), msg, "warning").exec()
             self.ai_search_running = False
@@ -6370,14 +6404,14 @@ class DialogCodeText(QtWidgets.QWidget):
             chunks = filtered_chunks
 
         if len(chunks) == 0:
-            self.ui.plainTextEdit.setPlainText('')
+            self._show_ai_search_message()
             msg = _('AI: No new data found for "') + self.ai_search_code_name + _(
                 '" beside what has already been coded with this code.')
             Message(self.app, _('AI Search'), msg, "warning").exec()
             self.ai_search_running = False
             return
 
-        self.ui.plainTextEdit.setPlainText(
+        self._show_ai_search_message(
             _('Potentially related data found, inspecting it closer. Please be patient...'))
 
         # 2) Send the first "ai_search_analysis_max_count" chunks to the llm for further analysis 
@@ -6396,6 +6430,10 @@ class DialogCodeText(QtWidgets.QWidget):
         the user has to click on 'find more' to continue), or 
         2) 'len(self.ai_search_similar_chunk_list)' is reached, meaning that all the 
         chunks found in step 1 have been analyzed and the search is finished."""
+
+        if not self._ai_search_ui_alive():  # coding window closed, stop the search
+            self.ai_search_running = False
+            return
 
         if self.ai_search_chunks_pos < len(self.ai_search_similar_chunk_list):
             # still chunks left for analysis            
@@ -6417,7 +6455,7 @@ class DialogCodeText(QtWidgets.QWidget):
                 self.ai_search_running = False
                 if len(self.ai_search_results) == 0:  # nothing found
                     self.ai_search_update_listview_action()
-                    self.ui.plainTextEdit.setPlainText('')
+                    self._show_ai_search_message()
                     msg = _('The closer inspection of the first ') + str(self.ai_search_chunks_pos) + ' ' + \
                           _('pieces of data yielded no results. You can continue to inspect more by clicking on "find '
                             'more" in the list on the left.')
@@ -6425,7 +6463,7 @@ class DialogCodeText(QtWidgets.QWidget):
         else:  # search finished
             self.ai_search_running = False
             if len(self.ai_search_results) == 0:  # nothing found
-                self.ui.plainTextEdit.setPlainText('')
+                self._show_ai_search_message()
                 self.ai_search_update_listview_action()
                 msg = _(
                     'Upon closer inspection, no pieces of data relevant to your search query could be identified. '
@@ -6443,6 +6481,9 @@ class DialogCodeText(QtWidgets.QWidget):
         if session_id is not None and int(session_id) != int(self.ai_search_session_id):
             return
         if not self.ai_search_running:  # Search has been cancelled
+            return
+        if not self._ai_search_ui_alive():  # coding window closed while running
+            self.ai_search_running = False
             return
         if doc is not None:
             self.ai_search_results.append(doc)
@@ -6472,6 +6513,9 @@ class DialogCodeText(QtWidgets.QWidget):
         - Stop search: Shown if a search is actually running in the background
         - (search finished): Shown if all results from stage 1 have already been analyzed  
         """
+        if not self._ai_search_ui_alive():  # nothing to update anymore
+            return
+
         # add action item to the list if necessary
         if self.ui.listWidget_ai.count() <= len(self.ai_search_results):
             self.ui.listWidget_ai.addItem('')
@@ -6636,6 +6680,13 @@ class DialogCodeText(QtWidgets.QWidget):
     def ai_search_update_spinner(self):
         """ Updating the ai_progressBar and the text spinner in the list view to indicate to the user that 
         an AI search is running in the background. """
+        if not self._ai_search_ui_alive():  # coding window closed, stop the timer
+            self.ai_search_running = False
+            try:
+                self.ai_search_spinner_timer.stop()
+            except RuntimeError:
+                pass
+            return
         if self._ai_search_scope_status() in ('finished', 'errored', 'canceled', 'idle'):
             self.ai_search_running = False
         if self.ai_search_running:

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -4972,12 +4972,12 @@ class DialogCodeText(QtWidgets.QWidget):
         if self.ui.tabWidget.currentIndex() == 1:  # ai search
             ai_search_result = self.get_overlapping_ai_search_result()
             if ai_search_result is not None:
-                # fixed English labels: the memo is a provenance record, not UI text
-                memo = "**AI interpretation:** " + ai_search_result["interpretation"]
-                memo += "\n\n**AI search prompt:** " + prompt_name_and_scope(self.ai_search_prompt)
-                memo += "\n**AI profile:** " + str(self.ai_search_ai_model)
+                # labels are bold and translatable, the markup stays out of the catalog
+                memo = f'**{_("AI interpretation")}:** ' + ai_search_result["interpretation"]
+                memo += f'\n\n**{_("AI search prompt")}:** ' + prompt_name_and_scope(self.ai_search_prompt)
+                memo += f'\n**{_("AI profile")}:** ' + str(self.ai_search_ai_model)
                 if str(self.ai_search_ai_model_id).strip() != '':
-                    memo += "\n**AI model:** " + str(self.ai_search_ai_model_id).strip()
+                    memo += f'\n**{_("AI model")}:** ' + str(self.ai_search_ai_model_id).strip()
 
                 msg = '<p style="font-size: ' + str(self.app.settings['fontsize']) + 'pt">'
                 msg += _("Do you want to store the AI interpretation in a memo together with the coding?<br/><br/>")

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -4972,11 +4972,12 @@ class DialogCodeText(QtWidgets.QWidget):
         if self.ui.tabWidget.currentIndex() == 1:  # ai search
             ai_search_result = self.get_overlapping_ai_search_result()
             if ai_search_result is not None:
-                memo = _("AI interpretation: ") + ai_search_result["interpretation"]
-                memo += _("\n\nAI search prompt: ") + prompt_name_and_scope(self.ai_search_prompt)
-                memo += _("\nAI profile: ") + self.ai_search_ai_model
+                # fixed English labels: the memo is a provenance record, not UI text
+                memo = "**AI interpretation:** " + ai_search_result["interpretation"]
+                memo += "\n\n**AI search prompt:** " + prompt_name_and_scope(self.ai_search_prompt)
+                memo += "\n**AI profile:** " + str(self.ai_search_ai_model)
                 if str(self.ai_search_ai_model_id).strip() != '':
-                    memo += _("\nAI model: ") + str(self.ai_search_ai_model_id).strip()
+                    memo += "\n**AI model:** " + str(self.ai_search_ai_model_id).strip()
 
                 msg = '<p style="font-size: ' + str(self.app.settings['fontsize']) + 'pt">'
                 msg += _("Do you want to store the AI interpretation in a memo together with the coding?<br/><br/>")

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -587,6 +587,21 @@ class DialogCodeText(QtWidgets.QWidget):
 
         self.ui.pushButton_ai_search.setEnabled(self._ai_menu_options_enabled())
 
+    def closeEvent(self, event):
+        """Cancel a running AI search so it does not block the next coding window."""
+
+        try:
+            if self.ai_search_running:
+                self.ai_search_running = False
+                try:
+                    self.ai_search_spinner_timer.stop()
+                except RuntimeError:
+                    pass
+            self._cancel_ai_search_scope(wait_ms=0)
+        except Exception as err:
+            logger.debug(f"Could not cancel AI search on close: {err}")
+        event.accept()
+
     def _ai_search_scope_id(self):
         return id(self)
 
@@ -603,6 +618,8 @@ class DialogCodeText(QtWidgets.QWidget):
     def _show_ai_search_message(self, message=''):
         """Show a temporary search message instead of the file text."""
 
+        if not self._ai_search_ui_alive():  # window gone, nothing to show
+            return
         self.ai_search_message_shown = True
         self.ui.plainTextEdit.setPlainText(message)
         if getattr(self, 'eventFilterTT', None) is not None and self.file_ is not None:
@@ -6376,6 +6393,9 @@ class DialogCodeText(QtWidgets.QWidget):
 
         if session_id is not None and int(session_id) != int(self.ai_search_session_id):
             return
+        if not self._ai_search_ui_alive():  # coding window closed while running
+            self.ai_search_running = False
+            return
         if self._ai_search_scope_status() == 'canceled':
             self.ai_search_running = False
             self._show_ai_search_message()
@@ -6674,6 +6694,8 @@ class DialogCodeText(QtWidgets.QWidget):
     def scroll_text_into_view(self):
         """Scroll so the current selection is centered in the viewport."""
 
+        if not self._ai_search_ui_alive():  # deferred call, window may be gone
+            return
         editor = self.ui.plainTextEdit
         original_cursor = editor.textCursor()
         if not original_cursor.hasSelection():

--- a/src/qualcoder/code_text.py
+++ b/src/qualcoder/code_text.py
@@ -3035,6 +3035,8 @@ class DialogCodeText(QtWidgets.QWidget):
 
         self.overlaps_at_pos = []
         self.overlaps_at_pos_idx = 0
+        if self.ai_search_message_shown:  # the editor holds a search message
+            return
         pos = self.ui.plainTextEdit.textCursor().position()
         for item in self.code_text:
             if item['pos0'] <= pos + self.file_['start'] <= item['pos1']:
@@ -4887,6 +4889,9 @@ class DialogCodeText(QtWidgets.QWidget):
         if self.file_ is None:
             Message(self.app, _('Warning'), _("No file was selected"), "warning").exec()
             return
+        if self.ai_search_message_shown:  # search message on screen, not the file text
+            Message(self.app, _('Warning'), _("Open a search result before coding"), "warning").exec()
+            return
         self.clear_edit_variables()
         item = self.ui.treeWidget.currentItem()
         if item is None:
@@ -6325,7 +6330,10 @@ class DialogCodeText(QtWidgets.QWidget):
             self.ai_search_prompt = ui.current_prompt
             self.ai_search_ai_model = self.app.ai_models[int(self.app.settings['ai_model_index'])]['name']
             # store the model id actually used, not only the profile label
-            self.ai_search_ai_model_id = self.app.ai.get_active_model_id()
+            try:
+                self.ai_search_ai_model_id = self.app.ai.get_active_model_id()
+            except Exception:
+                self.ai_search_ai_model_id = ''
 
             # Prepare the UI
             self.ai_search_running = True

--- a/src/qualcoder/code_text_coding_margin.py
+++ b/src/qualcoder/code_text_coding_margin.py
@@ -97,6 +97,9 @@ class CodingMargin(QtWidgets.QWidget):
 
         if not self.dialog.file_ or not self.dialog.code_text:
             return None, [], None
+        if getattr(self.dialog, 'ai_search_message_shown', False):
+            # the editor holds a search message, not the file text
+            return None, [], None
 
         current_fid = self.dialog.file_['id']
         important_only = getattr(self.dialog, 'important', False)
@@ -195,6 +198,8 @@ class CodingMargin(QtWidgets.QWidget):
             background_color = self.editor.viewport().palette().color(QtGui.QPalette.ColorRole.Base)
             painter.fillRect(event.rect(), background_color)
             if not self.dialog.file_ or not self.dialog.code_text:
+                return
+            if getattr(self.dialog, 'ai_search_message_shown', False):
                 return
             font = QtGui.QFont(self.dialog.app.settings['font'], 9)
             painter.setFont(font)
@@ -321,6 +326,8 @@ class CodingMargin(QtWidgets.QWidget):
         Matches both the coloured stripe and the code name label"""
 
         if not self.dialog.file_ or not self.dialog.code_text:
+            return None
+        if getattr(self.dialog, 'ai_search_message_shown', False):
             return None
 
         ctid_columns, _sorted, current_fid = self._compute_lane_layout()


### PR DESCRIPTION
Hi @kaixxx 

I found some issues when using AI Assistance in Code Text. The first is that the coding margin keeps showing the codings of the document that was in the viewer, and the segments found by the search appear as if they were coded, tooltips included. That can be confusing and can lead to deleting codings by accident.

There is also a problem when switching coding windows while the assistant is running.

On top of that, when the AI Agent assigns codes it leaves no trace in the memos, unlike what happens with AI Assistance. I added that trace and, along with it, the model being used, for traceability and auditing, and to keep both ways of coding with AI consistent.

This last part is a proposal, since academic journals increasingly ask authors to state the model used, not only the tool.


**Closed window fix**

- No more crash when the coding window is closed while an AI search is running.

```
  File "D:\QualCoder-master\src\qualcoder\code_text.py", line 6310, in <lambda>
    lambda chunks, session_id=current_session_id: self.ai_search_prepare_analysis(chunks, session_id),
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "D:\QualCoder-master\src\qualcoder\code_text.py", line 6380, in ai_search_prepare_analysis
    self.ui.plainTextEdit.setPlainText(

RuntimeError: wrapped C/C++ object of type QPlainTextEdit has been deleted
```

**Coding margin fix**

- Codes no longer float in the margin during a search, and the highlight colours no longer come back if something refreshes the project in the background.

<img width="977" height="432" alt="image" src="https://github.com/user-attachments/assets/932595e8-9e16-4c51-b10d-3bff0b452391" />


- While the message is on screen there are no code tooltips and no margin clicks, and that text cannot be coded by mistake.
- Everything returns to normal once a result is opened or the file changes.

**AI model**

- The chat shows the actual model under the heading of each answer, not just the profile name, and stores it with the message so an old chat still says what produced it.
- The model is fixed when the answer starts, so it cannot change mid-run.
- What the agent codes carries the model in its memo, keeps it when the agent edits its own work later, and never stamps a human's memo.
- In AI-assisted coding the memo now separates profile and model.
- If the model cannot be determined, everything behaves as before.

<img width="543" height="428" alt="image" src="https://github.com/user-attachments/assets/1dbce63d-ad9a-4e6c-9acb-bcf3dadbd944" />
