### PR TITLE
column issues (manage files, cases, journals & references)

### DIFF
--- a/src/qualcoder/cases.py
+++ b/src/qualcoder/cases.py
@@ -845,6 +845,8 @@ class DialogCases(QtWidgets.QDialog):
         action_hide_columns_starting = menu.addAction(_("Hide columns starting with"))
         action_show_columns_starting = menu.addAction(_("Show columns starting with"))
         action = menu.exec(self.ui.tableWidget.mapToGlobal(position))
+        if action is None:  # Dismissed menu: None matches unbuilt actions
+            return
         if action == action_show_all_columns:
             for c in range(0, self.ui.tableWidget.columnCount()):
                 self.ui.tableWidget.setColumnHidden(c, False)
@@ -858,6 +860,8 @@ class DialogCases(QtWidgets.QDialog):
             msg = _("Hide columns starting with:")
             hide_col, ok = QtWidgets.QInputDialog.getText(self, _("Hide Columns"), msg,
                                                             QtWidgets.QLineEdit.EchoMode.Normal)
+            if not ok or hide_col == "":  # Empty prefix matched every column
+                return
             for c in range(1, self.ui.tableWidget.columnCount()):
                 h_text = self.ui.tableWidget.horizontalHeaderItem(c).text()
                 if len(h_text) >= len(hide_col) and hide_col == h_text[:len(hide_col)]:
@@ -867,6 +871,8 @@ class DialogCases(QtWidgets.QDialog):
             msg = _("Show columns starting with:")
             show_col, ok = QtWidgets.QInputDialog.getText(self, _("Show Columns"), msg,
                                                             QtWidgets.QLineEdit.EchoMode.Normal)
+            if not ok or show_col == "":  # Cancel must not rearrange columns
+                return
             for c in range(3, self.ui.tableWidget.columnCount()):
                 h_text = self.ui.tableWidget.horizontalHeaderItem(c).text()
                 if len(h_text) >= len(show_col) and show_col == h_text[:len(show_col)]:

--- a/src/qualcoder/journals.py
+++ b/src/qualcoder/journals.py
@@ -421,6 +421,8 @@ class DialogJournals(QtWidgets.QDialog):
             action_attribute_descending = menu.addAction(_("Descending"))
 
         action = menu.exec(self.ui.tableWidget.mapToGlobal(position))
+        if action is None:  # Dismissed menu: None matches unbuilt actions
+            return
         if action == action_modified_date_asc:
             self.load_journals("date asc")
             return
@@ -487,13 +489,14 @@ class DialogJournals(QtWidgets.QDialog):
         action_show_all = None
         if self.rows_hidden:
             action_show_all = menu.addAction(_("Show all rows Ctrl A"))
-            self.rows_hidden = False
         # Convert journal to source file <- L    
         action_convert_to_source = None
         if row != -1:
             action_convert_to_source = menu.addAction(_("Convert journal to source file"))
 
         action = menu.exec(self.ui.tableWidget.mapToGlobal(position))
+        if action is None:  # Dismissed menu: None matches unbuilt actions
+            return
         if action == action_modified_date_asc:
             self.load_journals("date asc")
             return

--- a/src/qualcoder/manage_files.py
+++ b/src/qualcoder/manage_files.py
@@ -954,6 +954,8 @@ class DialogManageFiles(QtWidgets.QDialog):
         action_hide_columns_starting = menu.addAction(_("Hide columns starting with"))
         action_show_columns_starting = menu.addAction(_("Show columns starting with"))
         action = menu.exec(self.ui.tableWidget.mapToGlobal(position))
+        if action is None:  # Dismissed menu: None matches unbuilt actions
+            return
         if action == action_show_all_columns:
             for c in range(0, self.ui.tableWidget.columnCount()):
                 self.ui.tableWidget.setColumnHidden(c, False)
@@ -967,6 +969,8 @@ class DialogManageFiles(QtWidgets.QDialog):
             msg = _("Hide columns starting with:")
             hide_filter, ok = QtWidgets.QInputDialog.getText(self, _("Hide Columns"), msg,
                                                              QtWidgets.QLineEdit.EchoMode.Normal)
+            if not ok or hide_filter == "":  # Empty prefix matched every column
+                return
             for c in range(1, self.ui.tableWidget.columnCount()):
                 h_text = self.ui.tableWidget.horizontalHeaderItem(c).text()
                 if len(h_text) >= len(hide_filter) and hide_filter == h_text[:len(hide_filter)]:
@@ -975,6 +979,8 @@ class DialogManageFiles(QtWidgets.QDialog):
             msg = _("Show columns starting with:")
             show_filter, ok = QtWidgets.QInputDialog.getText(self, _("Show Columns"), msg,
                                                              QtWidgets.QLineEdit.EchoMode.Normal)
+            if not ok or show_filter == "":  # Cancel must not rearrange columns
+                return
             for c in range(4, self.ui.tableWidget.columnCount()):
                 h_text = self.ui.tableWidget.horizontalHeaderItem(c).text()
                 if len(h_text) >= len(show_filter) and show_filter == h_text[:len(show_filter)]:

--- a/src/qualcoder/manage_references.py
+++ b/src/qualcoder/manage_references.py
@@ -251,6 +251,8 @@ class DialogReferenceManager(QtWidgets.QDialog):
         if self.table_files_rows_hidden:
             action_show_all_rows = menu.addAction(_("Show all rows"))
         action = menu.exec(self.ui.tableWidget_files.mapToGlobal(position))
+        if action is None:  # Dismissed menu: None matches unbuilt actions
+            return
         if action == action_show_all_rows:
             for r in range(0, self.ui.tableWidget_files.rowCount()):
                 self.ui.tableWidget_files.setRowHidden(r, False)
@@ -540,6 +542,8 @@ class DialogReferenceManager(QtWidgets.QDialog):
             action_keywords_descending = menu.addAction(_("Descending"))
 
         action = menu.exec(self.ui.tableWidget_refs.mapToGlobal(position))
+        if action is None:  # Dismissed menu: None matches unbuilt actions
+            return
         if action == action_id_asc:
             sorted_list = sorted(self.refs, key=lambda x: x['risid'])
             self.refs = sorted_list
@@ -645,6 +649,8 @@ class DialogReferenceManager(QtWidgets.QDialog):
         action_edit_reference = menu.addAction(_("Edit reference"))
         action_delete_reference = menu.addAction(_("Delete"))
         action = menu.exec(self.ui.tableWidget_refs.mapToGlobal(position))
+        if action is None:  # Dismissed menu: None matches unbuilt actions
+            return
         if action == action_show_all_rows:
             for r in range(0, self.ui.tableWidget_refs.rowCount()):
                 self.ui.tableWidget_refs.setRowHidden(r, False)


### PR DESCRIPTION
Fixes: 
* Manage files: dismissing the header menu over the first column no longer hides it.
* Manage files and Manage cases: cancelling the hide or show columns by prefix dialogs no longer disturbs the table.
* Manage cases: dismissing the header menu over the first column no longer hides it.
* Journals: dismissing either of its two menus no longer reorders the table silently.
* Journals: the show all rows option no longer disappears while rows are still hidden.
* Manage references: dismissing its three menus no longer unhides rows or reorders.