### PR TITLE
Cleaner MacOS app termination

### DIFF
--- a/src/qualcoder/__main__.py
+++ b/src/qualcoder/__main__.py
@@ -39,6 +39,10 @@ from typing import Optional
 import urllib.request
 import webbrowser
 
+# Hugging Face tokenizers otherwise creates a native Rayon thread pool which can
+# outlive the Qt window in frozen macOS builds and crash during QApplication teardown.
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
 from PyQt6 import QtCore, QtGui, QtWidgets
 import qtawesome as qta
 from qualcoder.ai_chat import DialogAIChat
@@ -2908,7 +2912,11 @@ def gui():
         # log the exception and show error msg
         qt_exception_hook.exception_hook(type_e, value, tb_obj)
 
-    sys.exit(app.exec())
+    exit_code = app.exec()
+    app.processEvents()
+    QtCore.QCoreApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    app.processEvents()
+    return exit_code
 
 
 def install_droid_sans_mono():
@@ -2932,4 +2940,4 @@ def install_noto_sans():
 if __name__ == "__main__":
     # Pyinstaller fix
     multiprocessing.freeze_support()
-    gui()
+    sys.exit(gui())

--- a/src/qualcoder/ai_llm.py
+++ b/src/qualcoder/ai_llm.py
@@ -4782,6 +4782,8 @@ class AiLLM():
     def close(self):
         self._status = 'closing'
         self.cancel_all_runs(wait_ms=5000)
+        if not self.threadpool.waitForDone(5000):
+            logger.warning("AI LLM worker still running after 5s, cancellation left in place")
         self.sources_vectorstore.close()
         self._large_llm_params = None
         self._fast_llm_params = None

--- a/src/qualcoder/ai_vectorstore.py
+++ b/src/qualcoder/ai_vectorstore.py
@@ -45,6 +45,7 @@ os.environ['FAISS_NO_AVX2'] = '1'
 # index also compatible with older machines and non-intel platforms.    
 os.environ['FAISS_OPT_LEVEL'] = '' 
 os.environ["HF_HUB_DISABLE_TELEMETRY"] = "1"
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
 import faiss
 from huggingface_hub import hf_hub_download


### PR DESCRIPTION
Compiling on MacOS showed a small app termination problem, which could lead to a crash message after closing QualCoder. Fixed here.